### PR TITLE
[StreamExecutor] reduce memory consumption in forward pooling

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2955,32 +2955,10 @@ bool MIOpenSupport::DoPoolForward(
                                    miopenFloat};
   ScopedPoolingDescriptor pooling_desc{parent_, pooling_dimensions};
 
-  DeviceMemory<uint8> workspace;
-  size_t workspace_size_in_bytes = 0;
-  status = wrap::miopenPoolingGetWorkSpaceSize(parent_, dest_desc.handle(),
-                                                  &workspace_size_in_bytes);
-
-  if (status != miopenStatusSuccess) {
-    LOG(ERROR) << "failed to obtain workspace size for pooling on stream: "
-               << ToString(status);
-    return false;
-  }
-
-  // Allocate the workspace.
-  if (workspace_size_in_bytes > 0) {
-    assert(workspace_allocator);
-    auto allocated =
-        workspace_allocator->AllocateBytes(stream, workspace_size_in_bytes);
-    if (!allocated.ok() || (workspace = allocated.ValueOrDie()) == nullptr) {
-      LOG(ERROR) << "Failed to allocate pooling workspace";
-      return false;
-    }
-  }
-
   status = wrap::miopenPoolingForward(
       parent_, ToHandle(dnn_handle_), pooling_desc.handle(), &alpha,
       src_desc.handle(), input_data.opaque(), &beta, dest_desc.handle(),
-      output_data->opaque(), true, workspace.opaque(), workspace_size_in_bytes);
+      output_data->opaque(), false, nullptr, 0);
   if (status != miopenStatusSuccess) {
     LOG(ERROR) << "failed to enqueue forward pooling on stream: "
                << ToString(status);
@@ -3014,32 +2992,10 @@ bool MIOpenSupport::DoPoolForward(
                                    miopenHalf};
   ScopedPoolingDescriptor pooling_desc{parent_, pooling_dimensions};
 
-  DeviceMemory<uint8> workspace;
-  size_t workspace_size_in_bytes = 0;
-  status = wrap::miopenPoolingGetWorkSpaceSize(parent_, dest_desc.handle(),
-                                                  &workspace_size_in_bytes);
-
-  if (status != miopenStatusSuccess) {
-    LOG(ERROR) << "failed to obtain workspace size for pooling on stream: "
-               << ToString(status);
-    return false;
-  }
-
-  // Allocate the workspace.
-  if (workspace_size_in_bytes > 0) {
-    assert(workspace_allocator);
-    auto allocated =
-        workspace_allocator->AllocateBytes(stream, workspace_size_in_bytes);
-    if (!allocated.ok() || (workspace = allocated.ValueOrDie()) == nullptr) {
-      LOG(ERROR) << "Failed to allocate pooling workspace";
-      return false;
-    }
-  }
-
   status = wrap::miopenPoolingForward(
       parent_, ToHandle(dnn_handle_), pooling_desc.handle(), &alpha,
       src_desc.handle(), input_data.opaque(), &beta, dest_desc.handle(),
-      output_data->opaque(), true, workspace.opaque(), workspace_size_in_bytes);
+      output_data->opaque(), false, nullptr, 0);
   if (status != miopenStatusSuccess) {
     LOG(ERROR) << "failed to enqueue forward pooling on stream: "
                << ToString(status);


### PR DESCRIPTION
in forward pooling, workspace is not really used so we don't need to allocate
it in the first place. the workspace would be written in backward pooling.