### PR TITLE
Removing HIP Context API usage from the code

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_activation.cc
+++ b/tensorflow/stream_executor/rocm/rocm_activation.cc
@@ -22,13 +22,13 @@ limitations under the License.
 namespace stream_executor {
 namespace rocm {
 
-ROCmContext* ExtractROCmContext(ROCMExecutor *rocm_exec);
+int ExtractROCmDeviceOrdinal(ROCMExecutor *rocm_exec);
 ROCMExecutor *ExtractROCmExecutor(StreamExecutor *stream_exec);
 
 ScopedActivateExecutorContext::ScopedActivateExecutorContext(
     ROCMExecutor *rocm_exec):
       driver_scoped_activate_context_(
-          new ScopedActivateContext{ExtractROCmContext(rocm_exec)}) { }
+          new ScopedActivateContext{ExtractROCmDeviceOrdinal(rocm_exec)}) { }
 
 ScopedActivateExecutorContext::ScopedActivateExecutorContext(
     StreamExecutor *stream_exec)

--- a/tensorflow/stream_executor/rocm/rocm_activation.h
+++ b/tensorflow/stream_executor/rocm/rocm_activation.h
@@ -34,7 +34,7 @@ namespace rocm {
 class ROCMExecutor;
 class ScopedActivateContext;
 
-// Activates a ROCM context within an enclosing scope.
+// Activates a ROCM device within an enclosing scope.
 class ScopedActivateExecutorContext {
  public:
   // Form that takes a ROCM executor implementation.

--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -160,6 +160,8 @@ ScopedActivateContext::ScopedActivateContext(int device_ordinal) {
   
   tls->depth++;
 
+  to_restore_ = tls->current_device_ordinal;
+
   if (device_ordinal == tls->current_device_ordinal) {
     DCHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), device_ordinal);
     return;
@@ -167,8 +169,6 @@ ScopedActivateContext::ScopedActivateContext(int device_ordinal) {
 
   VLOG(3) << "ScopedActivateContext switching device from " << tls->current_device_ordinal
           << " to " << device_ordinal;
-
-  to_restore_ = tls->current_device_ordinal;
 
   // Set the device and update thread local.
   CHECK_EQ(hipSuccess, hipSetDevice(device_ordinal));

--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -41,65 +41,14 @@ bool FLAGS_gpuexec_rocm_driver_inject_init_error = false;
 bool FLAGS_gpuexec_rocm_sync_around_driver_calls = false;
 bool FLAGS_gpuexec_rocm_device_0_only = false;
 
-// Debugging: on each push and pop of a rocm context, verify the current context
+// Debugging: on each push and pop of a rocm context, verify the current device
 // matches the expected one.
-constexpr bool kVerifyROCmContext = false;
+constexpr bool kVerifyROCmDevice = false;
 
 namespace stream_executor {
 namespace rocm {
 
 namespace {
-
-// Manages the singleton map of contexts that we've created, mapping
-// from the hipCtx_t to the ROCmContext* that we pass around internally.
-// This also manages assignment of unique ids to ROCmContexts, to allow
-// for fast comparison of a context against the current context.
-//
-// ROCM-runtime-created contexts are avoided, if triple angle
-// brace launches are required, by using the scoped activations in
-// rocm_activation.h.
-class CreatedContexts {
- public:
-  // Returns whether context is a member of the live set.
-  static bool Has(hipCtx_t context) {
-    tf_shared_lock lock{mu_};
-    return Live()->find(context) != Live()->end();
-  }
-
-  // Adds context to the live set.
-  static ROCmContext* Add(hipCtx_t context) {
-    CHECK(context != nullptr);
-    mutex_lock lock{mu_};
-    auto rocm_context = new ROCmContext(context, next_id_++);
-    Live()->insert(
-        std::make_pair(context, std::unique_ptr<ROCmContext>(rocm_context)));
-    return rocm_context;
-  }
-
-  // Removes context from the live set.
-  static void Remove(hipCtx_t context) {
-    CHECK(context != nullptr);
-    mutex_lock lock{mu_};
-    auto it = Live()->find(context);
-    CHECK(it != Live()->end()) << context;
-    Live()->erase(it);
-  }
-
- private:
-  // Returns the live map singleton.
-  static std::map<hipCtx_t, std::unique_ptr<ROCmContext>> *Live() {
-    static auto singleton =
-        new std::map<hipCtx_t, std::unique_ptr<ROCmContext>>;
-    return singleton;
-  }
-
-  // Lock that guards access-to/mutation-of the live set.
-  static mutex mu_;
-  static int64 next_id_;
-};
-
-/* static */ mutex CreatedContexts::mu_{LINKER_INITIALIZED};
-/* static */ int64 CreatedContexts::next_id_ = 1;  // 0 means "no context"
 
 // Formats hipError_t to output prettified values into a log stream.
 // Error summaries taken from:
@@ -146,24 +95,6 @@ string ToString(hipError_t result) {
 #pragma GCC diagnostic pop
 }
 
-// Returns the current context and checks that it is in the set of ROCM contexts
-// created by StreamExecutor (to ensure that the ROCM runtime didn't create a
-// context behind our backs).
-hipCtx_t CurrentContext() {
-  hipCtx_t current = ROCMDriver::CurrentContextOrDie();
-  // XXX TODO FIGURE THIS OUT
-#if 0
-  if (current != nullptr && !CreatedContexts::Has(current)) {
-    LOG(FATAL) << "current context was not created by the StreamExecutor "
-                  "rocm_driver API: "
-               << current
-               << "; a ROCM runtime call "
-                  "was likely performed without using a StreamExecutor context";
-  }
-#endif
-  return current;
-}
-
 // ROCM driver routines may require a large amount of stack (particularly
 // hipModuleLoadDataEx, in our experience). To avoid stack overflow when using
 // stack-limited threads (such as those spawned by a default-argument
@@ -196,9 +127,9 @@ string MemorySpaceString(MemorySpace memory_space) {
 
 namespace {
 
-// Call hipCtxtSynchronize and crash if it doesn't succeed.
+// Call hipDeviceSynchronize and crash if it doesn't succeed.
 void SynchronizeOrDie() {
-  auto res = hipCtxSynchronize();
+  auto res = hipDeviceSynchronize();
   if (res != hipSuccess) {
     LOG(FATAL) << "Synchronize found "
                << ToString(res) << " :: " << port::CurrentStackTrace();
@@ -206,8 +137,7 @@ void SynchronizeOrDie() {
 }
 
 struct ThreadLocalData {
-  int64 id;
-  ROCmContext* context;  // Only valid if id == a known good context.
+  int current_device_ordinal;
   int depth;
 };
 
@@ -215,53 +145,60 @@ SE_STATIC_THREAD_LOCAL_POD(ThreadLocalData, tls_data);
 
 }  // namespace
 
-ScopedActivateContext::ScopedActivateContext(ROCmContext* rocm_context) {
-  if (FLAGS_gpuexec_rocm_sync_around_driver_calls) SynchronizeOrDie();
+ScopedActivateContext::ScopedActivateContext(int device_ordinal) {
+
+  if (FLAGS_gpuexec_rocm_sync_around_driver_calls) { SynchronizeOrDie(); }
 
   auto* tls = &tls_data.get();
+  if (tls->depth == 0) {
+    tls->current_device_ordinal = ROCMDriver::CurrentDeviceOrDie();
+  }
+
+  if (kVerifyROCmDevice) {
+    CHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), tls->current_device_ordinal);
+  }
+  
   tls->depth++;
-  if (tls->id == rocm_context->id()) {
-    if (kVerifyROCmContext) {
-      CHECK_EQ(CurrentContext(), rocm_context->context());
-    }
-    DCHECK_EQ(CurrentContext(), rocm_context->context());
+
+  if (device_ordinal == tls->current_device_ordinal) {
+    DCHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), device_ordinal);
     return;
   }
 
-  VLOG(3) << "ScopedActivateContext switching context from " << tls->id
-          << " to " << rocm_context->id();
+  VLOG(3) << "ScopedActivateContext switching device from " << tls->current_device_ordinal
+          << " to " << device_ordinal;
 
-  to_restore_ = (tls->depth == 1 ? nullptr : tls->context);
+  to_restore_ = tls->current_device_ordinal;
 
-  // Set the context and update thread local.
-  CHECK_EQ(hipSuccess, hipCtxSetCurrent(rocm_context->context()));
-  tls->id = rocm_context->id();
-  tls->context = rocm_context;
+  // Set the device and update thread local.
+  CHECK_EQ(hipSuccess, hipSetDevice(device_ordinal));
+  tls->current_device_ordinal = device_ordinal;
 }
 
 ScopedActivateContext::~ScopedActivateContext() {
-  if (FLAGS_gpuexec_rocm_sync_around_driver_calls) SynchronizeOrDie();
+
+  if (FLAGS_gpuexec_rocm_sync_around_driver_calls) { SynchronizeOrDie(); }
 
   auto* tls = &tls_data.get();
 
-  if (kVerifyROCmContext) {
-    // Note that if kVerifyROCmContext is used, and contexts are deleted, it's
-    // possible this could fail in the CurrentContext() call.
-    CHECK_EQ(CurrentContext(),
-             tls->context == nullptr ? nullptr : tls->context->context());
+  if (kVerifyROCmDevice) {
+    CHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), tls->current_device_ordinal);
   }
 
   tls->depth--;
   DCHECK_GE(tls->depth, 0);
-  if (to_restore_ == nullptr) {
-    // Leave context, tls->id, and tls->context set.
+  
+  if (to_restore_ == tls->current_device_ordinal) {
+    DCHECK_EQ(ROCMDriver::CurrentDeviceOrDie(), to_restore_);
     return;
   }
 
+  VLOG(3) << "ScopedActivateContext switching device from " << tls->current_device_ordinal
+          << " to " << to_restore_;
+
   // Set context and update thread local.
-  CHECK_EQ(hipSuccess, hipCtxSetCurrent(to_restore_->context()));
-  tls->id = to_restore_->id();
-  tls->context = to_restore_;
+  CHECK_EQ(hipSuccess, hipSetDevice(to_restore_));
+  tls->current_device_ordinal = to_restore_;
 }
 
 namespace {
@@ -295,20 +232,24 @@ string ROCMPointerToMemorySpaceString(hipDeviceptr_t pointer) {
 // primarily for logging purposes. Returns "error" if an error is encountered
 // in the process of querying.
 string ROCMPointersToCanAccessString(hipDeviceptr_t from, hipDeviceptr_t to) {
-  auto from_context = ROCMDriver::GetPointerContext(from);
-  if (!from_context.ok()) {
-    LOG(ERROR) << "could not retrieve source pointer's context: "
-               << from_context.status();
+  hipPointerAttribute_t from_pointerAttributes;
+  hipError_t result = hipPointerGetAttributes(&from_pointerAttributes, from);
+  if (result != hipSuccess) {
+    LOG(ERROR) << "could not retrieve source pointer's device: "
+               << ToString(result);
     return "error";
   }
-  auto to_context = ROCMDriver::GetPointerContext(to);
-  if (!to_context.ok()) {
-    LOG(ERROR) << "could not retrieve destination pointer's context: "
-               << to_context.status();
+
+  hipPointerAttribute_t to_pointerAttributes;
+  result = hipPointerGetAttributes(&to_pointerAttributes, to);
+  if (result != hipSuccess) {
+    LOG(ERROR) << "could not retrieve destination pointer's device: "
+               << ToString(result);
     return "error";
   }
-  return ROCMDriver::CanEnablePeerAccess(from_context.ValueOrDie(),
-                                         to_context.ValueOrDie())
+  
+  return ROCMDriver::CanEnablePeerAccess(from_pointerAttributes.device,
+                                         to_pointerAttributes.device)
              ? "true"
              : "false";
 }
@@ -386,62 +327,6 @@ bool DeviceOptionsToContextFlags(const DeviceOptions &device_options,
   return true;
 }
 
-/* static */ port::Status ROCMDriver::CreateContext(
-    hipDevice_t device, DeviceOptions device_options, ROCmContext** context) {
-  *context = nullptr;
-
-  int flags = 0;
-  if (!DeviceOptionsToContextFlags(device_options, &flags)) {
-    LOG(WARNING) << "could not convert all device options into context flags";
-  }
-
-  hipError_t res;
-  hipCtx_t former_context;
-  hipCtx_t new_context;
-  {
-    former_context = CurrentContext();
-    if (former_context != nullptr) {
-      LOG(WARNING)
-          << "creating context when one is currently active; existing: "
-          << former_context;
-    }
-    res = hipCtxCreate(&new_context, flags, device);
-  }
-  CHECK_EQ(hipSuccess, hipCtxSetCurrent(former_context));
-
-  if (res == hipSuccess) {
-    *context = CreatedContexts::Add(new_context);
-    CHECK(*context != nullptr)
-        << "success in this call must entail non-null result";
-    VLOG(2) << "created context " << context << " for this thread";
-    return port::Status::OK();
-  }
-
-  string message = "failed call to hipCtxCreate: " + ToString(res);
-  if (res == hipErrorMemoryAllocation) {
-    uint64 total_memory;
-    if (GetDeviceTotalMemory(device, &total_memory)) {
-      port::StrAppend(&message, "; total memory reported: ", total_memory);
-    } else {
-      port::StrAppend(&message, "; could not query total memory");
-    }
-  }
-
-  return port::Status{port::error::INTERNAL, message};
-}
-
-/* static */ void ROCMDriver::DestroyContext(ROCmContext* context) {
-  if (context == nullptr) {
-    return;
-  }
-  hipError_t res = hipCtxDestroy(context->context());
-
-  if (res != hipSuccess) {
-    LOG(ERROR) << "failed to release ROCM context; leaking: " << ToString(res);
-  }
-
-  CreatedContexts::Remove(context->context());
-}
 
 /* static */ bool ROCMDriver::FuncGetAttribute(hipDeviceAttribute_t attribute,
                                                hipFunction_t func,
@@ -469,15 +354,13 @@ bool DeviceOptionsToContextFlags(const DeviceOptions &device_options,
 }
 
 /* static */ port::StatusOr<hipSharedMemConfig>
-ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
+ROCMDriver::DeviceGetSharedMemConfig(int device_ordinal) {
   hipSharedMemConfig shared_mem_config;
-  ScopedActivateContext activation{context};
-  hipError_t result = hipCtxGetSharedMemConfig(&shared_mem_config);
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t result = hipDeviceGetSharedMemConfig(&shared_mem_config);
   if (result != hipSuccess) {
-    hipDevice_t device;
-    hipCtxGetDevice(&device);
     LOG(ERROR) << "failed to get ROCM device shared memory config. "
-               << "Context device ID: " << device
+               << "Context device ID: " << device_ordinal
                << ", result: " << ToString(result);
     return port::Status{
         port::error::INTERNAL,
@@ -486,15 +369,13 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return shared_mem_config;
 }
 
-/* static */ port::Status ROCMDriver::ContextSetSharedMemConfig(
-    ROCmContext* context, hipSharedMemConfig shared_mem_config) {
-  ScopedActivateContext activation{context};
-  hipError_t result = hipCtxSetSharedMemConfig(shared_mem_config);
+/* static */ port::Status ROCMDriver::DeviceSetSharedMemConfig(
+    int device_ordinal, hipSharedMemConfig shared_mem_config) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t result = hipDeviceSetSharedMemConfig(shared_mem_config);
   if (result != hipSuccess) {
-    hipDevice_t device;
-    hipCtxGetDevice(&device);
     LOG(ERROR) << "failed to set ROCM device shared memory config. "
-               << "Context device ID: " << device
+               << "Context device ID: " << device_ordinal
                << ", config: " << shared_mem_config
                << ", result: " << ToString(result);
     return port::Status{
@@ -505,12 +386,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
 }
 
 /* static */ bool ROCMDriver::LaunchKernel(
-    ROCmContext* context, hipFunction_t function, unsigned int grid_dim_x,
+    int device_ordinal, hipFunction_t function, unsigned int grid_dim_x,
     unsigned int grid_dim_y, unsigned int grid_dim_z, unsigned int block_dim_x,
     unsigned int block_dim_y, unsigned int block_dim_z,
     unsigned int shared_mem_bytes, hipStream_t stream, void **kernel_params,
     void **extra) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   VLOG(2) << "launching kernel: " << function << "; gdx: " << grid_dim_x
           << " gdy: " << grid_dim_y << " gdz: " << grid_dim_z
           << " bdx: " << block_dim_x << " bdy: " << block_dim_y
@@ -527,14 +408,14 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::LoadHsaco(ROCmContext* context,
+/* static */ bool ROCMDriver::LoadHsaco(int device_ordinal,
                                         const char *hsaco_contents,
                                         hipModule_t *module) {
   port::Notification notification;
   bool ret = true;
-  GetDriverExecutor()->Schedule([context, hsaco_contents, module, &ret,
+  GetDriverExecutor()->Schedule([device_ordinal, hsaco_contents, module, &ret,
                                  &notification]() {
-    ScopedActivateContext activation{context};
+    ScopedActivateContext activation{device_ordinal};
     void *hsaco_data = const_cast<char *>(hsaco_contents);
 
     hipError_t res = hipModuleLoadData(module, hsaco_data);
@@ -553,10 +434,10 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return ret;
 }
 
-/* static */ bool ROCMDriver::SynchronousMemsetUint8(ROCmContext* context,
+/* static */ bool ROCMDriver::SynchronousMemsetUint8(int device_ordinal,
                                                      hipDeviceptr_t location,
                                                      uint8 value, size_t size) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemset(location, value, size);
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to memset memory: " << ToString(res);
@@ -565,11 +446,11 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::SynchronousMemsetUint32(ROCmContext* context,
+/* static */ bool ROCMDriver::SynchronousMemsetUint32(int device_ordinal,
                                                       hipDeviceptr_t location,
                                                       uint32 value,
                                                       size_t uint32_count) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   void * pointer = port::bit_cast<void *>(location);
   unsigned char valueC = static_cast<unsigned char>(value);
   uint32_t value32 = (valueC << 24) | (valueC << 16) | (valueC << 8) | (valueC) ;
@@ -583,12 +464,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::AsynchronousMemsetUint8(ROCmContext* context,
+/* static */ bool ROCMDriver::AsynchronousMemsetUint8(int device_ordinal,
                                                       hipDeviceptr_t location,
                                                       uint8 value,
                                                       size_t uint32_count,
                                                       hipStream_t stream) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemsetAsync(location, value, uint32_count, stream);
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to enqueue async memset operation: " << ToString(res);
@@ -598,12 +479,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::AsynchronousMemsetUint32(ROCmContext* context,
+/* static */ bool ROCMDriver::AsynchronousMemsetUint32(int device_ordinal,
                                                        hipDeviceptr_t location,
                                                        uint32 value,
                                                        size_t uint32_count,
                                                        hipStream_t stream) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   void * pointer = port::bit_cast<void *>(location);
 
   /// XXX - need to set a 32-bit value here, need hipMemsetD32
@@ -620,7 +501,7 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::AddStreamCallback(ROCmContext* context,
+/* static */ bool ROCMDriver::AddStreamCallback(int device_ordinal,
                                                 hipStream_t stream,
                                                 StreamCallback callback,
                                                 void *data) {
@@ -632,11 +513,11 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::GetModuleFunction(ROCmContext *context,
+/* static */ bool ROCMDriver::GetModuleFunction(int device_ordinal,
                                                 hipModule_t module,
                                                 const char *kernel_name,
                                                 hipFunction_t *function) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   CHECK(module != nullptr && kernel_name != nullptr);
   hipError_t res = hipModuleGetFunction(function, module, kernel_name);
   if (res != hipSuccess) {
@@ -648,12 +529,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::GetModuleSymbol(ROCmContext* context,
+/* static */ bool ROCMDriver::GetModuleSymbol(int device_ordinal,
                                               hipModule_t module,
                                               const char *symbol_name,
                                               hipDeviceptr_t *dptr,
                                               size_t *bytes) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   CHECK(module != nullptr && symbol_name != nullptr &&
         (dptr != nullptr || bytes != nullptr));
   hipError_t res = hipModuleGetGlobal(dptr, bytes, module, symbol_name);
@@ -668,9 +549,9 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ void ROCMDriver::UnloadModule(ROCmContext *context,
+/* static */ void ROCMDriver::UnloadModule(int device_ordinal,
                                            hipModule_t module) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   hipError_t res = hipModuleUnload(module);
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to unload module " << module
@@ -678,56 +559,42 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   }
 }
 
-/* static */ port::StatusOr<hipDevice_t> ROCMDriver::DeviceFromContext(
-    ROCmContext* context) {
-  ScopedActivateContext activated{context};
-  hipDevice_t device;
-  hipError_t result = hipCtxGetDevice(&device);
-  if (result == hipSuccess) {
-    return device;
-  }
-
-  return port::Status{
-      port::error::INTERNAL,
-      port::StrCat("failed to get device for context: ", ToString(result))};
-}
-
-/* static */ bool ROCMDriver::CreateStream(ROCmContext *context,
+/* static */ bool ROCMDriver::CreateStream(int device_ordinal,
                                            hipStream_t *out) {
-  ScopedActivateContext activated{context};
-  hipError_t res = hipStreamCreateWithFlags(out, 0);
+  ScopedActivateContext activated{device_ordinal};
+  hipError_t res = hipStreamCreateWithFlags(out, hipStreamDefault);  // switch to hipStreamNonBlocking?
   if (res != hipSuccess) {
-    LOG(ERROR) << "could not allocate ROCM stream for context " << context
+    LOG(ERROR) << "could not allocate ROCM stream for device " << device_ordinal
                << ": " << ToString(res);
     return false;
   }
 
-  VLOG(2) << "successfully created stream " << *out << " for context "
-          << context << " on thread";
+  VLOG(2) << "successfully created stream " << *out << " for device "
+          << device_ordinal << " on thread";
   return true;
 }
 
-/* static */ void ROCMDriver::DestroyStream(ROCmContext* context,
+/* static */ void ROCMDriver::DestroyStream(int device_ordinal,
                                             hipStream_t *stream) {
   if (*stream == nullptr) {
     return;
   }
 
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   hipError_t res = hipStreamDestroy(*stream);
   if (res != hipSuccess) {
-    LOG(ERROR) << "failed to destroy ROCM stream for context " << context
+    LOG(ERROR) << "failed to destroy ROCM stream for device " << device_ordinal
                << ": " << ToString(res);
   } else {
-    VLOG(2) << "successfully destroyed stream " << *stream << " for context "
-            << context;
+    VLOG(2) << "successfully destroyed stream " << *stream << " for device "
+            << device_ordinal;
     *stream = nullptr;
   }
 }
 
-/* static */ void *ROCMDriver::DeviceAllocate(ROCmContext *context,
+/* static */ void *ROCMDriver::DeviceAllocate(int device_ordinal,
                                               uint64 bytes) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   hipDeviceptr_t result = 0;
   hipError_t res = hipMalloc(&result, bytes);
   if (res != hipSuccess) {
@@ -737,27 +604,27 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
     return nullptr;
   }
   void *ptr = reinterpret_cast<void *>(result);
-  VLOG(2) << "allocated " << ptr << " for context " << context << " of "
+  VLOG(2) << "allocated " << ptr << " for device " << device_ordinal << " of "
           << bytes << " bytes";
   return ptr;
 }
 
-/* static */ void ROCMDriver::DeviceDeallocate(ROCmContext* context,
+/* static */ void ROCMDriver::DeviceDeallocate(int device_ordinal,
                                                void *location) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipDeviceptr_t pointer = port::bit_cast<hipDeviceptr_t>(location);
   hipError_t res = hipFree(pointer);
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to free device memory at " << location
                << "; result: " << ToString(res);
   } else {
-    VLOG(2) << "deallocated " << location << " for context " << context;
+    VLOG(2) << "deallocated " << location << " for device " << device_ordinal;
   }
 }
 
-/* static */ void *ROCMDriver::HostAllocate(ROCmContext *context,
+/* static */ void *ROCMDriver::HostAllocate(int device_ordinal,
                                             uint64 bytes) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   void *host_mem = nullptr;
   // "Portable" memory is visible to all ROCM contexts. Safe for our use model.
   hipError_t res = hipHostMalloc(&host_mem, bytes, hipHostMallocPortable);
@@ -768,9 +635,9 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return host_mem;
 }
 
-/* static */ void ROCMDriver::HostDeallocate(ROCmContext* context,
+/* static */ void ROCMDriver::HostDeallocate(int device_ordinal,
                                              void *location) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipHostFree(location);
   if (res != hipSuccess) {
     LOG(ERROR) << "error deallocating host memory at " << location << ": "
@@ -778,9 +645,9 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   }
 }
 
-/* static */ bool ROCMDriver::HostRegister(ROCmContext* context, void *location,
+/* static */ bool ROCMDriver::HostRegister(int device_ordinal, void *location,
                                            uint64 bytes) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   // "Portable" memory is visible to all ROCM contexts. Safe for our use model.
   hipError_t res =
       hipHostRegister(location, bytes, hipHostRegisterPortable);
@@ -792,9 +659,9 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::HostUnregister(ROCmContext* context,
+/* static */ bool ROCMDriver::HostUnregister(int device_ordinal,
                                              void *location) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipHostUnregister(location);
   if (res != hipSuccess) {
     LOG(ERROR) << "error unregistering host memory at " << location << ": "
@@ -804,14 +671,14 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ port::Status ROCMDriver::DestroyEvent(ROCmContext* context,
+/* static */ port::Status ROCMDriver::DestroyEvent(int device_ordinal,
                                                    hipEvent_t *event) {
   if (*event == nullptr) {
     return port::Status{port::error::INVALID_ARGUMENT,
                         "input event cannot be null"};
   }
 
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   hipError_t res = hipEventDestroy(*event);
   *event = nullptr;
 
@@ -822,20 +689,20 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
     case hipErrorNotInitialized:
       return port::Status{
           port::error::FAILED_PRECONDITION,
-          port::Printf("error destroying ROCM event in context %p: %s", context,
+          port::Printf("error destroying ROCM event in device %d: %s", device_ordinal,
                        ToString(res).c_str())};
     default:
       return port::Status{
           port::error::INTERNAL,
-          port::Printf("error destroying ROCM event in context %p: %s", context,
+          port::Printf("error destroying ROCM event in device %d: %s", device_ordinal,
                        ToString(res).c_str())};
   }
 }
 
-/* static */ port::Status ROCMDriver::RecordEvent(ROCmContext* context,
+/* static */ port::Status ROCMDriver::RecordEvent(int device_ordinal,
                                                   hipEvent_t event,
                                                   hipStream_t stream) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   hipError_t res = hipEventRecord(event, stream);
   switch (res) {
     case hipSuccess:
@@ -855,8 +722,8 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
 }
 
 /* static */ port::StatusOr<hipError_t> ROCMDriver::QueryEvent(
-    ROCmContext *context, hipEvent_t event) {
-  ScopedActivateContext activated{context};
+    int device_ordinal, hipEvent_t event) {
+  ScopedActivateContext activated{device_ordinal};
   hipError_t res = hipEventQuery(event);
   if (res != hipSuccess && res != hipErrorNotReady) {
     return port::Status{
@@ -867,10 +734,10 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return res;
 }
 
-/* static */ bool ROCMDriver::GetEventElapsedTime(ROCmContext* context,
+/* static */ bool ROCMDriver::GetEventElapsedTime(int device_ordinal,
                                                   float *elapsed_milliseconds,
                                                   hipEvent_t start, hipEvent_t stop) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   // The stop event must have completed in order for hipEventElapsedTime to
   // work.
   hipError_t res = hipEventSynchronize(stop);
@@ -888,10 +755,10 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::WaitStreamOnEvent(ROCmContext* context,
+/* static */ bool ROCMDriver::WaitStreamOnEvent(int device_ordinal,
                                                 hipStream_t stream,
                                                 hipEvent_t event) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipStreamWaitEvent(stream, event, 0 /* = flags */);
   if (res != hipSuccess) {
     LOG(ERROR) << "could not wait stream on event: " << ToString(res);
@@ -901,11 +768,11 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::SynchronizeContext(ROCmContext* context) {
-  ScopedActivateContext activation{context};
-  hipError_t res = hipCtxSynchronize();
+/* static */ bool ROCMDriver::SynchronizeDevice(int device_ordinal) {
+  ScopedActivateContext activation{device_ordinal};
+  hipError_t res = hipDeviceSynchronize();
   if (res != hipSuccess) {
-    LOG(ERROR) << "could not synchronize on ROCM context: " << ToString(res)
+    LOG(ERROR) << "could not synchronize on ROCM device: " << ToString(res)
                << " :: " << port::CurrentStackTrace();
     return false;
   }
@@ -913,9 +780,9 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ port::Status ROCMDriver::SynchronizeStream(ROCmContext* context,
+/* static */ port::Status ROCMDriver::SynchronizeStream(int device_ordinal,
                                                 hipStream_t stream) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   CHECK(stream != nullptr);
   hipError_t res = hipStreamSynchronize(stream);
   if (res != hipSuccess) {
@@ -924,14 +791,14 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
     LOG(ERROR) << status << " :: " << port::CurrentStackTrace();
     return status;
   }
-  VLOG(2) << "successfully synchronized stream " << stream << " on context "
-          << context;
+  VLOG(2) << "successfully synchronized stream " << stream << " on device "
+          << device_ordinal;
   return port::Status::OK();
 }
 
-/* static */ bool ROCMDriver::IsStreamIdle(ROCmContext *context,
+/* static */ bool ROCMDriver::IsStreamIdle(int device_ordinal,
                                            hipStream_t stream) {
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   CHECK(stream != nullptr);
   hipError_t res = hipStreamQuery(stream);
   if (res == hipSuccess) {
@@ -944,11 +811,11 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return false;
 }
 
-/* static */ port::Status ROCMDriver::SynchronousMemcpyD2H(ROCmContext *context,
+/* static */ port::Status ROCMDriver::SynchronousMemcpyD2H(int device_ordinal,
                                                            void *host_dst,
                                                            hipDeviceptr_t gpu_src,
                                                            uint64 size) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemcpyDtoH(host_dst, gpu_src, size);
   if (res != hipSuccess) {
     return port::InternalError(
@@ -962,11 +829,11 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return port::Status::OK();
 }
 
-/* static */ port::Status ROCMDriver::SynchronousMemcpyH2D(ROCmContext *context,
+/* static */ port::Status ROCMDriver::SynchronousMemcpyH2D(int device_ordinal,
                                                            hipDeviceptr_t gpu_dst,
                                                            const void *host_src,
                                                            uint64 size) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemcpyHtoD(gpu_dst, const_cast<void*>(host_src), size);
   if (res != hipSuccess) {
     return port::InternalError(port::Printf(
@@ -979,11 +846,11 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return port::Status::OK();
 }
 
-/* static */ port::Status ROCMDriver::SynchronousMemcpyD2D(ROCmContext *context,
+/* static */ port::Status ROCMDriver::SynchronousMemcpyD2D(int device_ordinal,
                                                            hipDeviceptr_t gpu_dst,
                                                            hipDeviceptr_t gpu_src,
                                                            uint64 size) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemcpyDtoD(gpu_dst, gpu_src, size);
   if (res != hipSuccess) {
     return port::InternalError(port::Printf(
@@ -996,12 +863,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return port::Status::OK();
 }
 
-/* static */ bool ROCMDriver::AsynchronousMemcpyD2H(ROCmContext* context,
+/* static */ bool ROCMDriver::AsynchronousMemcpyD2H(int device_ordinal,
                                                     void *host_dst,
                                                     hipDeviceptr_t gpu_src,
                                                     uint64 size,
                                                     hipStream_t stream) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemcpyDtoHAsync(host_dst, gpu_src, size, stream);
   if (res != hipSuccess) {
     LOG(ERROR) << port::Printf(
@@ -1016,12 +883,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::AsynchronousMemcpyH2D(ROCmContext* context,
+/* static */ bool ROCMDriver::AsynchronousMemcpyH2D(int device_ordinal,
                                                     hipDeviceptr_t gpu_dst,
                                                     const void *host_src,
                                                     uint64 size,
                                                     hipStream_t stream) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t res = hipMemcpyHtoDAsync(gpu_dst, const_cast<void*>(host_src), size, stream);
   if (res != hipSuccess) {
     LOG(ERROR) << port::Printf(
@@ -1035,12 +902,12 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ bool ROCMDriver::AsynchronousMemcpyD2D(ROCmContext* context,
+/* static */ bool ROCMDriver::AsynchronousMemcpyD2D(int device_ordinal,
                                                     hipDeviceptr_t gpu_dst,
                                                     hipDeviceptr_t gpu_src,
                                                     uint64 size,
                                                     hipStream_t stream) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   hipError_t result = hipMemcpyDtoDAsync(gpu_dst, gpu_src, size, stream);
   if (result != hipSuccess) {
     LOG(ERROR) << port::Printf(
@@ -1061,7 +928,7 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
   return true;
 }
 
-/* static */ port::Status ROCMDriver::CreateEvent(ROCmContext* context,
+/* static */ port::Status ROCMDriver::CreateEvent(int device_ordinal,
                                                   hipEvent_t *result,
                                                   EventFlags flags) {
   int hipflags;
@@ -1076,7 +943,7 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
       LOG(FATAL) << "impossible event flags: " << int(hipflags);
   }
 
-  ScopedActivateContext activated{context};
+  ScopedActivateContext activated{device_ordinal};
   hipError_t res = hipEventCreateWithFlags(result, hipflags);
 
   if (res == hipSuccess) {
@@ -1103,22 +970,6 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
     device_count = 1;
   }
   return device_count;
-}
-
-/* static */ port::StatusOr<ROCmContext*> ROCMDriver::GetPointerContext(
-    hipDeviceptr_t pointer) {
-  ROCmContext* context = nullptr;
-  hipError_t result = hipSuccess;
-  // XXX FIXME
-  if (result == hipSuccess) {
-    CHECK(context != nullptr) << "success should entail non-null context";
-    return context;
-  }
-
-  return port::Status{
-      port::error::INTERNAL,
-      port::StrCat("failed to query device pointer for context: ",
-                   ToString(result))};
 }
 
 /* static */ port::StatusOr<MemorySpace> ROCMDriver::GetPointerMemorySpace(
@@ -1168,12 +1019,23 @@ ROCMDriver::ContextGetSharedMemConfig(ROCmContext* context) {
 
 /* static */ port::StatusOr<hipDevice_t> ROCMDriver::GetPointerDevice(
     hipDeviceptr_t pointer) {
-  auto result = GetPointerContext(pointer);
-  if (!result.ok()) {
-    return result.status();
+  hipPointerAttribute_t pointerAttributes;
+  hipError_t result = hipPointerGetAttributes(&pointerAttributes, pointer);
+  if (result != hipSuccess) {
+    return port::Status{
+      port::error::INTERNAL,
+	port::StrCat("failed to get device for pointer: ", ToString(result))};
   }
 
-  return DeviceFromContext(result.ValueOrDie());
+  hipDevice_t device;
+  result = hipDeviceGet(&device, pointerAttributes.device);
+  if (result != hipSuccess) {
+    return port::Status{
+      port::error::INTERNAL,
+	port::StrCat("failed to get device for pointer: ", ToString(result))};
+  }
+  
+  return device;
 }
 
 /* static */ port::Status ROCMDriver::GetAMDGPUISAVersion(int *version,
@@ -1311,10 +1173,10 @@ static port::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   return true;
 }
 
-/* static */ bool ROCMDriver::GetDeviceMemoryInfo(ROCmContext* context,
+/* static */ bool ROCMDriver::GetDeviceMemoryInfo(int device_ordinal,
                                                   int64 *free_out,
                                                   int64 *total_out) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
   size_t free = 0;
   size_t total = 0;
   hipError_t res = hipMemGetInfo(&free, &total);
@@ -1355,27 +1217,15 @@ static port::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   return pci_bus_id;
 }
 
-/* static */ bool ROCMDriver::CanEnablePeerAccess(ROCmContext* from,
-                                                  ROCmContext* to) {
-  if (from == to) {
+/* static */ bool ROCMDriver::CanEnablePeerAccess(int from_device_ordinal,
+                                                  int to_device_ordinal) {
+  if (from_device_ordinal == to_device_ordinal) {
     return true;  // A context can always access its own memory.
   }
 
   int can_access_peer = -1;
-  auto from_device = DeviceFromContext(from);
-  if (!from_device.ok()) {
-    LOG(ERROR) << "failed to resolve 'from' peer access context to a device: "
-               << from_device.status();
-    return false;
-  }
-  auto to_device = DeviceFromContext(to);
-  if (!to_device.ok()) {
-    LOG(ERROR) << "failed to resolve 'to' peer access context to a device: "
-               << to_device.status();
-    return false;
-  }
   hipError_t res = hipDeviceCanAccessPeer(
-      &can_access_peer, from_device.ValueOrDie(), to_device.ValueOrDie());
+      &can_access_peer, from_device_ordinal, to_device_ordinal);
   if (res != hipSuccess) {
     LOG(ERROR) << "failed to detect peer access capability: " << ToString(res);
     return false;
@@ -1384,19 +1234,20 @@ static port::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   return can_access_peer;
 }
 
-/* static */ port::Status ROCMDriver::EnablePeerAccess(ROCmContext* from,
-                                                       ROCmContext* to) {
-  if (from == to) {
+/* static */ port::Status ROCMDriver::EnablePeerAccess(int from_device_ordinal,
+                                                       int to_device_ordinal) {
+  if (from_device_ordinal == to_device_ordinal) {
     return port::Status::OK();  // A context can always access its own memory.
   }
 
-  ScopedActivateContext activated{from};
-  hipError_t result = hipCtxEnablePeerAccess(to->context(), 0 /* = flags */);
+  ScopedActivateContext activated{from_device_ordinal};
+  hipError_t result = hipDeviceEnablePeerAccess(to_device_ordinal, 0 /* = flags */);
   if (result != hipSuccess &&
       result != hipErrorPeerAccessAlreadyEnabled) {
     return port::Status{
         port::error::INTERNAL,
-        port::Printf("failed to enable peer access from %p to %p: %s", from, to,
+        port::Printf("failed to enable peer access from %p to %p: %s",
+		     from_device_ordinal, to_device_ordinal,
                      ToString(result).c_str())};
   }
 
@@ -1404,9 +1255,9 @@ static port::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
 }
 
 /* static */ port::StatusOr<int> ROCMDriver::GetMaxOccupiedBlocksPerCore(
-    ROCmContext* context, hipFunction_t kernel, int threads_per_block,
+    int device_ordinal, hipFunction_t kernel, int threads_per_block,
     size_t dynamic_shared_memory_bytes) {
-  ScopedActivateContext activation{context};
+  ScopedActivateContext activation{device_ordinal};
 
   int max_blocks = 0;
   hipError_t result = hipSuccess;
@@ -1421,11 +1272,11 @@ static port::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   return max_blocks;
 }
 
-/* static */ hipCtx_t ROCMDriver::CurrentContextOrDie() {
-  hipCtx_t current = nullptr;
-  hipError_t result = hipCtxGetCurrent(&current);
+/* static */ int ROCMDriver::CurrentDeviceOrDie() {
+  int current = -1;
+  hipError_t result = hipGetDevice(&current);
   if (result != hipSuccess) {
-    LOG(FATAL) << "failed to query current context: " << ToString(result);
+    LOG(FATAL) << "failed to query current device: " << ToString(result);
   }
   return current;
 }

--- a/tensorflow/stream_executor/rocm/rocm_driver.h
+++ b/tensorflow/stream_executor/rocm/rocm_driver.h
@@ -37,8 +37,6 @@ enum class MemorySpace { kHost, kDevice };
 // Returns a casual string, such as "host" for the provided memory space.
 string MemorySpaceString(MemorySpace memory_space);
 
-class ROCmContext;
-
 // ROCMDriver contains wrappers for calls to the userspace library driver. It's
 // useful to isolate these calls and put basic wrappers around them to separate
 // userspace library driver behaviors from the rest of the program.
@@ -51,55 +49,51 @@ class ROCmContext;
 // Thread safety: these functions should not be used from signal handlers.
 class ROCMDriver {
  public:
-  // Wraps a call to cuInit with logging to help indicate what has gone wrong in
+  // Wraps a call to hipInit with logging to help indicate what has gone wrong in
   // the case of failure. Safe to call multiple times; will be fast on all calls
   // after the first.
   static port::Status Init();
 
-  // Returns the device associated with the given context.
-  // device is an outparam owned by the caller, must not be null.
-  static port::StatusOr<hipDevice_t> DeviceFromContext(ROCmContext* context);
-
-  // Creates a new ROCM stream associated with the given context via
+  // Creates a new ROCM stream associated with the given device via
   // hipStreamCreate.
   // stream is an outparam owned by the caller, must not be null.
-  static bool CreateStream(ROCmContext* context, hipStream_t *stream);
+  static bool CreateStream(int device_ordinal, hipStream_t *stream);
 
-  // Destroys a ROCM stream associated with the given context.
+  // Destroys a ROCM stream associated with the given device.
   // stream is owned by the caller, must not be null, and *stream is set to null
   // if the stream is successfully destroyed.
-  static void DestroyStream(ROCmContext* context, hipStream_t *stream);
+  static void DestroyStream(int device_ordinal, hipStream_t *stream);
 
   // ROCM events can explicitly disable event TSC retrieval for some presumed
   // performance improvement if timing is unnecessary.
   enum class EventFlags { kDefault, kDisableTiming };
 
-  // Creates a new event associated with the given context.
+  // Creates a new event associated with the given device.
   // result is an outparam owned by the caller and must not be null.
-  static port::Status CreateEvent(ROCmContext* context, hipEvent_t *result,
+  static port::Status CreateEvent(int device_ordinal, hipEvent_t *result,
                                   EventFlags flags);
 
   // Destroys *event and turns it into a nullptr. event may not be null, but
   // *event may be, via hipEventDestroy
-  static port::Status DestroyEvent(ROCmContext* context, hipEvent_t *event);
+  static port::Status DestroyEvent(int device_ordinal, hipEvent_t *event);
 
   // Allocates a GPU memory space of size bytes associated with the given
-  // context via hipMemAlloc.
-  static void *DeviceAllocate(ROCmContext* context, uint64 bytes);
+  // device via hipMemAlloc.
+  static void *DeviceAllocate(int device_ordinal, uint64 bytes);
 
   // Deallocates a GPU memory space of size bytes associated with the given
-  // context via hipMemFree.
-  static void DeviceDeallocate(ROCmContext* context, void *location);
+  // device via hipMemFree.
+  static void DeviceDeallocate(int device_ordinal, void *location);
 
   // Allocates page-locked and ROCM-registered memory on the host via
   // hipMemAllocHost.
-  static void *HostAllocate(ROCmContext* context, uint64 bytes);
+  static void *HostAllocate(int device_ordinal, uint64 bytes);
 
   // Deallocates a location created by HostAllocate, via hipMemFreeHost.
-  static void HostDeallocate(ROCmContext* context, void *location);
+  static void HostDeallocate(int device_ordinal, void *location);
 
   // Registers a memory region at location of size bytes via hipMemHostRegister.
-  static bool HostRegister(ROCmContext* context, void *location, uint64 bytes);
+  static bool HostRegister(int device_ordinal, void *location, uint64 bytes);
 
   // Unregisters a memory region that was previously registered at location via
   // hipMemHostUnregister.
@@ -107,7 +101,7 @@ class ROCMDriver {
   //
   // TODO(leary) verify an error will be returned if the location wasn't
   // previously registered.
-  static bool HostUnregister(ROCmContext* context, void *location);
+  static bool HostUnregister(int device_ordinal, void *location);
 
   // Given a device ordinal, returns a device handle into the device outparam,
   // which must not be null.
@@ -120,17 +114,6 @@ class ROCMDriver {
   // device.
   static bool GetDeviceName(hipDevice_t device, string *name_out);
 
-  // Given a device to create a context for, returns a context handle into the
-  // context outparam, which must not be null.
-  static port::Status CreateContext(hipDevice_t device,
-                                    DeviceOptions device_options,
-                                    ROCmContext** context);
-
-  // Destroys the provided context via hipCtxDestroy.
-  // Don't do this while clients could still be using the context, per the docs
-  // bad things will happen.
-  static void DestroyContext(ROCmContext* context);
-
   // Queries the runtime for the specified attribute of the specified function.
   static bool FuncGetAttribute(hipDeviceAttribute_t attribute,
                                hipFunction_t function, int *attribute_value);
@@ -140,19 +123,19 @@ class ROCMDriver {
                                  hipFuncCache_t cache_config);
 
   // Gets the preferred shared memory bank configuration for the specified
-  // CONTEXT (not function!), either default or four- or eight-byte bank size.
-  static port::StatusOr<hipSharedMemConfig> ContextGetSharedMemConfig(
-      ROCmContext* context);
+  // DEVICE (not function!), either default or four- or eight-byte bank size.
+  static port::StatusOr<hipSharedMemConfig> DeviceGetSharedMemConfig(
+      int device_ordinal);
 
   // Sets the preferred shared memory bank configuration for the specified
-  // CONTEXT (not function!), either default or four- or eight-byte bank size.
-  static port::Status ContextSetSharedMemConfig(
-      ROCmContext* context, hipSharedMemConfig shared_mem_config);
+  // DEVICE (not function!), either default or four- or eight-byte bank size.
+  static port::Status DeviceSetSharedMemConfig(
+      int device_ordinal, hipSharedMemConfig shared_mem_config);
 
   // Launches a HIP kernel via hipLaunchKernel.
   // TODO(leary) describe the structure of kernel_params and extra in a readable
   // way.
-  static bool LaunchKernel(ROCmContext* context, hipFunction_t function,
+  static bool LaunchKernel(int device_ordinal, hipFunction_t function,
                            unsigned int grid_dim_x, unsigned int grid_dim_y,
                            unsigned int grid_dim_z, unsigned int block_dim_x,
                            unsigned int block_dim_y, unsigned int block_dim_z,
@@ -161,69 +144,69 @@ class ROCMDriver {
 
   // Loads HSACO with the ROCM runtime and stores the resulting handle in
   // "module". Any error logs that are produced are logged internally.
-  static bool LoadHsaco(ROCmContext* context, const char *hsaco_contents,
+  static bool LoadHsaco(int device_ordinal, const char *hsaco_contents,
                         hipModule_t *module);
 
   // Retrieves a named kernel from a loaded module, and places the resulting
   // handle into function (outparam) on success. Neither kernel_name nor
   // function may be null. No ownership is taken of kernel_name.
-  static bool GetModuleFunction(ROCmContext* context, hipModule_t module,
+  static bool GetModuleFunction(int device_ordinal, hipModule_t module,
                                 const char *kernel_name, hipFunction_t *function);
 
   // Retrieves a named global/constant symbol from a loaded module, and returns
   // a device pointer and size of the symbol on success. symbol_name may not be
   // null. At least one of dptr or bytes should not be null. No ownership is
   // taken of symbol_name.
-  static bool GetModuleSymbol(ROCmContext* context, hipModule_t module,
+  static bool GetModuleSymbol(int device_ordinal, hipModule_t module,
                               const char *symbol_name, hipDeviceptr_t *dptr,
                               size_t *bytes);
 
-  // Unloads module from the current context via cuModuleUnload.
+  // Unloads module from the current device via cuModuleUnload.
   // TODO(leary) the documentation doesn't say what kind of disasters happen
   // if you try to unload a module while its hipFunction_ts are in use.
-  static void UnloadModule(ROCmContext* context, hipModule_t module);
+  static void UnloadModule(int device_ordinal, hipModule_t module);
 
   // Performs a synchronous memset of the device memory segment via hipMemsetD8.
-  static bool SynchronousMemsetUint8(ROCmContext* context, hipDeviceptr_t location,
+  static bool SynchronousMemsetUint8(int device_ordinal, hipDeviceptr_t location,
                                      uint8 value, size_t size);
 
   // Performs a synchronous memset of the device memory segment via hipMemsetD32.
-  static bool SynchronousMemsetUint32(ROCmContext* context,
+  static bool SynchronousMemsetUint32(int device_ordinal,
                                       hipDeviceptr_t location, uint32 value,
                                       size_t uint32_count);
 
   // Performs an asynchronous memset of the device memory segment via
   // hipMemsetD8Async.
-  static bool AsynchronousMemsetUint8(ROCmContext* context, hipDeviceptr_t location,
+  static bool AsynchronousMemsetUint8(int device_ordinal, hipDeviceptr_t location,
                                       uint8 value, size_t uint32_count,
                                       hipStream_t stream);
 
   // Performs an asynchronous memset of the device memory segment via
   // hipMemsetD32Async.
-  static bool AsynchronousMemsetUint32(ROCmContext* context,
+  static bool AsynchronousMemsetUint32(int device_ordinal,
                                        hipDeviceptr_t location, uint32 value,
                                        size_t uint32_count, hipStream_t stream);
 
   // -- Synchronous memcopies.
 
-  static port::Status SynchronousMemcpyD2H(ROCmContext* context, void* host_dst,
+  static port::Status SynchronousMemcpyD2H(int device_ordinal, void* host_dst,
                                            hipDeviceptr_t gpu_src, uint64 size);
-  static port::Status SynchronousMemcpyH2D(ROCmContext* context,
+  static port::Status SynchronousMemcpyH2D(int device_ordinal,
                                            hipDeviceptr_t gpu_dst,
                                            const void* host_src, uint64 size);
-  static port::Status SynchronousMemcpyD2D(ROCmContext* context,
+  static port::Status SynchronousMemcpyD2D(int device_ordinal,
                                            hipDeviceptr_t gpu_dst,
                                            hipDeviceptr_t gpu_src, uint64 size);
 
   // -- Asynchronous memcopies.
 
-  static bool AsynchronousMemcpyD2H(ROCmContext* context, void *host_dst,
+  static bool AsynchronousMemcpyD2H(int device_ordinal, void *host_dst,
                                     hipDeviceptr_t gpu_src, uint64 size,
                                     hipStream_t stream);
-  static bool AsynchronousMemcpyH2D(ROCmContext* context, hipDeviceptr_t gpu_dst,
+  static bool AsynchronousMemcpyH2D(int device_ordinal, hipDeviceptr_t gpu_dst,
                                     const void *host_src, uint64 size,
                                     hipStream_t stream);
-  static bool AsynchronousMemcpyD2D(ROCmContext* context, hipDeviceptr_t gpu_dst,
+  static bool AsynchronousMemcpyD2D(int device_ordinal, hipDeviceptr_t gpu_dst,
                                     hipDeviceptr_t gpu_src, uint64 size,
                                     hipStream_t stream);
 
@@ -240,12 +223,12 @@ class ROCMDriver {
   // Enqueues a callback operation into stream.
   // See StreamCallback above ROCM documentation for additional
   // details.
-  static bool AddStreamCallback(ROCmContext* context, hipStream_t stream,
+  static bool AddStreamCallback(int device_ordinal, hipStream_t stream,
                                 StreamCallback callback, void *data);
 
   // Causes stream to wait for event to trigger before proceeding via
   // hipStreamWaitEvent.
-  static bool WaitStreamOnEvent(ROCmContext* context, hipStream_t stream,
+  static bool WaitStreamOnEvent(int device_ordinal, hipStream_t stream,
                                 hipEvent_t event);
 
   // Blocks the calling thread until the operations enqueued onto stream have
@@ -255,45 +238,42 @@ class ROCMDriver {
   // while another thread blocks like this, can you wind up waiting an unbounded
   // amount of time?
   //
-  static port::Status SynchronizeStream(ROCmContext* context, hipStream_t stream);
+  static port::Status SynchronizeStream(int device_ordinal, hipStream_t stream);
 
-  // Blocks the calling thread until the operations associated with the context
+  // Blocks the calling thread until the operations associated with the device
   // have been completed, via hipCtxSynchronize.
   //
-  static bool SynchronizeContext(ROCmContext* context);
+  static bool SynchronizeDevice(int device_ordinal);
 
   // Returns true if all stream tasks have completed at time of the call. Note
   // the potential for races around this call (if another thread adds work to
   // the stream immediately after this returns).
-  static bool IsStreamIdle(ROCmContext* context, hipStream_t stream);
+  static bool IsStreamIdle(int device_ordinal, hipStream_t stream);
 
-  // Returns whether code in the from context can access memory in the to
-  // context via hipDeviceCanAccessPeer.
-  static bool CanEnablePeerAccess(ROCmContext* from, ROCmContext* to);
+  // Returns whether code in the from device can access memory in the to
+  // device via hipDeviceCanAccessPeer.
+  static bool CanEnablePeerAccess(int from_device_ordinal, int to_device_ordinal);
 
-  // Enables peer access per CanEnablePeerAccess, via hipCtxEnablePeerAccess.
-  static port::Status EnablePeerAccess(ROCmContext* from, ROCmContext* to);
+  // Enables peer access per CanEnablePeerAccess, via hipDeviceEnablePeerAccess.
+  static port::Status EnablePeerAccess(int from_device_ordinal, int to_device_ordinal);
 
   // Returns the elapsed milliseconds between start and stop via
   // hipEventElapsedTime.
-  static bool GetEventElapsedTime(ROCmContext* context,
+  static bool GetEventElapsedTime(int device_ordinal,
                                   float *elapsed_milliseconds, hipEvent_t start,
                                   hipEvent_t stop);
 
   // Records that an event occurred when execution reaches the current point in
   // thestream via hipEventRecord.
-  static port::Status RecordEvent(ROCmContext* context, hipEvent_t event,
+  static port::Status RecordEvent(int device_ordinal, hipEvent_t event,
                                   hipStream_t stream);
 
   // Polls (without blocking) to determine the status of an event - pending or
   // complete (or an error status).
-  static port::StatusOr<hipError_t> QueryEvent(ROCmContext* context,
+  static port::StatusOr<hipError_t> QueryEvent(int device_ordinal,
                                              hipEvent_t event);
 
   // -- Pointer-specific calls.
-
-  // Returns the context in which pointer was allocated or registered.
-  static port::StatusOr<ROCmContext*> GetPointerContext(hipDeviceptr_t pointer);
 
   // Returns the device associated with the context from GetPointerContext().
   static port::StatusOr<hipDevice_t> GetPointerDevice(hipDeviceptr_t pointer);
@@ -350,12 +330,12 @@ class ROCMDriver {
   static bool IsEccEnabled(hipDevice_t device, bool *result);
 
   // Returns the total amount of memory available for allocation by the ROCM
-  // context, in bytes, via hipDeviceTotalMem.
+  // device, in bytes, via hipDeviceTotalMem.
   static bool GetDeviceTotalMemory(hipDevice_t device, uint64 *result);
 
   // Returns the free amount of memory and total amount of memory, as reported
   // by hipMemGetInfo.
-  static bool GetDeviceMemoryInfo(ROCmContext* context, int64* free,
+  static bool GetDeviceMemoryInfo(int device_ordinal, int64* free,
                                   int64* total);
 
   // Returns a PCI bus id string for the device.
@@ -381,51 +361,30 @@ class ROCMDriver {
   // Returns the maximum number of blocks (per multiprocessor) occupied by the
   // specified kernel/hipFunction_t when launched with the specified parameters.
   static port::StatusOr<int> GetMaxOccupiedBlocksPerCore(
-      ROCmContext* context, hipFunction_t kernel, int threads_per_block,
+      int device_ordinal, hipFunction_t kernel, int threads_per_block,
       size_t dynamic_shared_memory_bytes);
 
-  // Returns the current context set in CUDA. This is done by calling the cuda
-  // driver (e.g., this value is not our cached view of the current context).
-  static hipCtx_t CurrentContextOrDie();
+  // Returns the current device ordinal set in HIP. This is done by calling the
+  // HIP driver (e.g., this value is not our cached view of the current device).
+  static int CurrentDeviceOrDie();
 
   // Seam for injecting an error at CUDA initialization time for testing
   // purposes.
   static bool driver_inject_init_error_;
 };
 
-// Ensures a context is activated within a scope.
+// Ensures the given device is activated within a scope.
 class ScopedActivateContext {
  public:
-  // Activates the context via cuCtxSetCurrent, if it is not the currently
-  // active context (a la hipCtxGetCurrent).
-  explicit ScopedActivateContext(ROCmContext* context);
+  // Activates the given device , if it is not the currently active device
+  explicit ScopedActivateContext(int device_ordinal);
 
-  // Checks that the context has remained activated for the duration of the
+  // Checks that the device has remained activated for the duration of the
   // scope.
   ~ScopedActivateContext();
 
  private:
-  ROCmContext* to_restore_ = nullptr;
-};
-
-// ROCmContext wraps a rocm hipCtx_t handle, and includes a unique id. The
-// unique id is positive, and ids are not repeated within the process.
-class ROCmContext {
- public:
-  ROCmContext(hipCtx_t context, int64 id) : context_(context), id_(id) { }
-
-  hipCtx_t context() const { return context_; }
-  int64 id() const { return id_; }
-
-  // Disallow copying and moving.
-  ROCmContext(ROCmContext&&) = delete;
-  ROCmContext(const ROCmContext&) = delete;
-  ROCmContext& operator=(ROCmContext&&) = delete;
-  ROCmContext& operator=(const ROCmContext&) = delete;
-
- private:
-  hipCtx_t const context_;
-  const int64 id_;
+  int to_restore_ = -1;
 };
 
 }  // namespace rocm

--- a/tensorflow/stream_executor/rocm/rocm_event.cc
+++ b/tensorflow/stream_executor/rocm/rocm_event.cc
@@ -28,22 +28,22 @@ ROCMEvent::ROCMEvent(ROCMExecutor* parent)
 ROCMEvent::~ROCMEvent() {}
 
 port::Status ROCMEvent::Init() {
-  return ROCMDriver::CreateEvent(parent_->rocm_context(), &rocm_event_,
+  return ROCMDriver::CreateEvent(parent_->device_ordinal(), &rocm_event_,
                                  ROCMDriver::EventFlags::kDisableTiming);
 }
 
 port::Status ROCMEvent::Destroy() {
-  return ROCMDriver::DestroyEvent(parent_->rocm_context(), &rocm_event_);
+  return ROCMDriver::DestroyEvent(parent_->device_ordinal(), &rocm_event_);
 }
 
 port::Status ROCMEvent::Record(ROCMStream* stream) {
-  return ROCMDriver::RecordEvent(parent_->rocm_context(), rocm_event_,
+  return ROCMDriver::RecordEvent(parent_->device_ordinal(), rocm_event_,
                                  stream->rocm_stream());
 }
 
 Event::Status ROCMEvent::PollForStatus() {
   port::StatusOr<hipError_t> status =
-      ROCMDriver::QueryEvent(parent_->rocm_context(), rocm_event_);
+      ROCMDriver::QueryEvent(parent_->device_ordinal(), rocm_event_);
   if (!status.ok()) {
     LOG(ERROR) << "Error polling for event status: "
                << status.status().error_message();

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -87,14 +87,14 @@ static hipDeviceptr_t AsROCmDevicePtr(DeviceMemoryBase *gpu_mem) {
   return AsROCmDevicePtr(*gpu_mem);
 }
 
-static ROCmContext* GetROCmContext(Stream *stream) {
+static int GetROCmDeviceOrdinal(Stream *stream) {
   return static_cast<ROCMExecutor *>(stream->parent()->implementation())
-      ->rocm_context();
+    ->device_ordinal();
 }
 
-ROCmContext* ExtractROCmContext(ROCMExecutor *rocm_exec) {
+int ExtractROCmDeviceOrdinal(ROCMExecutor *rocm_exec) {
   CHECK(rocm_exec != nullptr);
-  return rocm_exec->rocm_context();
+  return rocm_exec->device_ordinal();
 }
 
 ROCMExecutor *ExtractROCmExecutor(StreamExecutor *stream_exec) {
@@ -103,13 +103,10 @@ ROCMExecutor *ExtractROCmExecutor(StreamExecutor *stream_exec) {
 
 ROCMExecutor::~ROCMExecutor() {
   for (auto &it : disk_modules_) {
-    ROCMDriver::UnloadModule(context_, it.second);
+    ROCMDriver::UnloadModule(device_ordinal_, it.second);
   }
   for (auto &it : in_memory_modules_) {
-    ROCMDriver::UnloadModule(context_, it.second);
-  }
-  if (context_ != nullptr) {
-    ROCMDriver::DestroyContext(context_);
+    ROCMDriver::UnloadModule(device_ordinal_, it.second);
   }
 }
 
@@ -123,11 +120,6 @@ port::Status ROCMExecutor::Init(int device_ordinal,
   }
 
   status = ROCMDriver::GetDevice(device_ordinal_, &device_);
-  if (!status.ok()) {
-    return status;
-  }
-
-  status = ROCMDriver::CreateContext(device_, device_options, &context_);
   if (!status.ok()) {
     return status;
   }
@@ -205,7 +197,7 @@ bool ROCMExecutor::GetKernel(const MultiKernelLoaderSpec &spec,
     module = in_memory_modules_[hsaco];
 
     if (module == nullptr) {
-      if (!ROCMDriver::LoadHsaco(context_, hsaco, &module)) {
+      if (!ROCMDriver::LoadHsaco(device_ordinal_, hsaco, &module)) {
         LOG(ERROR) << "failed to load HSACO\n";
         return false;
       }
@@ -217,7 +209,7 @@ bool ROCMExecutor::GetKernel(const MultiKernelLoaderSpec &spec,
   }
 
   VLOG(2) << "getting function " << kernelname << " from module " << module;
-  if (!ROCMDriver::GetModuleFunction(context_, module, kernelname->c_str(),
+  if (!ROCMDriver::GetModuleFunction(device_ordinal_, module, kernelname->c_str(),
                                      rocm_kernel->rocm_function_ptr())) {
     return false;
   }
@@ -301,7 +293,7 @@ bool ROCMExecutor::Launch(Stream *stream, const ThreadDim &thread_dims,
     HIP_LAUNCH_PARAM_END
   };
 
-  if (!ROCMDriver::LaunchKernel(GetROCmContext(stream), hipfunc, block_dims.x,
+  if (!ROCMDriver::LaunchKernel(GetROCmDeviceOrdinal(stream), hipfunc, block_dims.x,
                                 block_dims.y, block_dims.z, thread_dims.x,
                                 thread_dims.y, thread_dims.z,
                                 args.number_of_shared_bytes(), hipstream,
@@ -369,7 +361,7 @@ void ROCMExecutor::VlogOccupancyInfo(const KernelBase &kernel,
 }
 
 void *ROCMExecutor::Allocate(uint64 size) {
-  return ROCMDriver::DeviceAllocate(context_, size);
+  return ROCMDriver::DeviceAllocate(device_ordinal_, size);
 }
 
 void *ROCMExecutor::AllocateSubBuffer(DeviceMemoryBase *mem,
@@ -381,7 +373,7 @@ void *ROCMExecutor::AllocateSubBuffer(DeviceMemoryBase *mem,
 void ROCMExecutor::Deallocate(DeviceMemoryBase *mem) {
   // ROCM "sub-buffers" are just pointer + offset, so no dealloc is necessary.
   if (!mem->is_sub_buffer()) {
-    ROCMDriver::DeviceDeallocate(context_, mem->opaque());
+    ROCMDriver::DeviceDeallocate(device_ordinal_, mem->opaque());
   }
 }
 
@@ -391,25 +383,25 @@ bool ROCMExecutor::HostMemoryRegister(void *location, uint64 size) {
                  << location << "; size " << size;
   }
   VLOG(2) << "registering " << location << " size " << size;
-  return ROCMDriver::HostRegister(context_, location, size);
+  return ROCMDriver::HostRegister(device_ordinal_, location, size);
 }
 
 bool ROCMExecutor::HostMemoryUnregister(void *location) {
   VLOG(2) << "unregistering " << location;
-  return ROCMDriver::HostUnregister(context_, location);
+  return ROCMDriver::HostUnregister(device_ordinal_, location);
 }
 
 bool ROCMExecutor::SynchronizeAllActivity() {
-  return ROCMDriver::SynchronizeContext(context_);
+  return ROCMDriver::SynchronizeDevice(device_ordinal_);
 }
 
 bool ROCMExecutor::SynchronousMemZero(DeviceMemoryBase *location, uint64 size) {
   if (reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
       size % 4 == 0) {
     return ROCMDriver::SynchronousMemsetUint32(
-        context_, AsROCmDevicePtr(location), 0x0, size / 4);
+        device_ordinal_, AsROCmDevicePtr(location), 0x0, size / 4);
   }
-  return ROCMDriver::SynchronousMemsetUint8(context_, AsROCmDevicePtr(location),
+  return ROCMDriver::SynchronousMemsetUint8(device_ordinal_, AsROCmDevicePtr(location),
                                             0x0, size);
 }
 
@@ -422,29 +414,29 @@ bool ROCMExecutor::SynchronousMemSet(DeviceMemoryBase *location, int value,
     uint32 pattern = (byte_value << 24) | (byte_value << 16) |
                      (byte_value << 8) | byte_value;
     return ROCMDriver::SynchronousMemsetUint32(
-        context_, AsROCmDevicePtr(location), pattern, size / 4);
+        device_ordinal_, AsROCmDevicePtr(location), pattern, size / 4);
   }
-  return ROCMDriver::SynchronousMemsetUint8(context_, AsROCmDevicePtr(location),
+  return ROCMDriver::SynchronousMemsetUint8(device_ordinal_, AsROCmDevicePtr(location),
                                             value, size);
 }
 
 port::Status ROCMExecutor::SynchronousMemcpy(DeviceMemoryBase *gpu_dst,
                                              const void *host_src,
                                              uint64 size) {
-  return ROCMDriver::SynchronousMemcpyH2D(context_, AsROCmDevicePtr(gpu_dst),
+  return ROCMDriver::SynchronousMemcpyH2D(device_ordinal_, AsROCmDevicePtr(gpu_dst),
                                           host_src, size);
 }
 
 port::Status ROCMExecutor::SynchronousMemcpy(void *host_dst,
                                              const DeviceMemoryBase &gpu_src,
                                              uint64 size) {
-  return ROCMDriver::SynchronousMemcpyD2H(context_, host_dst,
+  return ROCMDriver::SynchronousMemcpyD2H(device_ordinal_, host_dst,
                                           AsROCmDevicePtr(gpu_src), size);
 }
 
 port::Status ROCMExecutor::SynchronousMemcpyDeviceToDevice(
     DeviceMemoryBase *gpu_dst, const DeviceMemoryBase &gpu_src, uint64 size) {
-  return ROCMDriver::SynchronousMemcpyD2D(context_, AsROCmDevicePtr(gpu_dst),
+  return ROCMDriver::SynchronousMemcpyD2D(device_ordinal_, AsROCmDevicePtr(gpu_dst),
                                           AsROCmDevicePtr(gpu_src), size);
 }
 
@@ -464,7 +456,7 @@ bool ROCMExecutor::Memset(Stream *stream, DeviceMemoryBase *location,
           << " at location " << location << " with size " << size
           << " and pattern " << std::hex << pattern;
   return ROCMDriver::AsynchronousMemsetUint8(
-      context_, AsROCmDevicePtr(location), pattern, size,
+      device_ordinal_, AsROCmDevicePtr(location), pattern, size,
       AsROCMStreamValue(stream));
 }
 
@@ -476,20 +468,20 @@ bool ROCMExecutor::Memset32(Stream *stream, DeviceMemoryBase *location,
   CHECK(reinterpret_cast<uintptr_t>(location->opaque()) % 4 == 0 &&
         size % 4 == 0);
   return ROCMDriver::AsynchronousMemsetUint32(
-      context_, AsROCmDevicePtr(location), pattern, size / 4,
+      device_ordinal_, AsROCmDevicePtr(location), pattern, size / 4,
       AsROCMStreamValue(stream));
 }
 
 bool ROCMExecutor::Memcpy(Stream *stream, void *host_dst,
                           const DeviceMemoryBase &gpu_src, uint64 size) {
-  return ROCMDriver::AsynchronousMemcpyD2H(context_, host_dst,
+  return ROCMDriver::AsynchronousMemcpyD2H(device_ordinal_, host_dst,
                                            AsROCmDevicePtr(gpu_src), size,
                                            AsROCMStreamValue(stream));
 }
 
 bool ROCMExecutor::Memcpy(Stream *stream, DeviceMemoryBase *gpu_dst,
                           const void *host_src, uint64 size) {
-  return ROCMDriver::AsynchronousMemcpyH2D(context_, AsROCmDevicePtr(gpu_dst),
+  return ROCMDriver::AsynchronousMemcpyH2D(device_ordinal_, AsROCmDevicePtr(gpu_dst),
                                            host_src, size,
                                            AsROCMStreamValue(stream));
 }
@@ -498,7 +490,7 @@ bool ROCMExecutor::MemcpyDeviceToDevice(Stream *stream,
                                         DeviceMemoryBase *gpu_dst,
                                         const DeviceMemoryBase &gpu_src,
                                         uint64 size) {
-  return ROCMDriver::AsynchronousMemcpyD2D(context_, AsROCmDevicePtr(gpu_dst),
+  return ROCMDriver::AsynchronousMemcpyD2D(device_ordinal_, AsROCmDevicePtr(gpu_dst),
                                            AsROCmDevicePtr(gpu_src), size,
                                            AsROCMStreamValue(stream));
 }
@@ -506,7 +498,7 @@ bool ROCMExecutor::MemcpyDeviceToDevice(Stream *stream,
 bool ROCMExecutor::HostCallback(Stream *stream,
                                 std::function<void()> callback) {
   auto callback_ptr = new std::function<void()>(callback);
-  return ROCMDriver::AddStreamCallback(context_, AsROCMStreamValue(stream),
+  return ROCMDriver::AddStreamCallback(device_ordinal_, AsROCMStreamValue(stream),
                                        InternalHostCallback, callback_ptr);
 }
 
@@ -532,7 +524,7 @@ port::Status ROCMExecutor::RecordEvent(Stream *stream, Event *event) {
 }
 
 port::Status ROCMExecutor::WaitForEvent(Stream *stream, Event *event) {
-  if (ROCMDriver::WaitStreamOnEvent(context_,
+  if (ROCMDriver::WaitStreamOnEvent(device_ordinal_,
                                     AsROCMStream(stream)->rocm_stream(),
                                     AsROCMEvent(event)->rocm_event())) {
     return port::Status::OK();
@@ -570,7 +562,7 @@ void ROCMExecutor::DeallocateTimer(Timer *timer) {
 
 bool ROCMExecutor::CreateStreamDependency(Stream *dependent, Stream *other) {
   hipEvent_t other_completed_event = *AsROCMStream(other)->completed_event();
-  bool ok = ROCMDriver::RecordEvent(context_, other_completed_event,
+  bool ok = ROCMDriver::RecordEvent(device_ordinal_, other_completed_event,
                                     AsROCMStreamValue(other))
       .ok();
   if (!ok) {
@@ -579,7 +571,7 @@ bool ROCMExecutor::CreateStreamDependency(Stream *dependent, Stream *other) {
     return false;
   }
 
-  return ROCMDriver::WaitStreamOnEvent(context_, AsROCMStreamValue(dependent),
+  return ROCMDriver::WaitStreamOnEvent(device_ordinal_, AsROCMStreamValue(dependent),
                                        other_completed_event);
 }
 
@@ -592,7 +584,7 @@ bool ROCMExecutor::StopTimer(Stream *stream, Timer *timer) {
 }
 
 port::Status ROCMExecutor::BlockHostUntilDone(Stream *stream) {
-  return ROCMDriver::SynchronizeStream(context_, AsROCMStreamValue(stream));
+  return ROCMDriver::SynchronizeStream(device_ordinal_, AsROCMStreamValue(stream));
 }
 
 blas::BlasSupport *ROCMExecutor::CreateBlas() {
@@ -658,17 +650,17 @@ bool ROCMExecutor::SupportsDnn() const {
 
 bool ROCMExecutor::CanEnablePeerAccessTo(StreamExecutorInterface *other) {
   ROCMExecutor *rocm_other = static_cast<ROCMExecutor *>(other);
-  return ROCMDriver::CanEnablePeerAccess(context_, rocm_other->context_);
+  return ROCMDriver::CanEnablePeerAccess(device_ordinal_, rocm_other->device_ordinal());
 }
 
 port::Status ROCMExecutor::EnablePeerAccessTo(StreamExecutorInterface *other) {
   ROCMExecutor *rocm_other = static_cast<ROCMExecutor *>(other);
-  return ROCMDriver::EnablePeerAccess(context_, rocm_other->context_);
+  return ROCMDriver::EnablePeerAccess(device_ordinal_, rocm_other->device_ordinal());
 }
 
 SharedMemoryConfig ROCMExecutor::GetDeviceSharedMemoryConfig() {
   port::StatusOr<hipSharedMemConfig> rocm_config =
-      ROCMDriver::ContextGetSharedMemConfig(context_);
+      ROCMDriver::DeviceGetSharedMemConfig(device_ordinal_);
   if (!rocm_config.ok()) {
     // Don't log; the failed call will log necessary output.
     return SharedMemoryConfig::kDefault;
@@ -704,11 +696,11 @@ port::Status ROCMExecutor::SetDeviceSharedMemoryConfig(
       LOG(FATAL) << "Invalid shared memory configuration specified: "
                  << static_cast<int>(config);
   }
-  return ROCMDriver::ContextSetSharedMemConfig(context_, rocm_config);
+  return ROCMDriver::DeviceSetSharedMemConfig(device_ordinal_, rocm_config);
 }
 
 bool ROCMExecutor::DeviceMemoryUsage(int64 *free, int64 *total) const {
-  return ROCMDriver::GetDeviceMemoryInfo(context_, free, total);
+  return ROCMDriver::GetDeviceMemoryInfo(device_ordinal_, free, total);
 }
 
 bool ROCMExecutor::GetSymbol(const string& symbol_name, void **mem,
@@ -716,7 +708,7 @@ bool ROCMExecutor::GetSymbol(const string& symbol_name, void **mem,
   {  // give limited scope to mutex_lock
     mutex_lock lock{disk_modules_mu_};
     for (auto &it : disk_modules_) {
-      if (ROCMDriver::GetModuleSymbol(context_, it.second, symbol_name.c_str(),
+      if (ROCMDriver::GetModuleSymbol(device_ordinal_, it.second, symbol_name.c_str(),
                                       reinterpret_cast<hipDeviceptr_t *>(mem),
                                       bytes)) {
         return true;
@@ -727,7 +719,7 @@ bool ROCMExecutor::GetSymbol(const string& symbol_name, void **mem,
   {  // give limited scope to mutex_lock
     mutex_lock lock{in_memory_modules_mu_};
     for (auto &it : in_memory_modules_) {
-      if (ROCMDriver::GetModuleSymbol(context_, it.second, symbol_name.c_str(),
+      if (ROCMDriver::GetModuleSymbol(device_ordinal_, it.second, symbol_name.c_str(),
                                       reinterpret_cast<hipDeviceptr_t *>(mem),
                                       bytes)) {
         return true;
@@ -781,9 +773,7 @@ ROCMExecutor::GetTimerImplementation() {
   return std::unique_ptr<internal::TimerInterface>(new ROCMTimer(this));
 }
 
-void *ROCMExecutor::GPUContextHack() { return context_; }
-
-ROCmContext* ROCMExecutor::rocm_context() { return context_; }
+void *ROCMExecutor::GPUContextHack() { return nullptr; }
 
 // Attempts to read the NUMA node corresponding to the GPU device's PCI bus out
 // of SysFS. Returns -1 if it cannot.

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -46,7 +46,6 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   // be a ROCM type.
   explicit ROCMExecutor(const PluginConfig &plugin_config)
       : device_(0),
-        context_(nullptr),
         device_ordinal_(0),
         version_(0),
         plugin_config_(plugin_config) {}
@@ -77,11 +76,11 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   // There's no external interface for us to otherwise control these DMA
   // settings.
   void *HostMemoryAllocate(uint64 size) override {
-    return ROCMDriver::HostAllocate(context_, size);
+    return ROCMDriver::HostAllocate(device_ordinal_, size);
   }
 
   void HostMemoryDeallocate(void *location) override {
-    return ROCMDriver::HostDeallocate(context_, location);
+    return ROCMDriver::HostDeallocate(device_ordinal_, location);
   }
 
   bool HostMemoryRegister(void *location, uint64 size) override;
@@ -202,8 +201,8 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
 
   void *GPUContextHack() override;
 
-  ROCmContext* rocm_context();
-
+  int device_ordinal() const { return device_ordinal_; }
+  
  private:
   // Attempts to find a more specific version of the file indicated by
   // filename by looking for AMDGPU ISA-specific suffixed versions.
@@ -251,9 +250,6 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   // Handle for the ROCM device being operated on. Immutable
   // post-initialization.
   hipDevice_t device_;
-
-  // Handle for session with the library/driver. Immutable post-initialization.
-  ROCmContext* context_;
 
   // The device ordinal value that this executor was initialized with; recorded
   // for use in getting device metadata. Immutable post-initialization.

--- a/tensorflow/stream_executor/rocm/rocm_stream.cc
+++ b/tensorflow/stream_executor/rocm/rocm_stream.cc
@@ -23,10 +23,10 @@ namespace stream_executor {
 namespace rocm {
 
 bool ROCMStream::Init() {
-  if (!ROCMDriver::CreateStream(parent_->rocm_context(), &rocm_stream_)) {
+  if (!ROCMDriver::CreateStream(parent_->device_ordinal(), &rocm_stream_)) {
     return false;
   }
-  return ROCMDriver::CreateEvent(parent_->rocm_context(), &completed_event_,
+  return ROCMDriver::CreateEvent(parent_->device_ordinal(), &completed_event_,
                                  ROCMDriver::EventFlags::kDisableTiming)
       .ok();
 }
@@ -34,17 +34,17 @@ bool ROCMStream::Init() {
 void ROCMStream::Destroy() {
   if (completed_event_ != nullptr) {
     port::Status status =
-        ROCMDriver::DestroyEvent(parent_->rocm_context(), &completed_event_);
+        ROCMDriver::DestroyEvent(parent_->device_ordinal(), &completed_event_);
     if (!status.ok()) {
       LOG(ERROR) << status.error_message();
     }
   }
 
-  ROCMDriver::DestroyStream(parent_->rocm_context(), &rocm_stream_);
+  ROCMDriver::DestroyStream(parent_->device_ordinal(), &rocm_stream_);
 }
 
 bool ROCMStream::IsIdle() const {
-  return ROCMDriver::IsStreamIdle(parent_->rocm_context(), rocm_stream_);
+  return ROCMDriver::IsStreamIdle(parent_->device_ordinal(), rocm_stream_);
 }
 
 ROCMStream *AsROCMStream(Stream *stream) {


### PR DESCRIPTION
This PR removes all calls to the HIP Context API from the codebase.

From a functionality point of view, this means that we will no longer explicitly create a new "context" in the `ROCmExecutor::Init` routine and simply use the default / primary context instead (which is implicitly created by the HIP runtime) 

Since we now always use the primary context associated with each GPU device, all we need to keep track of the "current context" is the device id associated with the GPU device. This is reflect in the changes which essentially replace the "context" with "device_ordinal"

The local compile completes successfully with these changes....pushing this PR to get CI to run the unit tests


