### PR TITLE
Fix build failure for reduction_gpu_kernels.cu.h

### DIFF
--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -151,6 +151,8 @@ struct DividesBy<std::complex<double>> {
   }
 };
 
+#endif
+
 template <>
 struct DividesBy<float, Eigen::half> {
   float divisor;
@@ -161,7 +163,6 @@ struct DividesBy<float, Eigen::half> {
     return Eigen::half(x / divisor);
   }
 };
-#endif
 
 struct HalfToFloat {
   __host__ __device__ float operator()(const Eigen::half& x) const {


### PR DESCRIPTION
In file included from tensorflow/core/kernels/reduction_ops_half_mean_sum.cu.cc:20:
./tensorflow/core/kernels/reduction_gpu_kernels.cu.h:118:66: error: no viable conversion from returned value of type 'float' to function return type 'Eigen::half'
  __host__ __device__ outT operator()(const T& x) const { return x / divisor; }