### PR TITLE
contrib/verbs and contrib/gdr ready for ROCm

### DIFF
--- a/tensorflow/contrib/gdr/gdr_memory_manager.cc
+++ b/tensorflow/contrib/gdr/gdr_memory_manager.cc
@@ -33,10 +33,10 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/bfc_allocator.h"
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/common_runtime/gpu/gpu_util.h"
 #include "tensorflow/core/common_runtime/gpu/process_state.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/framework/allocator_registry.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/macros.h"
@@ -273,10 +273,10 @@ Status GdrMemoryManager::Init() {
   }
 
   Allocator* allocators[] = {
-#if GOOGLE_CUDA
-    ProcessState::singleton()->GetCUDAHostAllocator(0),
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+    ProcessState::singleton()->GetGPUHostAllocator(0),
     ProcessState::singleton()->GetCPUAllocator(0),
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     cpu_allocator(),
   };
 
@@ -302,7 +302,7 @@ Status GdrMemoryManager::Init() {
     }
   }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   VisitableAllocator::Visitor cuda_alloc_visitor =
       std::bind(&GdrMemoryManager::InsertMemoryRegion, this, _1, _2);
   if (IsGDRAvailable()) {
@@ -311,7 +311,7 @@ Status GdrMemoryManager::Init() {
     ProcessState::singleton()->AddGPUAllocVisitor(bus_id, cuda_alloc_visitor);
     LOG(INFO) << "Instrumenting GPU allocator with bus_id " << bus_id;
   }
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
   return Status::OK();
 }
@@ -428,9 +428,9 @@ void GdrMemoryManager::TransportOptionsFromTensor(
 
   ibv_mr* mr = FindMemoryRegion(addr, length);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   if (!on_host) {
-    Allocator* alloc = ProcessState::singleton()->GetCUDAHostAllocator(0);
+    Allocator* alloc = ProcessState::singleton()->GetGPUHostAllocator(0);
     Tensor* host_copy = new Tensor(alloc, tensor.dtype(), tensor.shape());
     GPUUtil::CopyGPUTensorToCPU(
         device, device_context, &tensor, host_copy,
@@ -493,7 +493,7 @@ void GdrMemoryManager::TransportOptionsFromTensor(
 
   uint64_t checksum = 0;
   if (VLOG_IS_ON(2)) {
-#ifdef GOOGLE_CUDA
+#ifdef GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     if (!on_host) {
       checksum = GPUUtil::Checksum(device, device_context, tensor);
     } else {
@@ -530,16 +530,16 @@ void GdrMemoryManager::TensorFromTransportOptions(
   ibv_mr* mr = FindMemoryRegion(addr, length);
 
   Tensor host_copy;
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   if (mr == nullptr && !on_host) {
-    Allocator* alloc = ProcessState::singleton()->GetCUDAHostAllocator(0);
+    Allocator* alloc = ProcessState::singleton()->GetGPUHostAllocator(0);
     host_copy = Tensor(alloc, tensor->dtype(), tensor->shape());
     buffer = DMAHelper::buffer(&host_copy);
     addr = buffer->data();
     length = buffer->size();
     mr = FindMemoryRegion(addr, length);
   }
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
   if (mr == nullptr) {
     done(errors::Unavailable("Cannot find pinned memory region"));
@@ -591,7 +591,7 @@ void GdrMemoryManager::TensorFromTransportOptions(
     return;
   }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   if (host_copy.NumElements() > 0) {
     uint64_t checksum = 0;
     if (VLOG_IS_ON(2)) {
@@ -620,7 +620,7 @@ void GdrMemoryManager::TensorFromTransportOptions(
         });
     return;
   }
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
   uint64_t end = Env::Default()->NowMicros();
 
@@ -630,7 +630,7 @@ void GdrMemoryManager::TensorFromTransportOptions(
 
   uint64_t checksum = 0;
   if (VLOG_IS_ON(2)) {
-#ifdef GOOGLE_CUDA
+#ifdef GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     if (device->tensorflow_gpu_device_info() && (!on_host)) {
       checksum = GPUUtil::Checksum(device, device_context, *tensor);
     } else {

--- a/tensorflow/contrib/gdr/gdr_worker.cc
+++ b/tensorflow/contrib/gdr/gdr_worker.cc
@@ -18,9 +18,9 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/device.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/common_runtime/gpu/gpu_util.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/common_runtime/process_util.h"
 #include "tensorflow/core/common_runtime/step_stats_collector.h"
 #include "tensorflow/core/distributed_runtime/graph_mgr.h"
@@ -117,7 +117,7 @@ void GdrWorker::GrpcRecvTensorAsync(CallOptions* opts,
           } else {
             // Non-DMA cases.
             if (src_dev->tensorflow_gpu_device_info() && (!on_host)) {
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
               const DeviceContext* send_dev_context = send_args.device_context;
               AllocatorAttributes alloc_attrs;
               alloc_attrs.set_gpu_compatible(true);
@@ -140,7 +140,7 @@ void GdrWorker::GrpcRecvTensorAsync(CallOptions* opts,
                                           copy_ready);
 #else
               done(errors::Internal("No GPU device in process"));
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
             } else {
               grpc::EncodeTensorToByteBuffer(is_dead, val, response);
               done(Status::OK());

--- a/tensorflow/contrib/verbs/rdma_mgr.cc
+++ b/tensorflow/contrib/verbs/rdma_mgr.cc
@@ -281,10 +281,10 @@ void RdmaMgr::InitAllocators() {
   RdmaMemoryMgr::Singleton().pd_ = rdma_adapter_->pd_;
 
   Allocator* allocators[] = {
-#if GOOGLE_CUDA
-    ProcessState::singleton()->GetCUDAHostAllocator(0),
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+    ProcessState::singleton()->GetGPUHostAllocator(0),
     ProcessState::singleton()->GetCPUAllocator(0),
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     cpu_allocator(),
   };
 
@@ -312,7 +312,7 @@ void RdmaMgr::InitAllocators() {
     }
   }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   if (IsGDRAvailable()) {
     // Note we don't free allocated GPU memory so there is no free visitor
     int32_t bus_id = TryToReadNumaNode(rdma_adapter_->context_->device) + 1;
@@ -326,7 +326,7 @@ void RdmaMgr::InitAllocators() {
     ProcessState::singleton()->AddGPUAllocVisitor(bus_id, cuda_alloc_visitor);
     LOG(INFO) << "Instrumenting GPU allocator with bus_id " << bus_id;
   }
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 }
 
 }  // end namespace tensorflow


### PR DESCRIPTION
Add TENSORFLOW_USE_ROCM to GOOGLE_CUDA preprocessor if statements.
Rename GetCUDAHostAllocator to GetGPUHostAllocator.