### PR TITLE
Removing '//tensorflow/python:timeline_test' from the whitelist. 

### DIFF
--- a/tensorflow/tools/ci_build/linux/gpu/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/gpu/run_py3_core.sh
@@ -42,5 +42,4 @@ bazel test --config=cuda --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchma
     --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
     //tensorflow/... -//tensorflow/compiler/... -//tensorflow/contrib/... \
     -//tensorflow/python/kernel_tests:softplus_op_test \
-    -//tensorflow/python/kernel_tests:softsign_op_test \
-    -//tensorflow/python:timeline_test
+    -//tensorflow/python/kernel_tests:softsign_op_test

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -65,6 +65,5 @@ bazel test --test_sharding_strategy=disabled --config=rocm --test_tag_filters=-n
     -//tensorflow/python/ops/parallel_for:gradients_test \
     -//tensorflow/python:layers_normalization_test \
     -//tensorflow/python:layout_optimizer_test \
-    -//tensorflow/python:nn_fused_batchnorm_test \
-    -//tensorflow/python:timeline_test
+    -//tensorflow/python:nn_fused_batchnorm_test
 


### PR DESCRIPTION
It was on the whitelist because one subtest within it was flaky (would sometimes fail on both CUDA and ROCm). That subtest has now been disabled in the upstream repo (for the same reason), which means this unit test should now pass consistently, hence removing it from the whitelist