### PR TITLE
Changes crosstool for hip-clang

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -318,7 +318,7 @@ def _rpath_linkopts(name):
         ],
         clean_dep("//tensorflow:windows"): [],
         "//conditions:default": [
-            "-Wl,%s" % (_make_search_paths("\\\$$ORIGIN", levels_to_root),),
+          "-Wl,%s" % (_make_search_paths("$$ORIGIN", levels_to_root),),
         ],
     })
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm-hipclang
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm-hipclang
@@ -1,0 +1,203 @@
+# This Dockerfile provides a starting point for a ROCm installation of 
+# MIOpen and tensorflow.
+
+# This Dockerfile uses a multi-stage build
+# The first stage is to build the HCC, HIP and other tools we need for the TF build
+# The second stage is to do the TF CI build itself
+# The separation of stages allows to reduce the size of the final docker image
+# by copying over only the packages built in the first stage over to the second one
+
+
+###################################################
+# Stage 1 : build the tools needed for the TF build
+#     Note: experimental! hip-clang build/install
+###################################################
+
+FROM rocm/rocm-terminal:1.8.2 as tool_builder
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV HOME /home/rocm-user
+
+# install packages needed for this image
+RUN sudo apt-get update && sudo apt-get install -y python rpm git mercurial libxml2 libxml2-dev 
+
+# Build and install LLVM with Clang and LLD. Checkout clang and lld into llvm/tools/ dir.
+RUN cd $HOME && git clone -b amd-common https://github.com/RadeonOpenCompute/llvm.git
+WORKDIR $HOME/llvm/tools
+RUN git clone -b amd-common http://github.com/radeonopencompute/clang.git
+RUN git clone -b amd-common https://github.com/RadeonOpenCompute/lld.git
+RUN mkdir $HOME/llvm/build
+WORKDIR $HOME/llvm/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" .. && make -j$(nproc) && sudo make -j$(nproc) install
+
+# Build and install ROCDL
+WORKDIR $HOME
+RUN git clone -b master https://github.com/RadeonOpenCompute/ROCm-Device-Libs
+RUN mkdir -p $HOME/ROCm-Device-Libs/build
+WORKDIR $HOME/ROCm-Device-Libs/build
+ENV LLVM_BUILD=$HOME/llvm/build
+RUN CC=$LLVM_BUILD/bin/clang cmake -DLLVM_DIR=$LLVM_BUILD -DAMDHSACOD=/opt/rocm/hsa/bin/x86_64/amdhsacod .. && make -j$(nproc) package && sudo dpkg -i ./*.deb
+
+# Build and install HCC
+WORKDIR $HOME
+RUN git clone --recursive -b clang_tot_upgrade https://github.com/RadeonOpenCompute/hcc.git
+RUN mkdir -p $HOME/hcc/build
+WORKDIR $HOME/hcc/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && make -j$(nproc) package && sudo dpkg -i ./*.deb
+
+# Build and install HIP-HCC-RT
+WORKDIR $HOME
+RUN git clone -b master https://github.com/ROCm-Developer-Tools/HIP
+RUN mkdir $HOME/HIP/build
+WORKDIR $HOME/HIP/build
+RUN cmake .. && make -j$(nproc) package && sudo dpkg -i ./*.deb
+
+# Set up environment for hip-clang
+ENV HIP_CLANG_PATH=/opt/rocm/llvm/bin
+ENV DEVICE_LIB_PATH=/opt/rocm/lib
+
+# Workaround : build MIOpen from source using fork of the public repo with the temporary fix for issue #1061 ($HOME env not set)
+RUN sudo apt-get install -y wget unzip libssl-dev libboost-dev libboost-system-dev libboost-filesystem-dev
+
+RUN cd $HOME && git clone https://github.com/RadeonOpenCompute/rocm-cmake.git
+RUN cd $HOME/rocm-cmake && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i ./rocm-cmake*.deb
+
+RUN cd $HOME && git clone https://github.com/ROCmSoftwarePlatform/MIOpenGEMM.git
+RUN cd $HOME/MIOpenGEMM && mkdir build && cd build && cmake .. && sudo make package -j$(nproc) && sudo dpkg -i ./miopengemm*.deb
+
+RUN cd $HOME && mkdir half && cd half && sudo wget https://downloads.sourceforge.net/project/half/half/1.12.0/half-1.12.0.zip && sudo unzip *.zip
+
+RUN cd $HOME && git clone -b pr1061-fix https://github.com/deven-amd/MIOpen.git
+RUN cd $HOME/MIOpen && mkdir build && cd build && \
+  CXX=/opt/rocm/bin/hcc cmake \
+    -DMIOPEN_BACKEND=HIP \
+    -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" \
+    -DCMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" \
+    -DHALF_INCLUDE_DIR=$HOME/half/include \
+    -DCMAKE_BUILD_TYPE=Release \
+    .. && sudo make package -j$(nproc)
+
+
+
+###########################
+# Stage 2 : do the TF build
+###########################
+
+FROM ubuntu:xenial
+MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
+
+ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/debian/
+ARG ROCM_PATH=/opt/rocm
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TF_NEED_ROCM 1
+ENV HOME /root/
+RUN apt update && apt install -y wget software-properties-common 
+
+# Add rocm repository
+RUN apt-get clean all
+RUN wget -qO - $DEB_ROCM_REPO/rocm.gpg.key | apt-key add -
+RUN sh -c  "echo deb [arch=amd64] $DEB_ROCM_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
+
+# Install misc pkgs
+RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential \
+  clang-3.8 \
+  clang-format-3.8 \
+  clang-tidy-3.8 \
+  cmake \
+  cmake-qt-gui \
+  ssh \
+  curl \
+  apt-utils \
+  pkg-config \
+  g++-multilib \
+  git \
+  libunwind-dev \
+  libfftw3-dev \
+  libelf-dev \
+  libncurses5-dev \
+  libpthread-stubs0-dev \
+  vim \
+  gfortran \
+  libboost-program-options-dev \
+  libssl-dev \
+  libboost-dev \
+  libboost-system-dev \
+  libboost-filesystem-dev \
+  rpm \
+  libnuma-dev \
+  pciutils \
+  virtualenv \
+  python-pip \
+  python3-pip \
+  libxml2 \
+  libxml2-dev \
+  wget && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rocm pkgs
+RUN apt-get update --allow-insecure-repositories && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
+    rocm-dev rocm-libs rocm-utils \
+    rocfft miopen-hip miopengemm rocblas hipblas rocrand \
+    rocm-profiler cxlactivitylogger && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# COPY and install llvm built in the previous stage
+RUN mkdir -p /opt/rocm && rm -rf /opt/rocm/llvm
+COPY --from=tool_builder /opt/rocm/llvm /opt/rocm/
+
+# COPY and install the ROCDL package built in the previous stage
+RUN mkdir -p $HOME/pkgs/ROCm-Device-Libs
+COPY --from=tool_builder /home/rocm-user/ROCm-Device-Libs/build/*.deb $HOME/pkgs/ROCm-Device-Libs/
+RUN cd $HOME/pkgs/ROCm-Device-Libs && dpkg -i *.deb
+
+# COPY and install the hcc package built in the previous stage
+RUN mkdir -p $HOME/pkgs/hcc
+COPY --from=tool_builder /home/rocm-user/hcc/build/*.deb $HOME/pkgs/hcc/
+RUN cd $HOME/pkgs/hcc && dpkg -i *.deb
+
+# COPY and install the HIP package built in the previous stage
+RUN mkdir -p $HOME/pkgs/HIP
+COPY --from=tool_builder /home/rocm-user/HIP/build/*.deb $HOME/pkgs/HIP/
+RUN cd $HOME/pkgs/HIP && dpkg -i *.deb
+
+# COPY and install the MIOpen package built in the previous stage
+RUN mkdir -p $HOME/pkgs/MIOpen
+COPY --from=tool_builder /home/rocm-user/MIOpen/build/*.deb $HOME/pkgs/MIOpen/
+RUN cd $HOME/pkgs/MIOpen && dpkg -i *.deb
+
+ENV HCC_HOME=$ROCM_PATH/hcc
+ENV HIP_PATH=$ROCM_PATH/hip
+ENV OPENCL_ROOT=$ROCM_PATH/opencl
+ENV PATH="$HCC_HOME/bin:$HIP_PATH/bin:${PATH}"
+ENV PATH="$ROCM_PATH/bin:${PATH}"
+ENV PATH="$OPENCL_ROOT/bin:${PATH}"
+
+# Add target file to help determine which device(s) to build for
+RUN echo -e "gfx803\ngfx900" >> /opt/rocm/bin/target.lst
+
+# Set up environment for hip-clang
+ENV HIP_CLANG_PATH=/opt/rocm/llvm/bin
+ENV DEVICE_LIB_PATH=/opt/rocm/lib
+
+# Copy and run the install scripts.
+COPY install/*.sh /install/
+ARG DEBIAN_FRONTEND=noninteractive
+RUN /install/install_bootstrap_deb_packages.sh
+RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    add-apt-repository -y ppa:george-edison55/cmake-3.x
+RUN /install/install_deb_packages.sh
+RUN /install/install_pip_packages.sh
+RUN /install/install_bazel.sh
+RUN /install/install_golang.sh
+
+# Set up the master bazelrc configuration file.
+COPY install/.bazelrc /etc/bazel.bazelrc
+
+# Configure the build for our CUDA configuration.
+ENV TF_NEED_ROCM 1
+

--- a/tensorflow/tools/ci_build/Dockerfile.rocm-hipclang
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm-hipclang
@@ -147,8 +147,8 @@ RUN apt-get update --allow-insecure-repositories && \
     rm -rf /var/lib/apt/lists/*
 
 # COPY and install llvm built in the previous stage
-RUN mkdir -p /opt/rocm && rm -rf /opt/rocm/llvm
-COPY --from=tool_builder /opt/rocm/llvm /opt/rocm/
+RUN rm -rf /opt/rocm/llvm && mkdir -p /opt/rocm/llvm
+COPY --from=tool_builder /opt/rocm/llvm/ /opt/rocm/llvm/
 
 # COPY and install the ROCDL package built in the previous stage
 RUN mkdir -p $HOME/pkgs/ROCm-Device-Libs

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -214,8 +214,18 @@ def main():
   if args.pass_exit_codes:
     gpu_compiler_flags = [flag for flag in sys.argv[1:]
                                if not flag.startswith(('-pass-exit-codes'))]
-    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + gpu_compiler_flags)))
-    return subprocess.call([HIPCC_PATH] + gpu_compiler_flags)
+
+    # special handling for $ORIGIN
+    # - guard every argument with ''
+    # - replace $ORIGIN with \$ORIGIN so it won't be evaluated by hipcc which
+    #   is a bash script itself
+    modified_gpu_compiler_flags = []
+    for flag in gpu_compiler_flags:
+      modified_gpu_compiler_flags.append(
+          "'" + flag.replace('$ORIGIN', '\$ORIGIN') + "'")
+
+    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + modified_gpu_compiler_flags)))
+    return subprocess.call([HIPCC_PATH] + modified_gpu_compiler_flags)
 
   # Strip our flags before passing through to the CPU compiler for files which
   # are not -x rocm. We can't just pass 'leftover' because it also strips -x.

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -30,6 +30,8 @@ GCC_HOST_COMPILER_PATH = ('%{gcc_host_compiler_path}')
 
 HIPCC_PATH = '%{hipcc_path}'
 PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
+HIPCC_ENV = '%{hipcc_env}'
+VERBOSE = '%{crosstool_verbose}'=='1'
 
 def Log(s):
   print('gpus/crosstool: {0}'.format(s))
@@ -189,8 +191,11 @@ def InvokeHipcc(argv, log=False):
 
   # TODO(zhengxq): for some reason, 'gcc' needs this help to find 'as'.
   # Need to investigate and fix.
-  cmd = 'PATH=' + PREFIX_DIR + ':$PATH ' + cmd
+  cmd = 'PATH=' + PREFIX_DIR + ':$PATH '\
+        + HIPCC_ENV + ' '\
+        + cmd
   if log: Log(cmd)
+  if VERBOSE: print(cmd)
   return os.system(cmd)
 
 
@@ -204,6 +209,9 @@ def main():
   parser.add_argument('-pass-exit-codes', action='store_true')
   args, leftover = parser.parse_known_args(sys.argv[1:])
 
+  if VERBOSE: print('PWD=' + os.getcwd())
+  if VERBOSE: print('HIPCC_ENV=' + HIPCC_ENV)
+  
   if args.x and args.x[0] == 'rocm':
     if args.rocm_log: Log('-x rocm')
     leftover = [pipes.quote(s) for s in leftover]
@@ -224,8 +232,11 @@ def main():
       modified_gpu_compiler_flags.append(
           "'" + flag.replace('$ORIGIN', '\$ORIGIN') + "'")
 
-    if args.rocm_log: Log('Link with hipcc: %s' % (' '.join([HIPCC_PATH] + modified_gpu_compiler_flags)))
-    return subprocess.call([HIPCC_PATH] + modified_gpu_compiler_flags)
+    cmd = HIPCC_ENV.split() + [HIPCC_PATH] + modified_gpu_compiler_flags
+    cmd_str = ' '.join(cmd)
+    if args.rocm_log: Log('Link with hipcc: %s' %(cmd_str))
+    if VERBOSE: print(cmd_str)
+    return os.system(cmd_str)
 
   # Strip our flags before passing through to the CPU compiler for files which
   # are not -x rocm. We can't just pass 'leftover' because it also strips -x.
@@ -237,7 +248,7 @@ def main():
 
   # XXX: SE codes need to be built with gcc, but need this macro defined
   cpu_compiler_flags.append("-D__HIP_PLATFORM_HCC__")
-
+  if VERBOSE: print(' '.join([CPU_COMPILER] + cpu_compiler_flags))
   return subprocess.call([CPU_COMPILER] + cpu_compiler_flags)
 
 if __name__ == '__main__':

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -230,11 +230,14 @@ def main():
       modified_gpu_compiler_flags.append(
           "'" + flag + "'")
 
+    HIPCC_ENV_list = HIPCC_ENV.split('=')
+    HIPCC_ENV_dict = dict(zip(HIPCC_ENV_list[::2],HIPCC_ENV_list[1::2]))
     cmd = HIPCC_ENV.split() + [HIPCC_PATH] + modified_gpu_compiler_flags
     cmd_str = ' '.join(cmd)
     if args.rocm_log: Log('Link with hipcc: %s' %(cmd_str))
     if VERBOSE: print(cmd_str)
-    return os.system(cmd_str)
+    sub_process = subprocess.Popen([HIPCC_PATH] + modified_gpu_compiler_flags, env=HIPCC_ENV_dict)
+    return sub_process.wait()
 
   # Strip our flags before passing through to the CPU compiler for files which
   # are not -x rocm. We can't just pass 'leftover' because it also strips -x.

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -210,6 +210,37 @@ def _amdgpu_targets(repository_ctx):
       auto_configure_fail("Invalid AMDGPU target: %s" % amdgpu_target)
   return amdgpu_targets
 
+def _hipcc_env(repository_ctx):
+  """Returns the environment variable string for hipcc.
+
+  Args:
+    repository_ctx: The repository context.
+
+  Returns:
+    A string containing environment variables for hipcc.
+  """
+  hipcc_env = ""
+  for name in ["HIP_CLANG_PATH", "DEVICE_LIB_PATH", "HIP_VDI_HOME",\
+               "HIPCC_VERBOSE"]:
+    if name in repository_ctx.os.environ:
+      hipcc_env = hipcc_env + " " + name + "=" + \
+                repository_ctx.os.environ[name].strip()
+  return hipcc_env.strip()
+
+def _crosstool_verbose(repository_ctx):
+  """Returns the environment variable value CROSSTOOL_VERBOSE.
+
+  Args:
+    repository_ctx: The repository context.
+
+  Returns:
+    A string containing value of environment variable CROSSTOOL_VERBOSE.
+  """
+  name = "CROSSTOOL_VERBOSE"
+  if name in repository_ctx.os.environ:
+    return repository_ctx.os.environ[name].strip()
+  return "0"
+
 def _cpu_value(repository_ctx):
   """Returns the name of the host operating system.
 
@@ -580,6 +611,8 @@ def _create_local_rocm_repository(repository_ctx):
        {
            "%{cpu_compiler}": str(cc),
            "%{hipcc_path}": "/opt/rocm/bin/hipcc",
+           "%{hipcc_env}": _hipcc_env(repository_ctx),
+           "%{crosstool_verbose}": _crosstool_verbose(repository_ctx),
            "%{gcc_host_compiler_path}": str(cc),
            "%{rocm_amdgpu_targets}": ",".join(
                ["\"%s\"" % c for c in rocm_config.amdgpu_targets]),

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -221,7 +221,7 @@ def _hipcc_env(repository_ctx):
   """
   hipcc_env = ""
   for name in ["HIP_CLANG_PATH", "DEVICE_LIB_PATH", "HIP_VDI_HOME",\
-               "HIPCC_VERBOSE"]:
+               "HIPCC_VERBOSE", "HIP_AUTO_INCLUDE_HEADER"]:
     if name in repository_ctx.os.environ:
       hipcc_env = hipcc_env + " " + name + "=" + \
                 repository_ctx.os.environ[name].strip()


### PR DESCRIPTION
To let hipcc use hip-clang instead of hcc to build TensorFlow, hipcc environment variables need to be passed to hipcc through crosstool. This patch implements that.