### PR TITLE
Add r1.8 release info

### DIFF
--- a/README.ROCm.md
+++ b/README.ROCm.md
@@ -23,7 +23,7 @@ For details on installation and usage, see these links:
 
 ## Known Issues / Workarounds
 
-### tensorflow/benchmarks workaround for TF v1.3
+### tensorflow/benchmarks workaround for TF v1.8
 Since our current port of TF supports v1.3, we can't use some of the newest commits in `tensorflow/benchmarks`. The RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
 
 ```

--- a/README.ROCm.md
+++ b/README.ROCm.md
@@ -24,7 +24,7 @@ For details on installation and usage, see these links:
 ## Known Issues / Workarounds
 
 ### tensorflow/benchmarks workaround for TF v1.8
-Since our current port of TF supports v1.8, we can't use some of the newest commits in `tensorflow/benchmarks`. The RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
+Since our current port of TF supports v1.8, we can't use some of the newest commits in `tensorflow/benchmarks`. RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
 
 ```
 git checkout -b may22 ddb23306fdc60fefe620e6ce633bcd645561cb0d && \

--- a/README.ROCm.md
+++ b/README.ROCm.md
@@ -24,7 +24,7 @@ For details on installation and usage, see these links:
 ## Known Issues / Workarounds
 
 ### tensorflow/benchmarks workaround for TF v1.8
-Since our current port of TF supports v1.3, we can't use some of the newest commits in `tensorflow/benchmarks`. The RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
+Since our current port of TF supports v1.8, we can't use some of the newest commits in `tensorflow/benchmarks`. The RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
 
 ```
 git checkout -b may22 ddb23306fdc60fefe620e6ce633bcd645561cb0d && \

--- a/README.ROCm.md
+++ b/README.ROCm.md
@@ -8,7 +8,7 @@ This repository hosts the port of [Tensorflow](https://github.com/tensorflow/ten
 
 For further background information on ROCm, refer [here](https://github.com/RadeonOpenCompute/ROCm/blob/master/README.md).
 
-The project is derived from TensorFlow 1.3.0 and has been verified to work with the latest ROCm 1.7.1 release.
+The project is derived from TensorFlow 1.8.0 and has been verified to work with the latest ROCm 1.8.2 release.
 
 For details on installation and usage, see these links:
 * [Basic installation](rocm_docs/tensorflow-install-basic.md)
@@ -23,31 +23,10 @@ For details on installation and usage, see these links:
 
 ## Known Issues / Workarounds
 
-### X freezes under load
-ROCm 1.7.1 a kernel parameter `noretry` has been set to 1 to improve overall system performance. However it has been proven to bring instability to graphics driver shipped with Ubuntu. This is an ongoing issue and we are looking into it.
-
-Before that, please try apply this change by changing `noretry` bit to 0.
-
-```
-echo 0 | sudo tee /sys/module/amdkfd/parameters/noretry
-```
-
-Files under `/sys` won't be preserved after reboot so you'll need to do it every time.
-
-One way to keep `noretry=0` is to change `/etc/modprobe.d/amdkfd.conf` and make it be:
-
-```
-options amdkfd noretry=0
-```
-
-Once it's done, run `sudo update-initramfs -u`. Reboot and verify `/sys/module/amdkfd/parameters/noretry` stays as 0.
-
-For more information please check this [issue report](https://github.com/ROCmSoftwarePlatform/tensorflow/issues/13)
-
 ### tensorflow/benchmarks workaround for TF v1.3
-Since our current port of TF supports v1.3, we can't use some of the newest commits in `tensorflow/benchmarks`.  One specific error you could observe is a `ImportError: cannot import name batching`.  "Batching" was introduced in this [commit](https://github.com/tensorflow/benchmarks/commit/82dd0539c76afa8491e50d8f796e686b4d97b988). Also RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
+Since our current port of TF supports v1.3, we can't use some of the newest commits in `tensorflow/benchmarks`. The RCCL, a ROCm version of NCCL, is under implementation. Therefore we have to drop back to an earlier point in the commit history, and disable NCCL.
 
 ```
-git checkout -b sep7 6a33b4a4b5bda950bb7e45faf13120115cbfdb2f
+git checkout -b may22 ddb23306fdc60fefe620e6ce633bcd645561cb0d && \
 sed -i 's|from tensorflow.contrib import nccl|#from tensorflow.contrib import nccl|g' ./scripts/tf_cnn_benchmarks/variable_mgr.py
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Keep up to date with release announcements and security updates by
 subscribing to
 [announce@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/announce).
 
