### PR TITLE
Revert to use march=native for host_copt.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -486,7 +486,7 @@ def set_cc_opt_flags(environ_cp):
   elif is_windows():
     default_cc_opt_flags = '/arch:AVX'
   else:
-    default_cc_opt_flags = '-march=haswell'
+    default_cc_opt_flags = '-march=haswell' # ROCm supports Haswell or later architecture
   question = ('Please specify optimization flags to use during compilation when'
               ' bazel option "--config=opt" is specified [Default is %s]: '
              ) % default_cc_opt_flags
@@ -496,7 +496,7 @@ def set_cc_opt_flags(environ_cp):
     write_to_bazelrc('build:opt --copt=%s' % opt)
   # It should be safe on the same build host.
   if not is_ppc64le() and not is_windows():
-    write_to_bazelrc('build:opt --host_copt=-march=haswell')
+    write_to_bazelrc('build:opt --host_copt=-march=native')
   write_to_bazelrc('build:opt --define with_default_optimizations=true')
 
 def set_tf_cuda_clang(environ_cp):


### PR DESCRIPTION
Even though ROCm supports Haswell or later architecture,  the host machine architecture of building environment does not necessary to be same(e.g. build `tensorflow-upstream` on CI build server or Docker). So this PR revert to use `-march=native` for `host_copt` architecture. It should solve #80
