### PR TITLE
Update to build script

### DIFF
--- a/build
+++ b/build
@@ -8,7 +8,7 @@
 #
 # press enter all the way
 #
+pip3 uninstall -y tensorflow || true
 LD_LIBRARY_PATH=~/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/host/bin/tensorflow bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip3 uninstall -y tensorflow &&
 pip3 install /tmp/tensorflow_pkg/tensorflow-1.8.0rc1-cp35-cp35m-linux_x86_64.whl


### PR DESCRIPTION
The 'pip3 uninstall' command gives a non-zero exit code when building from scratch.  This affects containerized builds (e.g. docker).  This forces a successful exit for 'pip3 uninstall'