### PR TITLE
Change the default optimization on ROCm to be -march=haswell

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -486,7 +486,7 @@ def set_cc_opt_flags(environ_cp):
   elif is_windows():
     default_cc_opt_flags = '/arch:AVX'
   else:
-    default_cc_opt_flags = '-march=native'
+    default_cc_opt_flags = '-march=haswell'
   question = ('Please specify optimization flags to use during compilation when'
               ' bazel option "--config=opt" is specified [Default is %s]: '
              ) % default_cc_opt_flags
@@ -496,7 +496,7 @@ def set_cc_opt_flags(environ_cp):
     write_to_bazelrc('build:opt --copt=%s' % opt)
   # It should be safe on the same build host.
   if not is_ppc64le() and not is_windows():
-    write_to_bazelrc('build:opt --host_copt=-march=native')
+    write_to_bazelrc('build:opt --host_copt=-march=haswell')
   write_to_bazelrc('build:opt --define with_default_optimizations=true')
   # TODO(mikecase): Remove these default defines once we are able to get
   # TF Lite targets building without them.

--- a/tensorflow/contrib/cmake/CMakeLists.txt
+++ b/tensorflow/contrib/cmake/CMakeLists.txt
@@ -30,7 +30,7 @@ option(tensorflow_BUILD_CC_TESTS "Build cc unit tests " OFF)
 option(tensorflow_BUILD_PYTHON_TESTS "Build python unit tests " OFF)
 option(tensorflow_BUILD_MORE_PYTHON_TESTS "Build more python unit tests for contrib packages" OFF)
 option(tensorflow_BUILD_SHARED_LIB "Build TensorFlow as a shared library" OFF)
-option(tensorflow_OPTIMIZE_FOR_NATIVE_ARCH "Enable compiler optimizations for the native processor architecture (if available)" ON)
+option(tensorflow_OPTIMIZE_FOR_NATIVE_ARCH "Enable compiler optimizations for the native processor architecture (if available)" OFF)
 option(tensorflow_ENABLE_SNAPPY_SUPPORT "Enable SNAPPY compression support" ON)
 option(tensorflow_DISABLE_EIGEN_FORCEINLINE "Disable forceinline, to speed up build on windows." OFF)
 

--- a/tensorflow/contrib/makefile/build_all_linux.sh
+++ b/tensorflow/contrib/makefile/build_all_linux.sh
@@ -43,6 +43,6 @@ tensorflow/contrib/makefile/compile_linux_protobuf.sh
 
 # Build TensorFlow.
 make -j"${JOB_COUNT}" -f tensorflow/contrib/makefile/Makefile \
-  OPTFLAGS="-O3 -march=native" \
+  OPTFLAGS="-O3 -march=haswell" \
   HOST_CXXFLAGS="--std=c++11 -march=native" \
   MAKEFILE_DIR=$SCRIPT_DIR

--- a/tensorflow/docs_src/install/install_sources.md
+++ b/tensorflow/docs_src/install/install_sources.md
@@ -238,13 +238,13 @@ the desired version instead of relying on the default.
 One of the questions that `configure` will ask is as follows:
 
 <pre>
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=native]
+Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=haswell]
 </pre>
 
 This question refers to a later phase in which you'll use bazel to [build the
 pip package](#build-the-pip-package) or the [C/Java libraries](#BuildCorJava).
-We recommend accepting the default (`-march=native`), which will optimize the
-generated code for your local machine's CPU type.  However, if you are building
+We recommend accepting the default (`-march=haswell`), for better portability over different Linux falvors and CPU architectures.
+However, if you are building
 TensorFlow on one CPU type but will run TensorFlow on a different CPU type, then
 consider specifying a more specific optimization
 flag as described in [the gcc
@@ -263,7 +263,7 @@ Found possible Python library paths:
 Please input the desired Python library path to use.  Default is [/usr/lib/python2.7/dist-packages]
 
 Using python library path: /usr/local/lib/python2.7/dist-packages
-Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=native]:
+Please specify optimization flags to use during compilation when bazel option "--config=opt" is specified [Default is -march=haswell]:
 Do you wish to use jemalloc as the malloc implementation? [Y/n]
 jemalloc enabled
 Do you wish to build TensorFlow with Google Cloud Platform support? [y/N]


### PR DESCRIPTION
This PR set the default opt option to be -march="haswell" on ROCm.
With this PR, the TF package should be able to support both AMD EPYC systems and Intel post-Haswell systems.