### PR TITLE
adding option to disable sharding 

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -33,26 +33,16 @@ export TF_NEED_ROCM=1
 yes "" | $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
-bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchmark-test -k \
+bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchmark-test -k \
     --test_lang_filters=py --jobs=${N_JOBS} --test_timeout 300,450,1200,3600 \
     --build_tests_only --test_output=errors --local_test_jobs=4 --config=opt \
     --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
     //tensorflow/... -//tensorflow/compiler/... -//tensorflow/contrib/... \
-    -//tensorflow/python/eager:backprop_test \
     -//tensorflow/python/estimator:boosted_trees_test   \
     -//tensorflow/python/feature_column:feature_column_test \
     -//tensorflow/python/keras:activations_test \
-    -//tensorflow/python/keras:core_test \
-    -//tensorflow/python/keras:gru_test \
-    -//tensorflow/python/keras:local_test \
-    -//tensorflow/python/keras:lstm_test \
-    -//tensorflow/python/keras:model_subclassing_test \
     -//tensorflow/python/keras:normalization_test \
     -//tensorflow/python/keras:pooling_test \
-    -//tensorflow/python/keras:sequential_test \
-    -//tensorflow/python/keras:simplernn_test \
-    -//tensorflow/python/keras:training_eager_test \
-    -//tensorflow/python/keras:wrappers_test \
     -//tensorflow/python/kernel_tests:atrous_conv2d_test \
     -//tensorflow/python/kernel_tests:batch_matmul_op_test \
     -//tensorflow/python/kernel_tests:bias_op_test \
@@ -65,7 +55,6 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     -//tensorflow/python/kernel_tests:conv1d_test \
     -//tensorflow/python/kernel_tests:conv2d_backprop_filter_grad_test \
     -//tensorflow/python/kernel_tests:conv2d_transpose_test \
-    -//tensorflow/python/kernel_tests:cwise_ops_test  \
     -//tensorflow/python/kernel_tests:dct_ops_test \
     -//tensorflow/python/kernel_tests:depthwise_conv_op_test \
     -//tensorflow/python/kernel_tests:fft_ops_test \
@@ -86,20 +75,16 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     -//tensorflow/python/kernel_tests:pooling_ops_test \
     -//tensorflow/python/kernel_tests:qr_op_test \
     -//tensorflow/python/kernel_tests:reduction_ops_test   \
-    -//tensorflow/python/kernel_tests:scan_ops_test \
     -//tensorflow/python/kernel_tests:scatter_nd_ops_test \
     -//tensorflow/python/kernel_tests:scatter_ops_test \
     -//tensorflow/python/kernel_tests:segment_reduction_ops_test \
     -//tensorflow/python/kernel_tests:self_adjoint_eig_op_test \
-    -//tensorflow/python/kernel_tests:split_op_test \
     -//tensorflow/python/kernel_tests:svd_op_test \
     -//tensorflow/python/kernel_tests:tensordot_op_test \
     -//tensorflow/python/profiler/internal:run_metadata_test \
     -//tensorflow/python/profiler:profile_context_test \
     -//tensorflow/python/profiler:profiler_test \
-    -//tensorflow/python:cluster_test \
     -//tensorflow/python:cost_analyzer_test \
-    -//tensorflow/python:function_test \
     -//tensorflow/python:gradient_checker_test \
     -//tensorflow/python:histogram_ops_test \
     -//tensorflow/python:image_grad_test \
@@ -123,7 +108,6 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     -//tensorflow/python/estimator:baseline_test \
     -//tensorflow/python/estimator:dnn_test \
     -//tensorflow/python/estimator:estimator_test \
-    -//tensorflow/python/estimator:linear_test \
-    -//tensorflow/python/estimator:dnn_linear_combined_test
+    -//tensorflow/python/estimator:linear_test
 
 # Note: temp. disabling 87 unit tests in order to esablish a CI baseline (2018/06/13)


### PR DESCRIPTION
Also enabling tests that start passing because sharding is disabled.

Some of the tests that start passing are flaky (sometimes pass sometimes fail), the flaky ones are being re-enabled. 
Table below shows all tests that passed in CI when sharding was disabled. 
They were run 3 different times locally to see which pass consistenly. Only ones that passed on all 3 attempts below were re-enabled

```
| //tensorflow/python/eager:backprop_test                | ------ in 7.0s   | ------ in 5.8s   | ------ in 6.3s   |
| //tensorflow/python/estimator:baseline_test            | FAILED in 5.7s   | FAILED in 5.6s   | FAILED in 5.6s   |
| //tensorflow/python/estimator:boosted_trees_test       | FAILED in 5.8s   | FAILED in 5.6s   | FAILED in 8.9s   |
| //tensorflow/python/estimator:dnn_linear_combined_test | ------ in 71.7s  | ------ in 74.1s  | ------ in 73.2s  |
| //tensorflow/python/keras:core_test                    | ------ in 9.1s   | ------ in 8.5s   | ------ in 8.6s   |
| //tensorflow/python/keras:gru_test                     | ------ in 19.5s  | ------ in 19.3s  | ------ in 19.8s  |
| //tensorflow/python/keras:local_test                   | ------ in 8.5s   | ------ in 8.7s   | ------ in 8.6s   |
| //tensorflow/python/keras:lstm_test                    | ------ in 27.7s  | ------ in 28.3s  | ------ in 43.0s  |
| //tensorflow/python/keras:model_subclassing_test       | ------ in 19.8s  | ------ in 19.3s  | ------ in 19.2s  |
| //tensorflow/python/keras:models_test                  | ------ in 6.8s   | ------ in 6.7s   | ------ in 7.0s   |
| //tensorflow/python/keras:sequential_test              | ------ in 5.8s   | ------ in 5.8s   | ------ in 5.8s   |
| //tensorflow/python/keras:simplernn_test               | ------ in 11.5s  | ------ in 11.6s  | ------ in 11.6s  |
| //tensorflow/python/keras:training_eager_test          | ------ in 12.2s  | ------ in 11.5s  | ------ in 10.9s  |
| //tensorflow/python/keras:training_test                | ------ in 20.9s  | FAILED in 11.8s  | ------ in 20.5s  |
| //tensorflow/python/keras:wrappers_test                | ------ in 30.0s  | ------ in 29.5s  | ------ in 29.7s  |
| //tensorflow/python/kernel_tests:atrous_conv2d_test    | FAILED in 4.5s   | FAILED in 4.1s   | FAILED in 4.3s   |
| //tensorflow/python/kernel_tests:cwise_ops_test        | ------ in 200.4s | ------ in 198.6s | ------ in 199.8s |
| //tensorflow/python/kernel_tests:reduction_ops_test    | FAILED in 30.6s  | FAILED in 30.5s  | FAILED in 31.5s  |
| //tensorflow/python/kernel_tests:scan_ops_test         | ------ in 14.0s  | ------ in 12.2s  | ------ in 11.7s  |
| //tensorflow/python/kernel_tests:split_op_test         | ------ in 7.9s   | ------ in 7.0s   | ------ in 7.1s   |
| //tensorflow/python:cluster_test                       | ------ in 24.2s  | ------ in 4.8s   | ------ in 4.7s   |
| //tensorflow/python:function_test                      | ------ in 56.1s  | ------ in 52.5s  | ------ in 54.6s  |
| //tensorflow/python:gradient_checker_test              | ------ in 5.8s   | ------ in 5.6s   | FAILED in 5.7s   |
| //tensorflow/python:virtual_gpu_test                   | FAILED in 4.6s   | ------ in 9.9s   | ------ in 10.1s  |
```