### PR TITLE
Adding support for ROCm-targeted pip builds

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip.sh
+++ b/tensorflow/tools/ci_build/builds/pip.sh
@@ -131,8 +131,8 @@ echo "Using Bazel flags: ${BAZEL_FLAGS}"
 
 PIP_BUILD_TARGET="//tensorflow/tools/pip_package:build_pip_package"
 GPU_FLAG=""
+ROCM_FLAG=""
 if [[ ${CONTAINER_TYPE} == "cpu" ]] || \
-   [[ ${CONTAINER_TYPE} == "rocm" ]] || \
    [[ ${CONTAINER_TYPE} == "debian.jessie.cpu" ]]; then
   bazel build ${BAZEL_FLAGS} ${PIP_BUILD_TARGET} || \
       die "Build failed."
@@ -140,6 +140,10 @@ elif [[ ${CONTAINER_TYPE} == "gpu" ]]; then
   bazel build ${BAZEL_FLAGS} ${PIP_BUILD_TARGET} || \
       die "Build failed."
   GPU_FLAG="--gpu"
+elif [[ ${CONTAINER_TYPE} == "rocm" ]]; then
+  bazel build ${BAZEL_FLAGS} ${PIP_BUILD_TARGET} || \
+      die "Build failed."
+  ROCM_FLAG="--rocm"
 else
   die "Unrecognized container type: \"${CONTAINER_TYPE}\""
 fi
@@ -193,7 +197,7 @@ fi
 PIP_WHL_DIR="${PIP_TEST_ROOT}/whl"
 PIP_WHL_DIR=$(realpath ${PIP_WHL_DIR})  # Get absolute path
 rm -rf ${PIP_WHL_DIR} && mkdir -p ${PIP_WHL_DIR}
-bazel-bin/tensorflow/tools/pip_package/build_pip_package ${PIP_WHL_DIR} ${GPU_FLAG} ${NIGHTLY_FLAG} || \
+bazel-bin/tensorflow/tools/pip_package/build_pip_package ${PIP_WHL_DIR} ${GPU_FLAG} ${ROCM_FLAG} ${NIGHTLY_FLAG} || \
     die "build_pip_package FAILED"
 
 WHL_PATH=$(ls ${PIP_WHL_DIR}/${PROJECT_NAME}*.whl)
@@ -391,7 +395,7 @@ do_virtualenv_pip_test() {
     return ${SKIP_RETURN_CODE}
   else
     # Call run_pip_tests.sh to perform test-on-install
-    "${SCRIPT_DIR}/run_pip_tests.sh" --virtualenv ${GPU_FLAG} ${MAC_FLAG}
+    "${SCRIPT_DIR}/run_pip_tests.sh" --virtualenv ${GPU_FLAG} ${ROCM_FLAG} ${MAC_FLAG}
     if [[ $? != 0 ]]; then
       echo "PIP tests-on-install FAILED"
       return 1
@@ -411,7 +415,7 @@ do_virtualenv_oss_serial_pip_test() {
   else
     # Call run_pip_tests.sh to perform test-on-install
     "${SCRIPT_DIR}/run_pip_tests.sh" \
-      --virtualenv ${GPU_FLAG} ${MAC_FLAG} --oss_serial
+      --virtualenv ${GPU_FLAG} ${ROCM_FLAG} ${MAC_FLAG} --oss_serial
     if [[ $? != 0 ]]; then
       echo "PIP tests-on-install (oss_serial) FAILED"
       return 1
@@ -424,7 +428,7 @@ do_virtualenv_oss_serial_pip_test() {
 ################################################################################
 do_test_user_ops() {
   if [[ "${DO_TEST_USER_OPS}" == "1" ]]; then
-    "${SCRIPT_DIR}/test_user_ops.sh" --virtualenv ${GPU_FLAG}
+    "${SCRIPT_DIR}/test_user_ops.sh" --virtualenv ${GPU_FLAG} ${ROCM_FLAG}
     if [[ $? != 0 ]]; then
       echo "PIP user-op tests-on-install FAILED"
       return 1

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -52,6 +52,7 @@ function main() {
 
   PKG_NAME_FLAG=""
   GPU_BUILD=0
+  ROCM_BUILD=0
   NIGHTLY_BUILD=0
   while true; do
     if [[ "$1" == "--nightly_flag" ]]; then
@@ -60,6 +61,8 @@ function main() {
       GPU_BUILD=1
     elif [[ "$1" == "--gpudirect" ]]; then
       PKG_NAME_FLAG="--project_name tensorflow_gpudirect"
+    elif [[ "$1" == "--rocm" ]]; then
+      ROCM_BUILD=1
     fi
     shift
 
@@ -70,10 +73,14 @@ function main() {
 
   if [[ ${NIGHTLY_BUILD} == "1" && ${GPU_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tf_nightly_gpu"
+  elif [[ ${NIGHTLY_BUILD} == "1" && ${ROCM_BUILD} == "1" ]]; then
+    PKG_NAME_FLAG="--project_name tf_nightly_rocm"
   elif [[ ${NIGHTLY_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tf_nightly"
   elif [[ ${GPU_BUILD} == "1" ]]; then
     PKG_NAME_FLAG="--project_name tensorflow_gpu"
+  elif [[ ${ROCM_BUILD} == "1" ]]; then
+    PKG_NAME_FLAG="--project_name tensorflow_rocm"
   fi
 
   echo $(date) : "=== Using tmpdir: ${TMPDIR}"


### PR DESCRIPTION
Adding support for ROCm-targeted pip builds -- the metadata has to be updated to produce `tensorflow-rocm` packages.  This added functionally is the same as recent commits to `develop-upstream`; however, there were challenges with cherry-picking those commits into this release branch.  