### PR TITLE
[XLA] add new XLA_AMDGPU device class

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -44,7 +44,7 @@ cc_library(
         ":xla_gpu_device",
         ":xla_gpu_jit",
     ]) + if_rocm_is_configured([
-        ":xla_gpu_device",
+        ":xla_amdgpu_device",
         ":xla_gpu_jit",
     ]),
     alwayslink = 1,
@@ -100,6 +100,23 @@ cc_library(
 cc_library(
     name = "xla_gpu_device",
     srcs = ["xla_gpu_device.cc"],
+    visibility = [":friends"],
+    deps = [
+        ":jit_compilation_passes",
+        ":xla_device",
+        "//tensorflow/compiler/jit/kernels:xla_launch_op",
+        "//tensorflow/compiler/tf2xla:xla_compiler",
+        "//tensorflow/compiler/tf2xla/kernels:xla_ops",
+        "//tensorflow/compiler/xla/service:gpu_plugin",  # buildcleaner: keep
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:lib",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
+    name = "xla_amdgpu_device",
+    srcs = ["xla_amdgpu_device.cc"],
     visibility = [":friends"],
     deps = [
         ":jit_compilation_passes",
@@ -500,7 +517,10 @@ cc_header_only_library(
     deps = [
         ":xla_cpu_device",
         ":xla_cpu_jit",
-        ":xla_gpu_device",
         ":xla_gpu_jit",
-    ],
+    ] + if_cuda_is_configured([
+        ":xla_gpu_device",
+    ]) + if_rocm_is_configured([
+        ":xla_amdgpu_device",
+    ]),
 )

--- a/tensorflow/compiler/tests/build_defs.bzl
+++ b/tensorflow/compiler/tests/build_defs.bzl
@@ -1,12 +1,15 @@
 """Build rules for Tensorflow/XLA testing."""
 
 load("@local_config_cuda//cuda:build_defs.bzl", "cuda_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "rocm_is_configured")
 load("//tensorflow/compiler/tests:plugin.bzl", "plugins")
 
 def all_backends():
   b = ["cpu"] + plugins.keys()
   if cuda_is_configured():
     return b + ["gpu"]
+  elif rocm_is_configured():
+    return b + ["rocm"]
   else:
     return b
 
@@ -59,6 +62,11 @@ def tf_xla_py_test(name, srcs=[], deps=[], tags=[], data=[], main=None,
           "--types=DT_HALF,DT_FLOAT,DT_DOUBLE,DT_INT32,DT_INT64,DT_BOOL,DT_COMPLEX64,DT_BFLOAT16"
       ]
       backend_tags += ["requires-gpu-sm35"]
+    elif backend == "rocm":
+      backend_args += [
+          "--test_device=XLA_AMDGPU",
+          "--types=DT_HALF,DT_FLOAT,DT_DOUBLE,DT_INT32,DT_INT64,DT_BOOL"
+      ]
     elif backend in plugins:
       backend_args += ["--test_device=" + plugins[backend]["device"],
                        "--types=" + plugins[backend]["types"]]

--- a/tensorflow/compiler/tests/sort_ops_test.py
+++ b/tensorflow/compiler/tests/sort_ops_test.py
@@ -49,7 +49,7 @@ class XlaSortOpTest(xla_test.XLATestCase):
 
   def testSort(self):
     # TODO(b/26783907): The Sort HLO is not implemented on CPU or GPU.
-    if self.device in ["XLA_CPU", "XLA_GPU"]:
+    if self.device in ["XLA_CPU", "XLA_GPU", "XLA_AMDGPU"]:
       return
 
     supported_types = set([dtypes.bfloat16.as_numpy_dtype, np.float32])
@@ -61,7 +61,7 @@ class XlaSortOpTest(xla_test.XLATestCase):
 
   def testTopK(self):
     # TODO(b/26783907): The Sort HLO is not implemented on CPU or GPU.
-    if self.device in ["XLA_CPU", "XLA_GPU"]:
+    if self.device in ["XLA_CPU", "XLA_GPU", "XLA_AMDGPU"]:
       return
 
     supported_types = set(
@@ -91,7 +91,7 @@ class XlaSortOpTest(xla_test.XLATestCase):
   def testTopKZeros(self):
     """Tests that positive and negative zeros sort correctly."""
     # TODO(b/26783907): The Sort HLO is not implemented on CPU or GPU.
-    if self.device in ["XLA_CPU", "XLA_GPU"]:
+    if self.device in ["XLA_CPU", "XLA_GPU", "XLA_AMDGPU"]:
       return
 
     # Only bfloat16 is implemented.
@@ -113,7 +113,7 @@ class XlaSortOpTest(xla_test.XLATestCase):
   def testTopKInfinities(self):
     """Tests that positive and negative infinity sort correctly."""
     # TODO(b/26783907): The Sort HLO is not implemented on CPU or GPU.
-    if self.device in ["XLA_CPU", "XLA_GPU"]:
+    if self.device in ["XLA_CPU", "XLA_GPU", "XLA_AMDGPU"]:
       return
 
     # Only bfloat16 is implemented.

--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -144,7 +144,7 @@ cc_library(
     ] + if_cuda_is_configured([
         "xla_gpu_backend.cc",
     ]) + if_rocm_is_configured([
-        "xla_gpu_backend.cc",
+        "xla_amdgpu_backend.cc",
     ]),
     hdrs = [
         "const_analysis.h",

--- a/tensorflow/compiler/tf2xla/kernels/index_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/index_ops.cc
@@ -80,6 +80,10 @@ REGISTER_XLA_OP(Name("ArgMax")
                     .Device(DEVICE_GPU_XLA_JIT)
                     .CompileTimeConstInput("dimension"),
                 XlaArgMaxOp);
+REGISTER_XLA_OP(Name("ArgMax")
+                    .Device(DEVICE_AMDGPU_XLA_JIT)
+                    .CompileTimeConstInput("dimension"),
+                XlaArgMaxOp);
 
 namespace {
 

--- a/tensorflow/compiler/tf2xla/xla_amdgpu_backend.cc
+++ b/tensorflow/compiler/tf2xla/xla_amdgpu_backend.cc
@@ -1,0 +1,49 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2xla/legacy_flags/backend_registration_flags.h"
+#include "tensorflow/compiler/tf2xla/tf2xla_util.h"
+#include "tensorflow/compiler/tf2xla/xla_op_registry.h"
+#include "tensorflow/core/framework/kernel_def.pb.h"
+
+namespace tensorflow {
+
+bool AMDGpuOpFilter(KernelDef* kdef) {
+  // TODO(b/31361304): The GPU backend does not parallelize PRNG ops, leading to
+  // slow code.
+  legacy_flags::BackendRegistrationFlags* flags =
+      legacy_flags::GetBackendRegistrationFlags();
+  VLOG(2) << "flags->tf_enable_prng_ops_gpu: " << flags->tf_enable_prng_ops_gpu;
+  if (!flags->tf_enable_prng_ops_gpu &&
+      (kdef->op() == "RandomStandardNormal" || kdef->op() == "RandomUniform" ||
+       kdef->op() == "RandomUniformInt" || kdef->op() == "TruncatedNormal")) {
+    return false;
+  }
+  // TODO(b/26783907): The GPU backend currently does not implement sort.
+  if (kdef->op() == "XlaSort" || kdef->op() == "TopKV2") {
+    return false;
+  }
+  if (kdef->op() == "Const") {
+    AddDtypeToKernalDefConstraint("dtype", DT_STRING, kdef);
+  }
+  if (kdef->op() == "Assert") {
+    AddDtypeToKernalDefConstraint("T", DT_STRING, kdef);
+  }
+  return true;
+}
+
+REGISTER_XLA_BACKEND(DEVICE_AMDGPU_XLA_JIT, kAMDGpuAllTypes, AMDGpuOpFilter);
+
+}  // namespace tensorflow

--- a/tensorflow/compiler/tf2xla/xla_compiler_test.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler_test.cc
@@ -163,6 +163,8 @@ REGISTER_XLA_OP(Name("DummyDuplicateOp").Device(DEVICE_CPU_XLA_JIT),
                 DummyDuplicateOp);
 REGISTER_XLA_OP(Name("DummyDuplicateOp").Device(DEVICE_GPU_XLA_JIT),
                 DummyDuplicateOp);
+REGISTER_XLA_OP(Name("DummyDuplicateOp").Device(DEVICE_AMDGPU_XLA_JIT),
+                DummyDuplicateOp);
 
 // Tests compilation and execution of an empty graph.
 TEST_F(XlaCompilerTest, EmptyReturnValues) {

--- a/tensorflow/compiler/tf2xla/xla_op_registry.h
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.h
@@ -41,9 +41,11 @@ namespace tensorflow {
 
 extern const char* const DEVICE_CPU_XLA_JIT;  // "CPU_XLA_JIT"
 extern const char* const DEVICE_GPU_XLA_JIT;  // "GPU_XLA_JIT"
+extern const char* const DEVICE_AMDGPU_XLA_JIT;  // "AMDGPU_XLA_JIT"
 
 extern const char* const DEVICE_XLA_CPU;
 extern const char* const DEVICE_XLA_GPU;
+extern const char* const DEVICE_XLA_AMDGPU;
 
 constexpr std::array<DataType, 4> kFloatTypes = {
     {DT_HALF, DT_FLOAT, DT_DOUBLE, DT_BFLOAT16}};
@@ -58,6 +60,10 @@ constexpr std::array<DataType, 9> kCpuAllTypes = {
 constexpr std::array<DataType, 10> kGpuAllTypes = {
     {DT_UINT32, DT_UINT64, DT_INT32, DT_INT64, DT_HALF, DT_FLOAT, DT_DOUBLE,
      DT_COMPLEX64, DT_BOOL, DT_BFLOAT16}};
+
+constexpr std::array<DataType, 8> kAMDGpuAllTypes = {
+    {DT_UINT32, DT_UINT64, DT_INT32, DT_INT64, DT_HALF, DT_FLOAT, DT_DOUBLE,
+     DT_BOOL}};
 
 // Class that manages registrations of operators and devices for the XLA JIT.
 // Not thread-safe.


### PR DESCRIPTION
Per discussion in upstream PR: https://github.com/tensorflow/tensorflow/pull/20845 , register a new device class XLA_AMDGPU. Submit to `develop-upstream` branch first. Will revise the upstream PR after that.