### PR TITLE
Misc CI unit test updates - MIOpen HOME, fp16 gemm, 5d tensors

### DIFF
--- a/tensorflow/python/keras/layers/pooling_test.py
+++ b/tensorflow/python/keras/layers/pooling_test.py
@@ -126,8 +126,7 @@ class Pooling3DTest(test.TestCase):
   def test_maxpooling_3d(self):
 
     if test.is_built_with_rocm():
-      # 5D tensors are not yet supported in ROCm
-      return
+      self.skipTest("5D tensors are not yet supported in ROCm")
 
     pool_size = (3, 3, 3)
     testing_utils.layer_test(
@@ -150,8 +149,7 @@ class Pooling3DTest(test.TestCase):
   def test_averagepooling_3d(self):
 
     if test.is_built_with_rocm():
-      # 5D tensors are not yet supported in ROCm
-      return
+      self.skipTest("5D tensors are not yet supported in ROCm")
 
     pool_size = (3, 3, 3)
     testing_utils.layer_test(

--- a/tensorflow/python/keras/layers/pooling_test.py
+++ b/tensorflow/python/keras/layers/pooling_test.py
@@ -124,6 +124,11 @@ class Pooling3DTest(test.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def test_maxpooling_3d(self):
+
+    if test.is_built_with_rocm():
+      # 5D tensors are not yet supported in ROCm
+      return
+
     pool_size = (3, 3, 3)
     testing_utils.layer_test(
         keras.layers.MaxPooling3D,
@@ -143,6 +148,11 @@ class Pooling3DTest(test.TestCase):
 
   @tf_test_util.run_in_graph_and_eager_modes
   def test_averagepooling_3d(self):
+
+    if test.is_built_with_rocm():
+      # 5D tensors are not yet supported in ROCm
+      return
+
     pool_size = (3, 3, 3)
     testing_utils.layer_test(
         keras.layers.AveragePooling3D,

--- a/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
+++ b/tensorflow/python/kernel_tests/control_flow_ops_py_test.py
@@ -3159,7 +3159,7 @@ class AssertTest(test.TestCase):
       # That name assignment currently only happens for tensorflow build with CUDA, 
       # ROCm support for the same is still in the process of being implemented
       # Disabling this test for ROCm for the time being
-      return
+      self.skipTest("GPU device/stream tracing is not yet fully supported in ROCm")
     
     with self.test_session(use_gpu=True) as sess:
       with ops.device(test.gpu_device_name()):

--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -1049,8 +1049,7 @@ class ConvolutionOrthogonal3dInitializerTest(test.TestCase):
       return array_ops.concat([tmp_front, tmp, tmp_back], 3)
 
     if test.is_built_with_rocm():
-      # 5D tensors are not yet supported in ROCm
-      return
+      self.skipTest("5D tensors are not yet supported in ROCm")
 
     cout = 32
     shape = [1, 7, 7, 7, 16]

--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -693,6 +693,11 @@ class ConvolutionDeltaOrthogonalInitializerTest(test.TestCase):
         else:
           shape = [4, 16, 16, 16, 64]
           convolution = convolutional.conv3d
+
+          if test.is_built_with_rocm():
+            # 5D tensors are not yet supported in ROCm
+            continue
+
         inputs = random_ops.random_normal(shape, dtype=dtype)
         inputs_2norm = linalg_ops.norm(inputs)
         outputs = convolution(
@@ -1042,6 +1047,10 @@ class ConvolutionOrthogonal3dInitializerTest(test.TestCase):
                                   [-1, -1, -1, beginning, -1])
       tmp_back = array_ops.slice(tmp, [0, 0, 0, 0, 0], [-1, -1, -1, end, -1])
       return array_ops.concat([tmp_front, tmp, tmp_back], 3)
+
+    if test.is_built_with_rocm():
+      # 5D tensors are not yet supported in ROCm
+      return
 
     cout = 32
     shape = [1, 7, 7, 7, 16]

--- a/tensorflow/python/kernel_tests/pool_test.py
+++ b/tensorflow/python/kernel_tests/pool_test.py
@@ -218,6 +218,11 @@ class PoolingTest(test.TestCase):
                     strides=strides)
 
   def testPool3D(self):
+
+    if test.is_built_with_rocm():
+      # 5D tensors are not yet supported in ROCm
+      return
+
     with self.test_session(use_gpu=test.is_gpu_available()):
       for padding in ["SAME", "VALID"]:
         for pooling_type in ["MAX", "AVG"]:
@@ -273,7 +278,10 @@ class PoolingTest(test.TestCase):
               strides=[1, 2],
               dilation_rate=[1, 1],
               data_format="NCHW")
-          self._test(
+
+          if not test.is_built_with_rocm():
+            # 5D tensors are not yet supported in ROCm
+            self._test(
               input_shape=[2, 2, 7, 5, 3],
               window_shape=[2, 2, 2],
               padding=padding,
@@ -281,6 +289,7 @@ class PoolingTest(test.TestCase):
               strides=[1, 2, 1],
               dilation_rate=[1, 1, 1],
               data_format="NCDHW")
+
         self._test(
             input_shape=[2, 2, 7, 9],
             window_shape=[2, 2],
@@ -354,6 +363,11 @@ class PoolingTest(test.TestCase):
                     strides=strides)
 
   def testGradient3D(self):
+
+    if test.is_built_with_rocm():
+      # 5D tensors are not yet supported in ROCm
+      return
+
     with self.test_session(use_gpu=test.is_gpu_available()):
       for padding in ["SAME", "VALID"]:
         for pooling_type in ["AVG", "MAX"]:

--- a/tensorflow/python/kernel_tests/pool_test.py
+++ b/tensorflow/python/kernel_tests/pool_test.py
@@ -220,8 +220,7 @@ class PoolingTest(test.TestCase):
   def testPool3D(self):
 
     if test.is_built_with_rocm():
-      # 5D tensors are not yet supported in ROCm
-      return
+      self.skipTest("5D tensors are not yet supported in ROCm")
 
     with self.test_session(use_gpu=test.is_gpu_available()):
       for padding in ["SAME", "VALID"]:
@@ -365,8 +364,7 @@ class PoolingTest(test.TestCase):
   def testGradient3D(self):
 
     if test.is_built_with_rocm():
-      # 5D tensors are not yet supported in ROCm
-      return
+      self.skipTest("5D tensors are not yet supported in ROCm")
 
     with self.test_session(use_gpu=test.is_gpu_available()):
       for padding in ["SAME", "VALID"]:

--- a/tensorflow/python/training/momentum_test.py
+++ b/tensorflow/python/training/momentum_test.py
@@ -229,11 +229,7 @@ class MomentumOptimizerTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes(reset_test=True)
   def testMinimizeSparseResourceVariable(self):
-    dtypes_to_test = [dtypes.half, dtypes.float32, dtypes.float64]
-    if test.is_built_with_rocm():
-      # rocBLAS on ROCM stack doesn't support fp16 sgemm yet
-      dtypes_to_test = [dtypes.float32, dtypes.float64]
-    for dtype in dtypes_to_test:
+    for dtype in [dtypes.half, dtypes.float32, dtypes.float64]:
       # This test invokes the ResourceSparseApplyMomentum operation, which
       # did not have a registered GPU kernel as of April 2018. With graph
       # execution, the placement algorithm notices this and automatically

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -43,6 +43,7 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/distribute:distribute_coordinator_test \
     -//tensorflow/python/estimator:dnn_linear_combined_test \
     -//tensorflow/python/estimator:linear_test \
+    -//tensorflow/python/feature_column:feature_column_v2_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
     -//tensorflow/python/kernel_tests:conv1d_test \
     -//tensorflow/python/kernel_tests:conv2d_backprop_filter_grad_test \
@@ -58,6 +59,7 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/kernel_tests:pooling_ops_test \
     -//tensorflow/python/kernel_tests:matrix_exponential_op_test \
     -//tensorflow/python/ops/parallel_for:control_flow_ops_test \
+    -//tensorflow/python/ops/parallel_for:gradients_test \
     -//tensorflow/python/profiler/internal:run_metadata_test \
     -//tensorflow/python/profiler:profile_context_test \
     -//tensorflow/python:layers_normalization_test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -41,7 +41,6 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
     //tensorflow/... -//tensorflow/compiler/... -//tensorflow/contrib/... \
     -//tensorflow/python/distribute:distribute_coordinator_test \
-    -//tensorflow/python/eager:pywrap_tfe_test \
     -//tensorflow/python/estimator:dnn_linear_combined_test \
     -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -46,8 +46,6 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
     -//tensorflow/python/keras:pooling_test \
-    -//tensorflow/python/keras:model_subclassing_test \
-    -//tensorflow/python/keras:topology_test \
     -//tensorflow/python/kernel_tests:conv1d_test \
     -//tensorflow/python/kernel_tests:conv2d_backprop_filter_grad_test \
     -//tensorflow/python/kernel_tests:conv_ops_3d_test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -44,7 +44,6 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/estimator:dnn_linear_combined_test \
     -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
-    -//tensorflow/python/keras:pooling_test \
     -//tensorflow/python/kernel_tests:conv1d_test \
     -//tensorflow/python/kernel_tests:conv2d_backprop_filter_grad_test \
     -//tensorflow/python/kernel_tests:conv_ops_3d_test \
@@ -52,7 +51,6 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/kernel_tests:dct_ops_test \
     -//tensorflow/python/kernel_tests:depthwise_conv_op_test \
     -//tensorflow/python/kernel_tests:fft_ops_test \
-    -//tensorflow/python/kernel_tests:init_ops_test \
     -//tensorflow/python/kernel_tests:matrix_inverse_op_test \
     -//tensorflow/python/kernel_tests:matrix_triangular_solve_op_test \
     -//tensorflow/python/kernel_tests:pool_test \


### PR DESCRIPTION
1. Removing 2 more tests from the whitelist that pass with the MIOpen $HOME bug workaround
`//tensorflow/python/keras:model_subclassing_test`
`//tensorflow/python/keras:topology_test`

2. Removing 1 test from the whitelist that passes with the fp16 gemm support enabled in rocblas.
`//tensorflow/python/eager:pywrap_tfe_test`

3. Removing 2 tests from the whitelist that pass after disabling subtests that use 5d tensors
`//tensorflow/python/keras:pooling_test`
`//tensorflow/python/kernel_tests:init_ops_test`