### PR TITLE
enabling fp16 subtests within a couple of unit tests…

### DIFF
--- a/tensorflow/python/kernel_tests/batch_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/batch_matmul_op_test.py
@@ -200,8 +200,7 @@ if __name__ == "__main__":
                     np.complex128, np.int32]
   if test.is_built_with_rocm():
     # rocBLAS in ROCm stack does not support GEMM for complex types
-    #dtypes_to_test = [np.float16, np.float32, np.float64, np.int32]
-    dtypes_to_test = [np.float32, np.float64, np.int32]
+    dtypes_to_test = [np.float16, np.float32, np.float64, np.int32]
   for dtype_ in dtypes_to_test:
     for adjoint_a_ in False, True:
       for adjoint_b_ in False, True:

--- a/tensorflow/python/kernel_tests/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/matmul_op_test.py
@@ -217,8 +217,7 @@ if __name__ == "__main__":
                   np.complex128]
   if test_lib.is_built_with_rocm():
     # rocBLAS on ROCm stack does not support GEMV for complex types
-    # rocBLAS on ROCm stack does not support SGEMM for fp16 types
-    dtypes_to_test = [np.int32, np.float32, np.float64]
+    dtypes_to_test = [np.int32, np.float16, np.float32, np.float64]
   for use_static_shape in [False, True]:
     for dtype in dtypes_to_test:
       if not use_static_shape and dtype == np.int32:

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -45,6 +45,7 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/estimator:linear_test \
     -//tensorflow/python/feature_column:feature_column_v2_test \
     -//tensorflow/python/keras:cudnn_recurrent_test \
+    -//tensorflow/python/kernel_tests:batch_matmul_op_test \
     -//tensorflow/python/kernel_tests:conv1d_test \
     -//tensorflow/python/kernel_tests:conv2d_backprop_filter_grad_test \
     -//tensorflow/python/kernel_tests:conv_ops_3d_test \
@@ -52,6 +53,7 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/kernel_tests:dct_ops_test \
     -//tensorflow/python/kernel_tests:depthwise_conv_op_test \
     -//tensorflow/python/kernel_tests:fft_ops_test \
+    -//tensorflow/python/kernel_tests:matmul_op_test \
     -//tensorflow/python/kernel_tests:matrix_inverse_op_test \
     -//tensorflow/python/kernel_tests:matrix_triangular_solve_op_test \
     -//tensorflow/python/kernel_tests:pool_test \


### PR DESCRIPTION
now that we have support for fp16 gemm in rocblas. The downside is that both tests now have functional failures which we now need to track and fix. The tests are

1. `//tensorflow/python/kernel_tests:batch_matmul_op_test`
2. `//tensorflow/python/kernel_tests:matmul_op_test`