### PR TITLE
Unit test fixes - 180803

### DIFF
--- a/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
+++ b/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
@@ -3152,6 +3152,14 @@ class TupleTest(test.TestCase):
 class AssertTest(test.TestCase):
 
   def testGuardedAssertDoesNotCopyWhenTrue(self):
+
+    if test.is_built_with_rocm() :
+      # This test depends on the presence of nodes with names "MEMCPYDtoH"
+      # That name assignment currently only happens for tensorflow build with CUDA, 
+      # ROCm support for the same is still in the process of being implemented
+      # Disabling this test for ROCm for the time being
+      return
+    
     with self.test_session(use_gpu=True) as sess:
       with ops.device(test.gpu_device_name()):
         value = constant_op.constant(1.0)

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -51,7 +51,6 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/keras:training_gpu_test \
     -//tensorflow/python/keras:model_subclassing_test \
     -//tensorflow/python/kernel_tests:atrous_conv2d_test \
-    -//tensorflow/python/kernel_tests:control_flow_ops_py_test \
     -//tensorflow/python/kernel_tests:conv1d_test \
     -//tensorflow/python/kernel_tests:conv2d_backprop_filter_grad_test \
     -//tensorflow/python/kernel_tests:conv2d_transpose_test \


### PR DESCRIPTION
Updates to the following tests to disable functionality not supported in `ROCm`

1. `//tensorflow/python/kernel_tests:control_flow_ops_py_test`
2. `//tensorflow/python:timeline_test`

Both tests have a subtest that test functionlality (tracing information for nodes with specific names  `stream:all`, `MEMCPYDtoH`) that is currently implemented only in `CUDA`  (see file `./tensorflow/core/platform/default/device_tracer.cc`)

Only `//tensorflow/python/kernel_tests:control_flow_ops_py_test` is being removed from the whitelist. 

The `//tensorflow/python:timeline_test` is flaky in nature (it fails every now and then depending on how nodes are placed...same flakiness also seen on `CUDA`). So not removing it from the whitelist for the time being.