### PR TITLE
Fix build scripts and re-enable passing unit tests to CI

### DIFF
--- a/build
+++ b/build
@@ -11,4 +11,4 @@
 pip uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip install /tmp/tensorflow_pkg/tensorflow-1.8.0-cp27-cp27mu-linux_x86_64.whl
+pip install /tmp/tensorflow_pkg/tensorflow-1.9.0rc0-cp27-cp27mu-linux_x86_64.whl

--- a/build_python3
+++ b/build_python3
@@ -11,4 +11,4 @@
 pip3 uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip3 install /tmp/tensorflow_pkg/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl
+pip3 install /tmp/tensorflow_pkg/tensorflow-1.9.0rc0-cp35-cp35m-linux_x86_64.whl

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -39,7 +39,6 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
     //tensorflow/... -//tensorflow/compiler/... -//tensorflow/contrib/... \
     -//tensorflow/python/eager:backprop_test \
-    -//tensorflow/python/eager:function_test \
     -//tensorflow/python/estimator:boosted_trees_test   \
     -//tensorflow/python/feature_column:feature_column_test \
     -//tensorflow/python/keras:activations_test \
@@ -94,18 +93,14 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     -//tensorflow/python/kernel_tests:self_adjoint_eig_op_test \
     -//tensorflow/python/kernel_tests:split_op_test \
     -//tensorflow/python/kernel_tests:svd_op_test \
-    -//tensorflow/python/kernel_tests:tensor_array_ops_test \
     -//tensorflow/python/kernel_tests:tensordot_op_test \
-    -//tensorflow/python/kernel_tests:variable_scope_test \
     -//tensorflow/python/profiler/internal:run_metadata_test \
     -//tensorflow/python/profiler:profile_context_test \
     -//tensorflow/python/profiler:profiler_test \
-    -//tensorflow/python:adam_test \
     -//tensorflow/python:cluster_test \
     -//tensorflow/python:cost_analyzer_test \
     -//tensorflow/python:function_test \
     -//tensorflow/python:gradient_checker_test \
-    -//tensorflow/python:gradients_test \
     -//tensorflow/python:histogram_ops_test \
     -//tensorflow/python:image_grad_test \
     -//tensorflow/python:image_ops_test \
@@ -118,18 +113,14 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     -//tensorflow/python:timeline_test \
     -//tensorflow/python:virtual_gpu_test \
     -//tensorflow/python:function_def_to_graph_test \
-    -//tensorflow/python:gradient_descent_test \
     -//tensorflow/python:momentum_test \
     -//tensorflow/python/keras:models_test \
     -//tensorflow/python/keras:training_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
-    -//tensorflow/python/kernel_tests/distributions:beta_test \
-    -//tensorflow/python/kernel_tests/distributions:dirichlet_test \
-    -//tensorflow/python/kernel_tests/distributions:student_t_test \
     -//tensorflow/python/estimator:baseline_test \
     -//tensorflow/python/estimator:dnn_test \
     -//tensorflow/python/estimator:estimator_test \
     -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/estimator:dnn_linear_combined_test
 
-# Note: temp. disabling 93 unit tests in order to esablish a CI baseline (2018/06/13)
+# Note: temp. disabling 84 unit tests in order to esablish a CI baseline (2018/06/13)

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -117,10 +117,13 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     -//tensorflow/python/keras:models_test \
     -//tensorflow/python/keras:training_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
+    -//tensorflow/python/kernel_tests/distributions:beta_test \
+    -//tensorflow/python/kernel_tests/distributions:dirichlet_test \
+    -//tensorflow/python/kernel_tests/distributions:student_t_test \
     -//tensorflow/python/estimator:baseline_test \
     -//tensorflow/python/estimator:dnn_test \
     -//tensorflow/python/estimator:estimator_test \
     -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/estimator:dnn_linear_combined_test
 
-# Note: temp. disabling 84 unit tests in order to esablish a CI baseline (2018/06/13)
+# Note: temp. disabling 87 unit tests in order to esablish a CI baseline (2018/06/13)


### PR DESCRIPTION
Since upstream sync on 180613 we are officially enter TensorFlow 1.9 era. Change build scripts to reflect that.

Also re-enable passing unit tests.
