### PR TITLE
Using MIOpen with the workaround for issue 1061 - take 2

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -48,8 +48,7 @@ RUN cd $HOME/MIOpen && mkdir build && cd build && \
     -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" \
     -DHALF_INCLUDE_DIR=$HOME/half/include \
     -DCMAKE_BUILD_TYPE=Release \
-    ..
-RUN sudo make package -j$(nproc)
+    .. && sudo make package -j$(nproc)
 
 
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -18,7 +18,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV HOME /home/rocm-user
 
 # install packages needed for this image
-RUN sudo apt-get update && sudo apt-get install -y python rpm git mercurial libxml2 libxml2-dev libssl-dev
+RUN sudo apt-get update && sudo apt-get install -y python rpm git mercurial libxml2 libxml2-dev 
 
 # Workaround : build HCC from source using the commit that is known to have fix for issue812
 RUN cd $HOME && git clone --recursive https://github.com/RadeonOpenCompute/hcc.git
@@ -28,6 +28,26 @@ RUN cd $HOME/hcc && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release 
 # Workaround: build HIP from source using fork that holds roc-1.8.x with the alternate fix for HIP PR 457
 RUN cd $HOME && git clone -b roc-1.8.x-pr457-altfix https://github.com/deven-amd/HIP.git
 RUN cd $HOME/HIP && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i *.deb
+
+# Workaround : build MIOpen from source using fork of the public repo with the temporary fix for issue #1061 ($HOME env not set)
+RUN apt-get install -y wget unzip libssl-dev libboost-dev libboost-system-dev libboost-filesystem-dev
+RUN cd $HOME && git clone https://github.com/RadeonOpenCompute/rocm-cmake.git
+RUN cd $HOME/rocm-cmake && mkdir -p build && cd build && cmake .. && make package -j$(nproc) && dpkg -i ./rocm-cmake*.deb
+RUN cd $HOME && git clone https://github.com/ROCmSoftwarePlatform/MIOpenGEMM.git
+RUN cd $HOME/MIOpenGEMM && mkdir -p build && cd build && cmake .. && make package -j$(nproc) && dpkg -i ./miopengemm*.deb
+RUN cd $HOME && mkdir half && cd half && wget https://downloads.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip && unzip *.zip
+RUN cd $HOME && git -b pr1061-fix clone https://github.com/deven-amd/MIOpen.git
+RUN cd $HOME/MIOpen && rm -rf build && mkdir build && cd build && \
+  CXX=/opt/rocm/bin/hcc cmake \
+    -DMIOPEN_BACKEND=HIP \
+    -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" \
+    -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" \
+    -DHALF_INCLUDE_DIR=$HOME/half/include \
+    -DCMAKE_BUILD_TYPE=Debug \
+    ..
+RUN make package -j$(nproc)
+
+
 
 ###########################
 # Stage 2 : do the TF build
@@ -105,6 +125,11 @@ RUN cd $HOME/pkgs/hcc && dpkg -i *.deb
 RUN mkdir -p $HOME/pkgs/HIP
 COPY --from=tool_builder /home/rocm-user/HIP/build/*.deb $HOME/pkgs/HIP/
 RUN cd $HOME/pkgs/HIP && dpkg -i *.deb
+
+# COPY and install the MIOpen package built in the previous stage
+RUN mkdir -p $HOME/pkgs/MIOpen
+COPY --from=tool_builder /home/rocm-user/MIOpen/build/*.deb $HOME/pkgs/MIOpen/
+RUN cd $HOME/pkgs/MIOpen && dpkg -i *.deb
 
 ENV HCC_HOME=$ROCM_PATH/hcc
 ENV HIP_PATH=$ROCM_PATH/hip

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -30,22 +30,26 @@ RUN cd $HOME && git clone -b roc-1.8.x-pr457-altfix https://github.com/deven-amd
 RUN cd $HOME/HIP && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i *.deb
 
 # Workaround : build MIOpen from source using fork of the public repo with the temporary fix for issue #1061 ($HOME env not set)
-RUN apt-get install -y wget unzip libssl-dev libboost-dev libboost-system-dev libboost-filesystem-dev
+RUN sudo apt-get install -y wget unzip libssl-dev libboost-dev libboost-system-dev libboost-filesystem-dev
+
 RUN cd $HOME && git clone https://github.com/RadeonOpenCompute/rocm-cmake.git
-RUN cd $HOME/rocm-cmake && mkdir -p build && cd build && cmake .. && make package -j$(nproc) && dpkg -i ./rocm-cmake*.deb
+RUN cd $HOME/rocm-cmake && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i ./rocm-cmake*.deb
+
 RUN cd $HOME && git clone https://github.com/ROCmSoftwarePlatform/MIOpenGEMM.git
-RUN cd $HOME/MIOpenGEMM && mkdir -p build && cd build && cmake .. && make package -j$(nproc) && dpkg -i ./miopengemm*.deb
-RUN cd $HOME && mkdir half && cd half && wget https://downloads.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip && unzip *.zip
-RUN cd $HOME && git -b pr1061-fix clone https://github.com/deven-amd/MIOpen.git
-RUN cd $HOME/MIOpen && rm -rf build && mkdir build && cd build && \
+RUN cd $HOME/MIOpenGEMM && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i ./miopengemm*.deb
+
+RUN cd $HOME && mkdir half && cd half && sudo wget https://downloads.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip && sudo unzip *.zip
+
+RUN cd $HOME && git clone -b pr1061-fix https://github.com/deven-amd/MIOpen.git
+RUN cd $HOME/MIOpen && mkdir build && cd build && \
   CXX=/opt/rocm/bin/hcc cmake \
     -DMIOPEN_BACKEND=HIP \
     -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" \
     -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" \
     -DHALF_INCLUDE_DIR=$HOME/half/include \
-    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_BUILD_TYPE=Release \
     ..
-RUN make package -j$(nproc)
+RUN sudo make package -j$(nproc)
 
 
 

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -43,6 +43,7 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/distribute:distribute_coordinator_test \
     -//tensorflow/python/eager:pywrap_tfe_test \
     -//tensorflow/python/estimator:dnn_linear_combined_test \
+    -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
     -//tensorflow/python/keras:pooling_test \
     -//tensorflow/python/keras:model_subclassing_test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -66,17 +66,5 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/profiler:profile_context_test \
     -//tensorflow/python:layers_normalization_test \
     -//tensorflow/python:nn_fused_batchnorm_test \
-    -//tensorflow/python/keras:normalization_test \
-    -//tensorflow/python/keras:training_gpu_test \
-    -//tensorflow/python/kernel_tests:atrous_conv2d_test \
-    -//tensorflow/python/kernel_tests:conv2d_transpose_test \
-    -//tensorflow/python/kernel_tests:lrn_op_test \
-    -//tensorflow/python/kernel_tests:neon_depthwise_conv_op_test \
-    -//tensorflow/python/ops/parallel_for:gradients_test \
-    -//tensorflow/python/profiler:profiler_test \
-    -//tensorflow/python:cost_analyzer_test \
-    -//tensorflow/python:image_ops_test \
-    -//tensorflow/python:layout_optimizer_test \
-    -//tensorflow/python:memory_optimizer_test \
     -//tensorflow/python:timeline_test
 


### PR DESCRIPTION
Updating `Dockerfile.rocm` to use the MIOpen build with the temporary fix/workaround for issue 1061. 
(crash when MIOpen is invokded with $HOME not set...fix will use "/tmp" for $HOME) 

MIOpen dependencies being installed manually to bypass the bzip2 install error we seem to be getting when installing the MIOpen dependencies vi cmake.