### PR TITLE
Removing use of HIP PR 457 in Dockerfile.rocm

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -60,10 +60,6 @@ RUN apt-get update --allow-insecure-repositories && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Workaround: use HIP PR#457 and then build from source
-RUN cd ~ && git clone https://github.com/GPUOpen-ProfessionalCompute-Tools/HIP.git
-RUN cd ~/HIP && git fetch origin pull/457/head:pr457 && git checkout pr457 && mkdir -p build && cd build && cmake .. && make package -j && dpkg -i *.deb
-
 ENV HCC_HOME=$ROCM_PATH/hcc
 ENV HIP_PATH=$ROCM_PATH/hip
 ENV OPENCL_ROOT=$ROCM_PATH/opencl


### PR DESCRIPTION
@whchung - This PR is to find unit tests that fail when HIP PR 457 is removed from `ci_build`'s Dockerfile.rocm.  