### PR TITLE
(Preview - Do Not Merge) Update Eigen commit  pointer to the commit that adds AMD GPU support in Eigen

### DIFF
--- a/tensorflow/contrib/lite/kernels/internal/optimized/eigen_tensor_reduced_instantiations_google.h
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/eigen_tensor_reduced_instantiations_google.h
@@ -103,7 +103,7 @@ limitations under the License.
   }
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorContractionThreadPool.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorContractionCuda.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorContractionGpu.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorConversion.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorConvolution.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorFFT.h"
@@ -135,7 +135,7 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorMap.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorRef.h"
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorReductionCuda.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorReductionGpu.h"
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/src/Tensor/TensorIO.h"
 

--- a/tensorflow/contrib/lite/kernels/internal/optimized/eigen_tensor_reduced_instantiations_oss.h
+++ b/tensorflow/contrib/lite/kernels/internal/optimized/eigen_tensor_reduced_instantiations_oss.h
@@ -94,7 +94,7 @@ typedef unsigned __int64 uint64_t;
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorCostModel.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorDeviceDefault.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorDeviceThreadPool.h"
-#include "unsupported/Eigen/CXX11/src/Tensor/TensorDeviceCuda.h"
+#include "unsupported/Eigen/CXX11/src/Tensor/TensorDeviceGpu.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorDeviceSycl.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorIndexList.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorDimensionList.h"
@@ -109,7 +109,7 @@ typedef unsigned __int64 uint64_t;
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorEvaluator.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorExpr.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorReduction.h"
-#include "unsupported/Eigen/CXX11/src/Tensor/TensorReductionCuda.h"
+#include "unsupported/Eigen/CXX11/src/Tensor/TensorReductionGpu.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorArgMax.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorConcatenation.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorContractionMapper.h"
@@ -128,7 +128,7 @@ typedef unsigned __int64 uint64_t;
 
 
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorContractionThreadPool.h"
-#include "unsupported/Eigen/CXX11/src/Tensor/TensorContractionCuda.h"
+#include "unsupported/Eigen/CXX11/src/Tensor/TensorContractionGpu.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorConversion.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorConvolution.h"
 #include "unsupported/Eigen/CXX11/src/Tensor/TensorFFT.h"

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -101,7 +101,7 @@ class EigenCudaStreamDevice : public ::Eigen::StreamInterface {
     context_ = context;
     scratch_ = scratch;
     semaphore_ =
-        reinterpret_cast<unsigned int*>(scratch + Eigen::kCudaScratchSize);
+        reinterpret_cast<unsigned int*>(scratch + Eigen::kGpuScratchSize);
     stream_ = cuda_stream;
     allocator_ = alloc;
     CudaGpuId cuda_gpu_id;
@@ -302,7 +302,7 @@ Status BaseGPUDevice::Init(const SessionOptions& options) {
     streams_.push_back(StreamGroupFactory::Global().GetOrCreate(
         tf_gpu_id_, i, executor_, options.config.gpu_options()));
 
-    size_t scratch_buffer_size = Eigen::kCudaScratchSize + sizeof(unsigned int);
+    size_t scratch_buffer_size = Eigen::kGpuScratchSize + sizeof(unsigned int);
     void* scratch_buffer = gpu_allocator_->AllocateRaw(
         Allocator::kAllocatorAlignment, scratch_buffer_size);
     if (scratch_buffer == nullptr) {
@@ -315,7 +315,7 @@ Status BaseGPUDevice::Init(const SessionOptions& options) {
         se::DeviceMemoryBase(scratch_buffer, scratch_buffer_size));
 
     bool ok = executor_->SynchronousMemZero(
-        &mem, Eigen::kCudaScratchSize + sizeof(unsigned int));
+        &mem, Eigen::kGpuScratchSize + sizeof(unsigned int));
     if (!ok) {
       return errors::FailedPrecondition(
           "Failed to memcopy into scratch buffer for device ",

--- a/tensorflow/core/kernels/check_numerics_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/check_numerics_op_gpu.cu.cc
@@ -60,9 +60,9 @@ template <typename T>
 struct CheckNumericsLaunch {
   void Run(const GPUDevice &d, const T *data, int size,
            int abnormal_detected[2]) {
-    const int32 block_size = d.maxCudaThreadsPerBlock();
+    const int32 block_size = d.maxGpuThreadsPerBlock();
     const int32 num_blocks =
-        (d.getNumCudaMultiProcessors() * d.maxCudaThreadsPerMultiProcessor()) /
+        (d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor()) /
         block_size;
 
     CheckNumericsKernel<T><<<num_blocks, block_size, 0, d.stream()>>>(

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.cu.cc
@@ -702,7 +702,7 @@ void LaunchDepthwiseConv2dGPU(const GpuDevice& device,
   const int max_block_count = kKnownFilterWidth < 0 || kKnownFilterHeight < 0 ||
                                       kKnownDepthMultiplier < 0
                                   ? std::numeric_limits<int>::max()
-                                  : device.getNumCudaMultiProcessors();
+                                  : device.getNumGpuMultiProcessors();
   kernel<<<std::min(max_block_count, config.block_count),
            config.thread_per_block, 0, device.stream()>>>(args, input, filter,
                                                           output, num_outputs);

--- a/tensorflow/core/kernels/random_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/random_op_gpu.cu.cc
@@ -217,9 +217,9 @@ void FillPhiloxRandom<GPUDevice, Distribution>::operator()(
     OpKernelContext*, const GPUDevice& d, random::PhiloxRandom gen,
     typename Distribution::ResultElementType* data, int64 size,
     Distribution dist) {
-  const int32 block_size = d.maxCudaThreadsPerBlock();
+  const int32 block_size = d.maxGpuThreadsPerBlock();
   const int32 num_blocks =
-      (d.getNumCudaMultiProcessors() * d.maxCudaThreadsPerMultiProcessor()) /
+      (d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor()) /
       block_size;
 
   FillPhiloxRandomKernelLaunch<Distribution>

--- a/tensorflow/core/util/cuda_launch_config.h
+++ b/tensorflow/core/util/cuda_launch_config.h
@@ -128,12 +128,12 @@ inline CudaLaunchConfig GetCudaLaunchConfig(int work_element_count,
   CudaLaunchConfig config;
   const int virtual_thread_count = work_element_count;
   const int physical_thread_count = std::min(
-      d.getNumCudaMultiProcessors() * d.maxCudaThreadsPerMultiProcessor(),
+      d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor(),
       virtual_thread_count);
-  const int thread_per_block = std::min(1024, d.maxCudaThreadsPerBlock());
+  const int thread_per_block = std::min(1024, d.maxGpuThreadsPerBlock());
   const int block_count =
       std::min(DivUp(physical_thread_count, thread_per_block),
-               d.getNumCudaMultiProcessors());
+               d.getNumGpuMultiProcessors());
 
   config.virtual_thread_count = virtual_thread_count;
   config.thread_per_block = thread_per_block;
@@ -184,7 +184,7 @@ inline CudaLaunchConfig GetCudaLaunchConfigFixedBlockSize(
   cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
       &block_count, func, fixed_block_size, dynamic_shared_memory_size);
   CHECK_EQ(err, cudaSuccess);
-  block_count = std::min(block_count * d.getNumCudaMultiProcessors(),
+  block_count = std::min(block_count * d.getNumGpuMultiProcessors(),
                          DivUp(work_element_count, fixed_block_size));
 
   config.virtual_thread_count = work_element_count;
@@ -213,7 +213,7 @@ inline Cuda2DLaunchConfig GetCuda2DLaunchConfig(int xdim, int ydim,
   int block_rows = std::max(kThreadsPerBlock / block_cols, 1);
 
   const int physical_thread_count =
-      d.getNumCudaMultiProcessors() * d.maxCudaThreadsPerMultiProcessor();
+      d.getNumGpuMultiProcessors() * d.maxGpuThreadsPerMultiProcessor();
 
   const int max_blocks = std::max(physical_thread_count / kThreadsPerBlock, 1);
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -107,11 +107,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "eigen_archive",
       urls = [
-          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
-          "https://bitbucket.org/eigen/eigen/get/fd6845384b86.tar.gz",
+          "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/8475e3c056d3.tar.gz",
+          "https://bitbucket.org/eigen/eigen/get/8475e3c056d3.tar.gz",
       ],
-      sha256 = "d956415d784fa4e42b6a2a45c32556d6aec9d0a3d8ef48baee2522ab762556a9",
-      strip_prefix = "eigen-eigen-fd6845384b86",
+      sha256 = "32b2e2f8751ac6ef223e2cd6ba70718fbc3c810463763083497f1ba203e13573",
+      strip_prefix = "eigen-eigen-8475e3c056d3",
       build_file = clean_dep("//third_party:eigen.BUILD"),
   )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -113,6 +113,7 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       sha256 = "32b2e2f8751ac6ef223e2cd6ba70718fbc3c810463763083497f1ba203e13573",
       strip_prefix = "eigen-eigen-8475e3c056d3",
       build_file = clean_dep("//third_party:eigen.BUILD"),
+      patch_file = clean_dep("//third_party:eigen_fix_gpu_compilation.patch"),
   )
 
   tf_http_archive(

--- a/third_party/eigen_fix_gpu_compilation.patch
+++ b/third_party/eigen_fix_gpu_compilation.patch
@@ -1,0 +1,19 @@
+diff -Naur eigen-eigen-8475e3c056d3/Eigen/src/Core/arch/GPU/PacketMathHalf.h eigen_archive/Eigen/src/Core/arch/GPU/PacketMathHalf.h
+--- eigen-eigen-8475e3c056d3/Eigen/src/Core/arch/GPU/PacketMathHalf.h	     2018-07-12 04:07:16.000000000 -0400
++++ eigen_archive/Eigen/src/Core/arch/GPU/PacketMathHalf.h		     2018-07-18 15:14:40.001758133 -0400
+@@ -945,10 +945,10 @@
+     AlignedOnScalar = 1,
+     size = 8,
+     HasHalfPacket = 0,
+-    HasAdd    = 1,
+-    HasSub    = 1,
+-    HasMul    = 1,
+-    HasNegate = 1,
++    HasAdd    = 0,
++    HasSub    = 0,
++    HasMul    = 0,
++    HasNegate = 0,
+     HasAbs    = 0,
+     HasAbs2   = 0,
+     HasMin    = 0,
+			      


### PR DESCRIPTION
Updating the eigen commit pointer to the commit / PR that add the AMD GPU support in the Eigen codebase.

The change in eigen renames some of the APIs from Cuda* to Gpu*.  This renaming requires corresponding updates in the Tensorflow code that uses those APIs. That is the reason for the changes in the Tensorflow code in this PR.


There is commit (in the eigen codebase) which is chronologically between the commit currently pointed to by TF and the commit that this PR updates to, which will cause a compiler failure for the TF build.  That commit is 
https://bitbucket.org/eigen/eigen/commits/4af74f577a4fc09dcfa202064e1291038d2046da?at=default

The eigen patch file is required to workaround the compile failure introduced by that commit (it does so by essentially turning OFF the AVX vectorization functionality introduced by that commit). It is assumed that this compile failure will be fixed by code updates either on the TF side or eigen side, after which the eigen patch file will again not be needed

The compile failure in question looks like

```
  (cd /root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow && \
  exec env - \
    LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64 \
    PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    PWD=/proc/self/cwd \
  external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -g0 '-march=haswell' -g0 -MD -MF bazel-out/host/bin/tensorflow/core/kernels/_objs/segment_reduction_ops/tensorflow/core/kernels/segment_reduction_ops.pic.d '-frandom-seed=bazel-out/\
host/bin/tensorflow/core/kernels/_objs/segment_reduction_ops/tensorflow/core/kernels/segment_reduction_ops.pic.o' -DEIGEN_MPL2_ONLY '-DEIGEN_MAX_ALIGN_BYTES=64' -D__CLANG_SUPPORT_DYN_ANNOTATION__ -DTENSORFLOW_USE_JEMALLOC -DTENSORFLOW_USE_ABSL -DTF_USE_SNAPPY -iquot\
e . -iquote bazel-out/host/genfiles -iquote external/nsync -iquote bazel-out/host/genfiles/external/nsync -iquote external/bazel_tools -iquote bazel-out/host/genfiles/external/bazel_tools -iquote external/eigen_archive -iquote bazel-out/host/genfiles/external/eigen_\
archive -iquote external/local_config_sycl -iquote bazel-out/host/genfiles/external/local_config_sycl -iquote external/com_google_absl -iquote bazel-out/host/genfiles/external/com_google_absl -iquote external/jemalloc -iquote bazel-out/host/genfiles/external/jemallo\
c -iquote external/gif_archive -iquote bazel-out/host/genfiles/external/gif_archive -iquote external/jpeg -iquote bazel-out/host/genfiles/external/jpeg -iquote external/protobuf_archive -iquote bazel-out/host/genfiles/external/protobuf_archive -iquote external/com_g\
ooglesource_code_re2 -iquote bazel-out/host/genfiles/external/com_googlesource_code_re2 -iquote external/farmhash_archive -iquote bazel-out/host/genfiles/external/farmhash_archive -iquote external/fft2d -iquote bazel-out/host/genfiles/external/fft2d -iquote external\
/highwayhash -iquote bazel-out/host/genfiles/external/highwayhash -iquote external/png_archive -iquote bazel-out/host/genfiles/external/png_archive -iquote external/zlib_archive -iquote bazel-out/host/genfiles/external/zlib_archive -iquote external/local_config_cuda\
 -iquote bazel-out/host/genfiles/external/local_config_cuda -iquote external/double_conversion -iquote bazel-out/host/genfiles/external/double_conversion -isystem external/nsync/public -isystem bazel-out/host/genfiles/external/nsync/public -isystem external/bazel_to\
ols/tools/cpp/gcc3 -isystem external/eigen_archive -isystem bazel-out/host/genfiles/external/eigen_archive -isystem external/jemalloc/include -isystem bazel-out/host/genfiles/external/jemalloc/include -isystem external/gif_archive/lib -isystem bazel-out/host/genfile\
s/external/gif_archive/lib -isystem external/protobuf_archive/src -isystem bazel-out/host/genfiles/external/protobuf_archive/src -isystem external/farmhash_archive/src -isystem bazel-out/host/genfiles/external/farmhash_archive/src -isystem external/png_archive -isys\
tem bazel-out/host/genfiles/external/png_archive -isystem external/zlib_archive -isystem bazel-out/host/genfiles/external/zlib_archive -isystem external/local_config_cuda/cuda -isystem bazel-out/host/genfiles/external/local_config_cuda/cuda -isystem external/local_c\
onfig_cuda/cuda/cuda/include -isystem bazel-out/host/genfiles/external/local_config_cuda/cuda/cuda/include -isystem external/local_config_cuda/cuda/cuda/include/crt -isystem bazel-out/host/genfiles/external/local_config_cuda/cuda/cuda/include/crt -isystem external/d\
ouble_conversion -isystem bazel-out/host/genfiles/external/double_conversion '-std=c++11' -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -fPIC -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -Wall \
-fno-omit-frame-pointer -no-canonical-prefixes -DNDEBUG -g0 -O2 -ffunction-sections -fdata-sections -DEIGEN_AVOID_STL_ARRAY -Iexternal/gemmlowp -Wno-sign-compare -fno-exceptions '-ftemplate-depth=900' '-DGOOGLE_CUDA=1' -msse3 -pthread '-DGOOGLE_CUDA=1' -c tensorflow\
/core/kernels/segment_reduction_ops.cc -o bazel-out/host/bin/tensorflow/core/kernels/_objs/segment_reduction_ops/tensorflow/core/kernels/segment_reduction_ops.pic.o)^M
In file included from external/eigen_archive/unsupported/Eigen/CXX11/Tensor:94:0,
                 from ./third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1,
                 from tensorflow/core/kernels/segment_reduction_ops.cc:24:
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorFunctors.h: In instantiation of 'Packet Eigen::internal::MeanReducer<T>::finalizePacket(const Packet&) const [with Packet = Eigen::internal::Packet8h; T = Eigen::half]':
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorReduction.h:654:44:   required from 'Eigen::TensorEvaluator<const Eigen::TensorReductionOp<Op, Dims, XprType, MakePointer_>, Device>::PacketReturnType Eigen::TensorEvaluator<const Eigen::TensorReduction\
Op<Op, Dims, XprType, MakePointer_>, Device>::packet(Eigen::TensorEvaluator<const Eigen::TensorReductionOp<Op, Dims, XprType, MakePointer_>, Device>::Index) const [with int LoadMode = 0; Op = Eigen::internal::MeanReducer<Eigen::half>; Dims = const Eigen::IndexList<E\
igen::type2index<0l> >; ArgType = const Eigen::TensorMap<Eigen::Tensor<const Eigen::half, 2, 1, long int>, 0, Eigen::MakePointer>; MakePointer_ = Eigen::MakePointer; Device = Eigen::DefaultDevice; Eigen::TensorEvaluator<const Eigen::TensorReductionOp<Op, Dims, XprTy\
pe, MakePointer_>, Device>::PacketReturnType = Eigen::internal::Packet8h; Eigen::TensorEvaluator<const Eigen::TensorReductionOp<Op, Dims, XprType, MakePointer_>, Device>::Index = long int]'
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorAssign.h:142:5:   required from 'void Eigen::TensorEvaluator<const Eigen::TensorAssignOp<LhsXprType, RhsXprType>, Device>::evalPacket(Eigen::TensorEvaluator<const Eigen::TensorAssignOp<LhsXprType, RhsXp\
rType>, Device>::Index) [with LeftArgType = Eigen::TensorMap<Eigen::Tensor<Eigen::half, 1, 1, long int>, 0, Eigen::MakePointer>; RightArgType = const Eigen::TensorReductionOp<Eigen::internal::MeanReducer<Eigen::half>, const Eigen::IndexList<Eigen::type2index<0l> >, \
const Eigen::TensorMap<Eigen::Tensor<const Eigen::half, 2, 1, long int>, 0, Eigen::MakePointer>, Eigen::MakePointer>; Device = Eigen::DefaultDevice; Eigen::TensorEvaluator<const Eigen::TensorAssignOp<LhsXprType, RhsXprType>, Device>::Index = long int]'
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorExecutor.h:68:11:   required from 'static void Eigen::internal::TensorExecutor<Expression, Eigen::DefaultDevice, true>::run(const Expression&, const Eigen::DefaultDevice&) [with Expression = const Eigen\
::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<Eigen::half, 1, 1, long int>, 0, Eigen::MakePointer>, const Eigen::TensorReductionOp<Eigen::internal::MeanReducer<Eigen::half>, const Eigen::IndexList<Eigen::type2index<0l> >, const Eigen::TensorMap<Eigen::Tensor<const\
 Eigen::half, 2, 1, long int>, 0, Eigen::MakePointer>, Eigen::MakePointer> >]'
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorMap.h:310:65:   required from 'Eigen::TensorMap<PlainObjectType, Options_, MakePointer_>::Self& Eigen::TensorMap<PlainObjectType, Options_, MakePointer_>::operator=(const OtherDerived&) [with OtherDeriv\
ed = Eigen::TensorReductionOp<Eigen::internal::MeanReducer<Eigen::half>, const Eigen::IndexList<Eigen::type2index<0l> >, const Eigen::TensorMap<Eigen::Tensor<const Eigen::half, 2, 1, long int>, 0, Eigen::MakePointer>, Eigen::MakePointer>; PlainObjectType = Eigen::Te\
nsor<Eigen::half, 1, 1, long int>; int Options_ = 0; MakePointer_ = Eigen::MakePointer; Eigen::TensorMap<PlainObjectType, Options_, MakePointer_>::Self = Eigen::TensorMap<Eigen::Tensor<Eigen::half, 1, 1, long int>, 0, Eigen::MakePointer>]'
tensorflow/core/kernels/segment_reduction_ops.cc:186:19:   required from 'void tensorflow::SegmentReductionOp<Device, T, Index, Reducer, default_value>::Compute(tensorflow::OpKernelContext*) [with Device = Eigen::ThreadPoolDevice; T = Eigen::half; Index = long long \
int; Reducer = Eigen::internal::MeanReducer<Eigen::half>; int default_value = 0]'
tensorflow/core/kernels/segment_reduction_ops.cc:1142:1:   required from here
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorFunctors.h:174:38: error: no matching function for call to 'pset1(const DenseIndex&)'
     return pdiv(vaccum, pset1<Packet>(packetCount_));
                                      ^
In file included from external/eigen_archive/Eigen/Core:409:0,
                 from ./third_party/eigen3/Eigen/Core:1,
                 from tensorflow/core/kernels/segment_reduction_ops.cc:23:
external/eigen_archive/Eigen/src/Core/GenericPacketMath.h:227:1: note: candidate: template<class Packet> Packet Eigen::internal::pset1(const typename Eigen::internal::unpacket_traits<Packet>::type&)
 pset1(const typename unpacket_traits<Packet>::type& a) { return a; }
 ^
external/eigen_archive/Eigen/src/Core/GenericPacketMath.h:227:1: note:   template argument deduction/substitution failed:
In file included from external/eigen_archive/unsupported/Eigen/CXX11/Tensor:94:0,
                 from ./third_party/eigen3/unsupported/Eigen/CXX11/Tensor:1,
                 from tensorflow/core/kernels/segment_reduction_ops.cc:24:
external/eigen_archive/unsupported/Eigen/CXX11/src/Tensor/TensorFunctors.h:174:38: note:   cannot convert '((const Eigen::internal::MeanReducer<Eigen::half>*)this)->Eigen::internal::MeanReducer<Eigen::half>::packetCount_' (type 'const DenseIndex {aka const long int}\
') to type 'const type& {aka const Eigen::half&}'
     return pdiv(vaccum, pset1<Packet>(packetCount_));

```
