### PR TITLE
adding *clang/8.0.0/include to the list of include dirs

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -168,6 +168,9 @@ def _rocm_include_path(repository_ctx, rocm_config):
   inc_dirs.append("/opt/rocm/hcc/include")
   inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/7.0.0/include/")
   inc_dirs.append("/opt/rocm/hcc/lib/clang/7.0.0/include")
+  # Newer hcc builds use/are based off of clang 8.0.0.
+  inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/8.0.0/include/")
+  inc_dirs.append("/opt/rocm/hcc/lib/clang/8.0.0/include")
 
   inc_entries = []
   for inc_dir in inc_dirs:


### PR DESCRIPTION
hcc seems to have been updated to use clan version 8.0.0 
(as of the following commit)

https://github.com/RadeonOpenCompute/llvm/commit/57bb7d2d7058512fff60f58c343aad15eae64afb#diff-af3b638bc2a3e6c650974192a53c7291

So hcc builds newer than this commit will have the "clang/8.0.0/include" directory.
Updating the ROCm configuration in the TF build to account for the same.