### PR TITLE
updating cuda_py_test to gpu_py_test to fix broken CI build

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/BUILD
@@ -235,7 +235,7 @@ gpu_py_test(
     ],
 )
 
-cuda_py_test(
+gpu_py_test(
     name = "linear_operator_zeros_test",
     size = "medium",
     srcs = ["linear_operator_zeros_test.py"],


### PR DESCRIPTION
The following is error that is fixed by this PR

(from CI run #257)
```
ERROR: /workspace/tensorflow/python/kernel_tests/linalg/BUILD:238:1: name 'cuda_py_test' is not defined (did you mean 'gpu_py_test'?)
ERROR: package contains errors: tensorflow/python/kernel_tests/linalg
```