### PR TITLE
removing MIOPen build from CI Dockerfile.rocm

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -29,18 +29,6 @@ RUN cd $HOME/hcc && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release 
 RUN cd $HOME && git clone -b roc-1.8.x-pr457-altfix https://github.com/deven-amd/HIP.git
 RUN cd $HOME/HIP && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i *.deb
 
-# Workaround: build MIOpen from source using fork that folds the public 1.4.2 release with the fix for issue 1061 
-RUN cd $HOME && git clone -b pr1061-fix https://github.com/deven-amd/MIOpen.git miopen
-RUN cd $HOME/miopen && sudo cmake -P install_deps.cmake
-RUN cd $HOME/miopen && mkdir build && cd build && \
-    CXX=/opt/rocm/bin/hcc cmake \
-    -DMIOPEN_BACKEND=HIP \
-    -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" \
-    -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" \
-    -DCMAKE_BUILD_TYPE=Release \
-    .. && \
-    sudo make package -j$(nproc)
-
 ###########################
 # Stage 2 : do the TF build
 ###########################
@@ -117,11 +105,6 @@ RUN cd $HOME/pkgs/hcc && dpkg -i *.deb
 RUN mkdir -p $HOME/pkgs/HIP
 COPY --from=tool_builder /home/rocm-user/HIP/build/*.deb $HOME/pkgs/HIP/
 RUN cd $HOME/pkgs/HIP && dpkg -i *.deb
-
-# COPY and install the MIOpen package built in the previous stage
-RUN mkdir -p $HOME/pkgs/miopen
-COPY --from=tool_builder /home/rocm-user/miopen/build/*.deb $HOME/pkgs/miopen/
-RUN cd $HOME/pkgs/miopen && dpkg -i *.deb
 
 ENV HCC_HOME=$ROCM_PATH/hcc
 ENV HIP_PATH=$ROCM_PATH/hip

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -64,4 +64,17 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/profiler:profile_context_test \
     -//tensorflow/python:layers_normalization_test \
     -//tensorflow/python:nn_fused_batchnorm_test \
+    -//tensorflow/python/keras:normalization_test \
+    -//tensorflow/python/keras:training_gpu_test \
+    -//tensorflow/python/kernel_tests:atrous_conv2d_test \
+    -//tensorflow/python/kernel_tests:conv2d_transpose_test \
+    -//tensorflow/python/kernel_tests:lrn_op_test \
+    -//tensorflow/python/kernel_tests:neon_depthwise_conv_op_test \
+    -//tensorflow/python/ops/parallel_for:gradients_test \
+    -//tensorflow/python/profiler:profiler_test \
+    -//tensorflow/python:cost_analyzer_test \
+    -//tensorflow/python:image_ops_test \
+    -//tensorflow/python:layout_optimizer_test \
+    -//tensorflow/python:memory_optimizer_test \
     -//tensorflow/python:timeline_test
+


### PR DESCRIPTION
MIOpen build process seems to be temporarily broken (because bzip2 site is down?)

https://github.com/AMDComputeLibraries/MLOpen/issues/1066

So 
1. Removing MIOpen build from the CI Dockerfile and 
2. adding back the tests that the build fixes, to the whitelist

to allow us to make progress on other PRs.