### PR TITLE
Special casing GpuAtomicMin / GpuAtomicMax for ROCm

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -69,8 +69,6 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/kernel_tests:pool_test \
     -//tensorflow/python/kernel_tests:pooling_ops_3d_test \
     -//tensorflow/python/kernel_tests:pooling_ops_test \
-    -//tensorflow/python/kernel_tests:reduction_ops_test   \
-    -//tensorflow/python/kernel_tests:scatter_ops_test \
     -//tensorflow/python/profiler/internal:run_metadata_test \
     -//tensorflow/python/profiler:profile_context_test \
     -//tensorflow/python/profiler:profiler_test \


### PR DESCRIPTION
The TF1.8 implementations for the float and double implementations of `GpuAtomicMin` and `GpuAtomicMax` routines assume the presence of   float and double versions of `min` and `max` `__device__` routines. That assumption is true for CUDA but not for HIP,  and what ends up happening is an implcit cast from `float`/`double` to `int` leading to bad results!

Fixing this by special casing the ROCm implementation to call `fminf` / `fmin` / `fmaxf` / `fmax`
