### PR TITLE
Remove dead codes in AlgorithmConfig

### DIFF
--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -769,24 +769,18 @@ class ProfileResult {
 //    the allocation for the scratch memory fails.
 class AlgorithmConfig {
  public:
-  AlgorithmConfig() : algorithm_(), scratch_size_(0), algorithm_no_scratch_() {}
-  explicit AlgorithmConfig(AlgorithmDesc algorithm)
-      : algorithm_(algorithm), scratch_size_(0), algorithm_no_scratch_() {}
-  explicit AlgorithmConfig(AlgorithmDesc algorithm, size_t scratch_size)
-      : algorithm_(algorithm),
-        scratch_size_(scratch_size),
-        algorithm_no_scratch_() {}
+  AlgorithmConfig() {}
+  explicit AlgorithmConfig(AlgorithmDesc algorithm) : algorithm_(algorithm) {}
+  AlgorithmConfig(AlgorithmDesc algorithm, AlgorithmDesc algorithm_no_scratch)
+      : algorithm_(algorithm), algorithm_no_scratch_(algorithm_no_scratch) {}
   AlgorithmDesc algorithm() const { return algorithm_; }
   void set_algorithm(AlgorithmDesc val) { algorithm_ = val; }
   AlgorithmDesc algorithm_no_scratch() const { return algorithm_no_scratch_; }
   void set_algorithm_no_scratch(AlgorithmDesc val) {
     algorithm_no_scratch_ = val;
   }
-  size_t scratch_size() const { return scratch_size_; }
-  void set_scratch_size(size_t val) { scratch_size_ = val; }
   bool operator==(const AlgorithmConfig& other) const {
     return this->algorithm_ == other.algorithm_ &&
-           this->scratch_size_ == other.scratch_size_ &&
            this->algorithm_no_scratch_ == other.algorithm_no_scratch_;
   }
   bool operator!=(const AlgorithmConfig& other) const {
@@ -796,7 +790,6 @@ class AlgorithmConfig {
 
  private:
   AlgorithmDesc algorithm_;
-  size_t scratch_size_;
   AlgorithmDesc algorithm_no_scratch_;
 };
 


### PR DESCRIPTION
@sunway513 There were some back-n-forth discussion with upstream maintainers wrt where `scratch_size_` should be placed. Eventually it was decided to be placed inside `AlgorithmDesc`. This PR removed unused codes in `AlgorithmConfig`.