+** Tensorflow ROCm port **
+This project is based on TensorFlow 1.8.0. It has been verified to work with the latest ROCm1.8.2 release. Please follow the instructions [here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md) to set up your ROCm stack.
+
+A docker container: **rocm/tensorflow:rocm1.7.1(https://hub.docker.com/r/rocm/tensorflow/)** is readily available to be used.
+
+The Wheels:
+- Python 2: http://repo.radeon.com/rocm/misc/tensorflow/tensorflow-1.8.0-cp27-cp27mu-manylinux1_x86_64.whl
+- Python 3: http://repo.radeon.com/rocm/misc/tensorflow/tensorflow-1.8.0-cp35-cp35m-manylinux1_x86_64.whl
+
+For details on Tensorflow ROCm port, please take a look at the [ROCm-specific README file](README.ROCm.md).
+
 ## Installation
 *See [Installing TensorFlow](https://www.tensorflow.org/get_started/os_setup.html) for instructions on how to install our release binaries or how to build from source.*
 

--- a/rocm_docs/tensorflow-install-basic.md
+++ b/rocm_docs/tensorflow-install-basic.md
@@ -110,17 +110,17 @@ pip list | grep tensorflow && pip uninstall -y tensorflow
 For Python 2-based systems:
 ```
 # wget the TensorFlow ROCm port whl package
-cd ~/ && wget http://repo.radeon.com/rocm/misc/tensorflow/tensorflow-1.3.0-cp27-cp27mu-linux_x86_64.whl
+cd ~/ && wget http://repo.radeon.com/rocm/misc/tensorflow/tensorflow-1.8.0-cp27-cp27mu-manylinux1_x86_64.whl
 
 # Pip install the whl package 
-cd ~ && sudo pip install tensorflow-1.3.0-cp27-cp27mu-linux_x86_64.whl && rm tensorflow-1.3.0-cp27-cp27mu-linux_x86_64.whl
+cd ~ && sudo pip install tensorflow-1.8.0-cp27-cp27mu-manylinux1_x86_64.whl && rm tensorflow-1.8.0-cp27-cp27mu-manylinux1_x86_64.whl
 ```
 
 For Python 3-based systems:
 ```
 # wget the TensorFlow ROCm port whl package
-cd ~/ && wget http://repo.radeon.com/rocm/misc/tensorflow/tensorflow-1.3.0-cp35-cp35m-linux_x86_64.whl
+cd ~/ && wget http://repo.radeon.com/rocm/misc/tensorflow/tensorflow-1.8.0-cp35-cp35m-manylinux1_x86_64.whl
 
 # Pip3 install the whl package 
-cd ~ && sudo pip3 install tensorflow-1.3.0-cp35-cp35m-linux_x86_64.whl && rm tensorflow-1.3.0-cp35-cp35m-linux_x86_64.whl
+cd ~ && sudo pip3 install tensorflow-1.8.0-cp35-cp35m-manylinux1_x86_64.whl && rm tensorflow-1.8.0-cp35-cp35m-manylinux1_x86_64.whl
 ```

--- a/rocm_docs/tensorflow-quickstart.md
+++ b/rocm_docs/tensorflow-quickstart.md
@@ -171,10 +171,10 @@ cd $HOME
 git clone https://github.com/tensorflow/benchmarks.git
 cd benchmarks
 
-# Temporary workaround to allow support for TF 1.3 without NCCL
-git checkout -b oct23 f5d85aef2851881001130b28385795bc4c59fa38
+# Temporary workaround to allow support for TF 1.8 without NCCL
+
+git checkout -b may22 ddb23306fdc60fefe620e6ce633bcd645561cb0d && \
 sed -i 's|from tensorflow.contrib import nccl|#from tensorflow.contrib import nccl|g' ./scripts/tf_cnn_benchmarks/variable_mgr.py
-sed -i 's|from tensorflow.contrib.all_reduce.python import all_reduce|#from tensorflow.contrib.all_reduce.python import all_reduce|g' ./scripts/tf_cnn_benchmarks/variable_mgr.py
 
 # Run the training benchmark (e.g. ResNet-50)
 python ./scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py --model=resnet50 --num_gpus=1


### PR DESCRIPTION
This PR updates the document to reflect the TF1.8 release on ROCm1.8.2.