### PR TITLE
 Better handling of -rpath,-Wl,$ORIGIN on ROCm path

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -12,4 +12,4 @@ cat ./configure_rocm | PYTHON_BIN_PATH=/usr/bin/python3 ./configure
 pip3 uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip3 install /tmp/tensorflow_pkg/tensorflow-1.10.0rc1-cp27-cp27mu-linux_x86_64.whl
+pip3 install /tmp/tensorflow_pkg/tensorflow-1.10.0rc1-cp35-cp35mu-linux_x86_64.whl

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -313,7 +313,7 @@ def _rpath_linkopts(name):
       clean_dep("//tensorflow:windows"): [],
       clean_dep("//tensorflow:windows_msvc"): [],
       "//conditions:default": [
-          "-Wl,%s" % (_make_search_paths("\\\$$ORIGIN", levels_to_root),),
+          "-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
       ],
   })
 

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -214,8 +214,18 @@ def main():
   if args.pass_exit_codes:
     gpu_compiler_flags = [flag for flag in sys.argv[1:]
                                if not flag.startswith(('-pass-exit-codes'))]
-    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + gpu_compiler_flags)))
-    return subprocess.call([HIPCC_PATH] + gpu_compiler_flags)
+
+    # special handling for $ORIGIN
+    # - guard every argument with ''
+    # - replace $ORIGIN with \$ORIGIN so it won't be evaluated by hipcc which
+    #   is a bash script itself
+    modified_gpu_compiler_flags = []
+    for flag in gpu_compiler_flags:
+      modified_gpu_compiler_flags.append(
+          "'" + flag.replace('$ORIGIN', '\$ORIGIN') + "'")
+
+    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + modified_gpu_compiler_flags)))
+    return subprocess.call([HIPCC_PATH] + modified_gpu_compiler_flags)
 
   # Strip our flags before passing through to the CPU compiler for files which
   # are not -x rocm. We can't just pass 'leftover' because it also strips -x.


### PR DESCRIPTION
This PR aims to fix the weird missing `libtensorflow_framework.so` issue in certain build targets under certain build configs.

It also fixes incorrect whl package name in `build_rocm_python3` script.
