### PR TITLE
Switch to using the ROCm fork for eigen.

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -109,13 +109,12 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "eigen_archive",
       urls = [
-          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/6913f0cf7d06.tar.gz",
-          "https://bitbucket.org/eigen/eigen/get/6913f0cf7d06.tar.gz",
+      	"https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/eigen-upstream/archive/385bea74ecaa3de29e7dcd976966fb62e296a176.zip",
+	"https://github.com/ROCmSoftwarePlatform/eigen-upstream/archive/385bea74ecaa3de29e7dcd976966fb62e296a176.zip",	
       ],
-      sha256 = "791b836cacd03e20bae5bdd25f1c4a5505a0a9975ba94a61eb4e2631fbd1d53a",
-      strip_prefix = "eigen-eigen-6913f0cf7d06",
+      sha256 = "a4b30699de01a0cc3beea34733f4618a2d84dfcb7d51f0e4b972464a5184e7ce",
+      strip_prefix = "eigen-upstream-385bea74ecaa3de29e7dcd976966fb62e296a176",
       build_file = clean_dep("//third_party:eigen.BUILD"),
-      patch_file = clean_dep("//third_party:eigen_fix_gpu_compilation.patch")
   )
 
   tf_http_archive(


### PR DESCRIPTION
I am not entirely convinced whether or not we should make this switch but submitting the PR nonetheless. The eigen-upstream commit verion being pointed to, is what I will submit to the eigen official repo, once CI confirms there are no regressions. I have verified that the build works, but have not tested functionality, and that is what I want to leverage CI for.

The code change involved is minimal, but it has the potential to break the CUDA build (no more patch file...yay!)

Going forward, we will need to figure out a way to have different patch files for CUDA and ROCm.
This is because we may not need the same patch for both, like when we make this switch.
After the switch, we need no patch (empty patch) for ROCm...dont know whether the same is true for CUDA.

Ofcourse the eigen-upstream commit we point to, will need to periodically updated (when we update code in eigen-upstream). Also, once the the code has upstreamed to the official bit-bucket repo, we will need to point to that instead.