### PR TITLE
Update rocPRIM to v0.3.2 prerelease.

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -657,11 +657,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "rocprim_archive",
       urls = [
-          "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rocPRIM/archive/8fe35fa.zip",
-          "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/8fe35fa.zip"
+          "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rocPRIM/archive/78faf38.zip",
+          "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/78faf38.zip"
       ],
-      sha256 = "a616863aa4c525b535f4432a0d1f1d2d599c559c6b1fd89502f7be5541615142",
-      strip_prefix = "rocPRIM-8fe35fae06dad429fd65b3694e0e3ba89729ac56",
+      sha256 = "95584fb3b8aaf5ad43e0d271912f6b5c048020e67ba67f32f8a8b8cd67dc2bff",
+      strip_prefix = "rocPRIM-78faf386a45de246e0eb34c2b2e589f29c5eb163",
       build_file = clean_dep("//third_party:rocprim.BUILD"),
   )
 


### PR DESCRIPTION
0.3.2 prerelease happened earlier today and full release is scheduled for Friday. This release fixes some bugs and hopefully will allow me to enable more TF cub kernels on ROCm. Let's see what the CI has to say to the current state.