### PR TITLE
Add code to print internal TF runtime profile

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -65,6 +65,7 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/device_name_utils.h"
 #include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/platform/env_time.h"
 
 namespace tensorflow {
 
@@ -490,6 +491,7 @@ Status DirectSession::RunInternal(int64 step_id, const RunOptions& run_options,
   args.tensor_store = &run_state.tensor_store;
   args.step_container = &run_state.step_container;
   args.sync_on_finish = sync_on_finish_;
+  args.print_this_run = run_options.print_this_run();
 
   const bool do_trace = (run_options.trace_level() > RunOptions::NO_TRACE);
 

--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -61,6 +61,7 @@ limitations under the License.
 #include "tensorflow/core/platform/tracing.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/tensor_slice_reader_cache.h"
+#include "tensorflow/core/platform/env_time.h"
 
 namespace tensorflow {
 namespace {
@@ -1312,6 +1313,7 @@ class ExecutorState {
   CancellationManager* cancellation_manager_;
   Executor::Args::Runner runner_;
   bool sync_on_finish_;
+  bool print_this_run_;
 
   // Owned.
 
@@ -1432,6 +1434,7 @@ ExecutorState::ExecutorState(const Executor::Args& args, ExecutorImpl* impl)
       cancellation_manager_(args.cancellation_manager),
       runner_(args.runner),
       sync_on_finish_(args.sync_on_finish),
+      print_this_run_(args.print_this_run),
       num_outstanding_ops_(0) {
   // We start the entire execution in iteration 0 of the root frame
   // so let us create the root frame and the state for iteration 0.
@@ -1651,6 +1654,7 @@ void ExecutorState::Process(TaggedNode tagged_node, int64 scheduled_usec) {
   NodeExecStatsWrapper* stats = nullptr;
   EntryVector outputs;
   bool completed = false;
+  static EnvTime* env_time = tensorflow::EnvTime::Default();
   inline_ready.push_back(tagged_node);
   while (!inline_ready.empty()) {
     tagged_node = inline_ready.front();
@@ -1660,6 +1664,11 @@ void ExecutorState::Process(TaggedNode tagged_node, int64 scheduled_usec) {
     const int64 input_iter = tagged_node.input_iter;
     const int id = node->id();
     const NodeItem& item = *gview.node(id);
+    uint64_t ts = 0;
+
+    if (print_this_run_) {
+      ts = env_time->NowMicros();
+    }
 
     // TODO(misard) Replace with a finer-grain enabling flag once we
     // add better optional debugging support.
@@ -1827,6 +1836,14 @@ void ExecutorState::Process(TaggedNode tagged_node, int64 scheduled_usec) {
       }
       // Postprocess.
       completed = NodeDone(s, item.node, ready, stats, &inline_ready);
+    }
+    if (print_this_run_) {
+      uint64_t time = env_time->NowMicros() - ts;
+      std::stringstream ss;
+      ss << "step " << step_id_ <<
+        ", op " << (*node).def().op() <<
+        ", device " << device->name();
+      env_time->PrintTime("process", ts, time, true, ss.str());
     }
   }  // while !inline_ready.empty()
 
@@ -2371,6 +2388,10 @@ void ExecutorState::DumpState() {
 }
 
 void ExecutorState::Finish() {
+  static EnvTime* env_time = tensorflow::EnvTime::Default();
+  uint64_t start;
+  if (print_this_run_)
+    start = env_time->NowMicros();
   mu_.lock();
   auto status = status_;
   auto done_cb = std::move(done_cb_);
@@ -2382,6 +2403,10 @@ void ExecutorState::Finish() {
     // methods have completed, this ensures that control is not returned to
     // the user until the step (and its side-effects) has actually completed.
     status = impl_->params_.device->Sync();
+    if (print_this_run_) {
+      uint64_t time = env_time->NowMicros() - start;
+      env_time->PrintTime("finish", start, time, true);
+    }
   }
   delete this;
   CHECK(done_cb != nullptr);

--- a/tensorflow/core/common_runtime/executor.h
+++ b/tensorflow/core/common_runtime/executor.h
@@ -93,6 +93,7 @@ class Executor {
 
     // If true, calls Sync() on the device.
     bool sync_on_finish = false;
+    bool print_this_run = false;
 
     typedef std::function<void()> Closure;
     typedef std::function<void(Closure)> Runner;

--- a/tensorflow/core/platform/env_time.h
+++ b/tensorflow/core/platform/env_time.h
@@ -18,6 +18,9 @@ limitations under the License.
 #include <stdint.h>
 
 #include "tensorflow/core/platform/types.h"
+#include <thread>
+#include <sstream>
+#include <iostream>
 
 namespace tensorflow {
 
@@ -39,6 +42,26 @@ class EnvTime {
 
   /// \brief Returns the number of seconds since the Unix epoch.
   virtual uint64 NowSeconds() { return NowMicros() / 1000000L; }
+
+  virtual void PrintTime(
+      std::string prof_name,
+      uint64 ts,
+      uint64 time,
+      bool print_tid = false,
+      std::string extra = "") {
+    std::stringstream ss;
+    ss << "tf-profile, prof_name " << prof_name;
+    if (print_tid) {
+      std::thread::id id = std::this_thread::get_id();
+      ss << ", id " << id;
+    }
+    ss << ", ts " << ts << ", time " << time;
+    if (extra != "") {
+      ss << ", " << extra;
+    }
+    ss << std::endl;
+    std::cerr << ss.str();
+  }
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -450,6 +450,8 @@ message RunOptions {
 
   Experimental experimental = 8;
 
+  bool print_this_run = 9;
+
   reserved 4;
 }
 


### PR DESCRIPTION
A prototype for printing TF runtime events.  Changes are as follows:
1) Add print_this_run to RunOptions to enable profiling for a specific
   run.  This is similar to TraceLevel.
2) Add a print function, namely "PrintTime", to the EnvTime class to
   print a profile to std::cerr.
3) Profile ExecutorState::Process and ExecutorState::Finish using
   EnvTime.
   - A ExecutorState::Process profile contains an execution info of
     synchronous or asynchronous operator in TF
   - A ExecutorState::Finish profile contains a synchronization info
     of an executor after it completely executes all operators

Note: This PR is per Jack's request.