### PR TITLE
updating eigen pointer to point  to ROCm eigen mirror with hip-clang related updates

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -118,11 +118,11 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "eigen_archive",
         urls = [
-            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/eigen-upstream/archive/3ecbb36eaeef7f0dcb02c87cdafa4c6432acb25b.tar.gz",
-            "https://github.com/ROCmSoftwarePlatform/eigen-upstream/archive/3ecbb36eaeef7f0dcb02c87cdafa4c6432acb25b.tar.gz",
+            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/eigen-upstream/archive/e85e22959ae92994776c9b05828cd986aa1291e8.tar.gz",
+            "https://github.com/ROCmSoftwarePlatform/eigen-upstream/archive/e85e22959ae92994776c9b05828cd986aa1291e8.tar.gz",
         ],
-        sha256 = "9cb9a85b580ae57b2c66ef447af7aad5549329e366c1d05ab01525e51b4f7ab6",
-        strip_prefix = "eigen-upstream-3ecbb36eaeef7f0dcb02c87cdafa4c6432acb25b",
+        sha256 = "40f5c5e4f3be755b007cf97dfb1984f4c3d595ac6d22ef7be5a1a3a0fc3fbc18",
+        strip_prefix = "eigen-upstream-e85e22959ae92994776c9b05828cd986aa1291e8",
         build_file = clean_dep("//third_party:eigen.BUILD"),
     )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -118,13 +118,12 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "eigen_archive",
         urls = [
-            "https://mirror.bazel.build/bitbucket.org/eigen/eigen/get/8475e3c056d3.tar.gz",
-            "https://bitbucket.org/eigen/eigen/get/8475e3c056d3.tar.gz",
+            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/eigen-upstream/archive/3ecbb36eaeef7f0dcb02c87cdafa4c6432acb25b.tar.gz",
+            "https://github.com/ROCmSoftwarePlatform/eigen-upstream/archive/3ecbb36eaeef7f0dcb02c87cdafa4c6432acb25b.tar.gz",
         ],
-        sha256 = "32b2e2f8751ac6ef223e2cd6ba70718fbc3c810463763083497f1ba203e13573",
-        strip_prefix = "eigen-eigen-8475e3c056d3",
+        sha256 = "9cb9a85b580ae57b2c66ef447af7aad5549329e366c1d05ab01525e51b4f7ab6",
+        strip_prefix = "eigen-upstream-3ecbb36eaeef7f0dcb02c87cdafa4c6432acb25b",
         build_file = clean_dep("//third_party:eigen.BUILD"),
-        patch_file = clean_dep("//third_party:eigen_fix_gpu_compilation.patch"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
Compiling the eigen unittests with hip-clang requires updates to the Eigen codebase.

Those changes will be submitted as a PR to the Eigen repo soon.

While we wait for these changes to show up in the official Eigen repo, I have applied those changes to the `deven_hip_clang_updates` branch in the git mirror we maintain of the Eigen repo.
(https://github.com/ROCmSoftwarePlatform/eigen-upstream/tree/deven_hip_clang_updates)

Note that the eigen PR getting accepted is not the only gating condition for switching the eigen pointer back to the official Eigen repo. 

It seems that that TF build is broken if we switch the eigen pointer to the tip of the official Eigen repo. Currently the eigen pointer in TF is approx 2 months behind the tip, and changes introduced since then break the TF build. This will also need to be fixed before updating the eigen pointer.

A consequence of this is the `deven_hip_clang_updates` branch is not based of the current tip of the Eigen repo, but off an older commit which does not break the TF build.
