### PR TITLE
Better handling of -Wl,-rpath,$ORIGIN on ROCm path, take 2

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -318,7 +318,7 @@ def _rpath_linkopts(name):
         ],
         clean_dep("//tensorflow:windows"): [],
         "//conditions:default": [
-            "-Wl,%s" % (_make_search_paths("\\\$$ORIGIN", levels_to_root),),
+            "-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
         ],
     })
 

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -214,8 +214,18 @@ def main():
   if args.pass_exit_codes:
     gpu_compiler_flags = [flag for flag in sys.argv[1:]
                                if not flag.startswith(('-pass-exit-codes'))]
-    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + gpu_compiler_flags)))
-    return subprocess.call([HIPCC_PATH] + gpu_compiler_flags)
+
+    # special handling for $ORIGIN
+    # - guard every argument with ''
+    # - replace $ORIGIN with \$ORIGIN so it won't be evaluated by hipcc which
+    #   is a bash script itself
+    modified_gpu_compiler_flags = []
+    for flag in gpu_compiler_flags:
+      modified_gpu_compiler_flags.append(
+          "'" + flag.replace('$ORIGIN', '\$ORIGIN') + "'")
+
+    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + modified_gpu_compiler_flags)))
+    return subprocess.call([HIPCC_PATH] + modified_gpu_compiler_flags)
 
   # Strip our flags before passing through to the CPU compiler for files which
   # are not -x rocm. We can't just pass 'leftover' because it also strips -x.

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -217,12 +217,10 @@ def main():
 
     # special handling for $ORIGIN
     # - guard every argument with ''
-    # - replace $ORIGIN with \$ORIGIN so it won't be evaluated by hipcc which
-    #   is a bash script itself
     modified_gpu_compiler_flags = []
     for flag in gpu_compiler_flags:
       modified_gpu_compiler_flags.append(
-          "'" + flag.replace('$ORIGIN', '\$ORIGIN') + "'")
+          "'" + flag + "'")
 
     if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + modified_gpu_compiler_flags)))
     return subprocess.call([HIPCC_PATH] + modified_gpu_compiler_flags)


### PR DESCRIPTION
This PR aims to fix the weird missing libtensorflow_framework.so issue in certain build targets under certain build configs.

The issue is originally raised in the upcoming `hip-clang` toolchain, not in the incumbent `hip/hcc` toolchain. So the validity for the PR remains to be checked on `hip/hcc` toolchain.