### PR TITLE
Some fixes for xla fails in unit tests

### DIFF
--- a/tensorflow/compiler/xla/tests/llvm_compiler_test.cc
+++ b/tensorflow/compiler/xla/tests/llvm_compiler_test.cc
@@ -18,7 +18,11 @@ limitations under the License.
 #include "tensorflow/compiler/xla/literal_util.h"
 #include "tensorflow/compiler/xla/service/backend.h"
 #include "tensorflow/compiler/xla/service/cpu/cpu_compiler.h"
-#include "tensorflow/compiler/xla/service/gpu/nvptx_compiler.h"
+#if GOOGLE_CUDA
+ #include "tensorflow/compiler/xla/service/gpu/nvptx_compiler.h"
+#elif TENSORFLOW_USE_ROCM
+ #include "tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h"
+#endif 
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/platform_util.h"
 #include "tensorflow/compiler/xla/test_helpers.h"
@@ -137,7 +141,11 @@ class CpuCompilerTest : public LLVMCompilerTest {
 
 class GpuCompilerTest : public LLVMCompilerTest {
  public:
+#if GOOGLE_CUDA
   GpuCompilerTest() : LLVMCompilerTest("CUDA") {}
+#elif TENSORFLOW_USE_ROCM
+  GpuCompilerTest() : LLVMCompilerTest("ROCM") {}
+#endif 
 };
 
 TEST_F(CpuCompilerTest, HooksTest) {
@@ -146,7 +154,11 @@ TEST_F(CpuCompilerTest, HooksTest) {
 }
 
 TEST_F(GpuCompilerTest, HooksTest) {
+#if GOOGLE_CUDA 
   gpu::NVPTXCompiler compiler;
+#elif TENSORFLOW_USE_ROCM
+  gpu::AMDGPUCompiler compiler;
+#endif 
   TestCompilerHooks(&compiler);
 }
 
@@ -156,7 +168,11 @@ TEST_F(CpuCompilerTest, MultiModuleCompilation) {
 }
 
 TEST_F(GpuCompilerTest, MultModuleCompilation) {
+#if GOOGLE_CUDA 
   gpu::NVPTXCompiler compiler;
+#elif TENSORFLOW_USE_ROCM
+  gpu::AMDGPUCompiler compiler;
+#endif 
   TestMultiModuleCompilation(&compiler);
 }
 }  // namespace

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -108,23 +108,22 @@ ROCMExecutor::~ROCMExecutor() {
   for (auto &it : in_memory_modules_) {
     ROCMDriver::UnloadModule(device_ordinal_, it.second);
   }
- CHECK(gpu_binary_to_module_.empty()) << "ROCMExecutor has loaded modules.";
- 
+  CHECK(gpu_binary_to_module_.empty()) << "ROCMExecutor has loaded modules.";
 }
 bool ROCMExecutor::UnloadModule(ModuleHandle module_handle) {
-  const char *gpu_binary = reinterpret_cast<const char *>(module_handle.id());
+  const char* gpu_binary = reinterpret_cast<const char*>(module_handle.id());
   mutex_lock lock{in_memory_modules_mu_};
   return UnloadGpuBinary(gpu_binary);
 }
 
-bool ROCMExecutor::UnloadGpuBinary(const void *gpu_binary) {
+bool ROCMExecutor::UnloadGpuBinary(const void* gpu_binary) {
   auto module_it = gpu_binary_to_module_.find(gpu_binary);
   if (gpu_binary_to_module_.end() == module_it) {
     VLOG(3) << "No loaded  HSACO module for " << gpu_binary;
     return false;
   }
-  auto &module = module_it->second.first;
-  auto &refcount = module_it->second.second;
+  auto& module = module_it->second.first;
+  auto& refcount = module_it->second.second;
   VLOG(3) << "Found HSACO module " << module << " with refcount " << refcount;
   if (--refcount == 0) {
     VLOG(3) << "Unloading  HSACO module " << module;
@@ -133,7 +132,6 @@ bool ROCMExecutor::UnloadGpuBinary(const void *gpu_binary) {
   }
   return true;
 }
-
 
 port::Status ROCMExecutor::Init(int device_ordinal,
                                 DeviceOptions device_options) {
@@ -322,8 +320,8 @@ bool ROCMExecutor::Launch(Stream *stream, const ThreadDim &thread_dims,
 
   return true;
 }
-bool ROCMExecutor::LoadModule(const MultiModuleLoaderSpec &spec,
-                              ModuleHandle *module_handle) {
+bool ROCMExecutor::LoadModule(const MultiModuleLoaderSpec& spec,
+                              ModuleHandle* module_handle) {
   // In ROCMExecutor we store the pointer to the  HSACO binary  as
   // ModuleHandle::id().
   hipModule_t hip_module = nullptr;
@@ -331,41 +329,39 @@ bool ROCMExecutor::LoadModule(const MultiModuleLoaderSpec &spec,
   if (spec.has_cuda_cubin_in_memory()) {
     mutex_lock lock{in_memory_modules_mu_};
     if (!LoadModuleFromHsaco(
-            reinterpret_cast<const char *>(spec.cuda_cubin_in_memory().data()),
+            reinterpret_cast<const char*>(spec.cuda_cubin_in_memory().data()),
             &hip_module)) {
       return false;
     }
-    *module_handle = ModuleHandle(const_cast<void *>(
-        static_cast<const void *>(spec.cuda_cubin_in_memory().data())));
+    *module_handle = ModuleHandle(const_cast<void*>(
+        static_cast<const void*>(spec.cuda_cubin_in_memory().data())));
     return true;
- }
- else {
-  LOG(ERROR) << "No HSACO binary found \n";
-  return false;
- }
+  } else {
+    LOG(ERROR) << "No HSACO binary found \n";
+    return false;
+  }
 }
 
-bool ROCMExecutor::LoadModuleFromHsaco(const char *hsaco, hipModule_t *module) {
+bool ROCMExecutor::LoadModuleFromHsaco(const char* hsaco, hipModule_t* module) {
   uint64_t module_refcount;
   std::tie(*module, module_refcount) = gpu_binary_to_module_[hsaco];
 
   if (*module == nullptr) {
-    if (!ROCMDriver::LoadHsaco(device_ordinal_, hsaco, module)){
+    if (!ROCMDriver::LoadHsaco(device_ordinal_, hsaco, module)) {
       LOG(ERROR) << "failed to load : HSACO \n";
       return false;
     }
     module_refcount = 1;
-    VLOG(3) << "Loaded HSACO " << static_cast<const void *>(hsaco)
+    VLOG(3) << "Loaded HSACO " << static_cast<const void*>(hsaco)
             << " as module " << *module;
   } else {
     ++module_refcount;
-    VLOG(3) << "HSACO " << static_cast<const void *>(hsaco)
+    VLOG(3) << "HSACO " << static_cast<const void*>(hsaco)
             << " is already loaded as module " << *module;
   }
   gpu_binary_to_module_[hsaco] = {*module, module_refcount};
   return true;
 }
-
 
 // This is a non-essential operation; if there's a failure, proceed without
 // logging an error. It's nearly certain that in case of failures, we'd never
@@ -748,22 +744,21 @@ bool ROCMExecutor::GetSymbol(const string& symbol_name, ModuleHandle module_hand
     if (static_cast<bool>(module_handle)) {
       auto it = gpu_binary_to_module_.find(module_handle.id());
       CHECK(it != gpu_binary_to_module_.end());
-      if (ROCMDriver::GetModuleSymbol(device_ordinal_, it->second.first, symbol_name.c_str(),
-                                      reinterpret_cast<hipDeviceptr_t *>(mem),
-                                      bytes)) {
+      if (ROCMDriver::GetModuleSymbol(
+              device_ordinal_, it->second.first, symbol_name.c_str(),
+              reinterpret_cast<hipDeviceptr_t*>(mem), bytes)) {
         return true;
       }
     }
 
-    for (auto &it : gpu_binary_to_module_) {
-      if (ROCMDriver::GetModuleSymbol(device_ordinal_, it.second.first, symbol_name.c_str(),
-                                      reinterpret_cast<hipDeviceptr_t *>(mem),
-                                      bytes)) {
+    for (auto& it : gpu_binary_to_module_) {
+      if (ROCMDriver::GetModuleSymbol(
+              device_ordinal_, it.second.first, symbol_name.c_str(),
+              reinterpret_cast<hipDeviceptr_t*>(mem), bytes)) {
         return true;
       }
     }
   }
- 
 
   LOG(INFO) << "Falied to find symbol in any modules: " << symbol_name;
   return false;

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -60,6 +60,13 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   bool GetKernel(const MultiKernelLoaderSpec &spec,
                  KernelBase *kernel) override;
 
+  bool LoadModule(const MultiModuleLoaderSpec &spec,
+                  ModuleHandle *module_handle) override;
+
+  bool UnloadModule(ModuleHandle module_handle) override;
+  bool UnloadGpuBinary(const void *gpu_binary)
+      EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
+
   bool Launch(Stream *stream, const ThreadDim &thread_dims,
               const BlockDim &block_dims, const KernelBase &k,
               const KernelArgsArrayBase &args) override;
@@ -226,6 +233,9 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   void VlogOccupancyInfo(const KernelBase &kernel, const ThreadDim &thread_dims,
                          const BlockDim &block_dims);
 
+  bool LoadModuleFromHsaco(const char *hsaco, hipModule_t *module)
+      EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
+
   // Guards the on-disk-module mapping.
   mutex disk_modules_mu_;
 
@@ -239,6 +249,10 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
 
   std::map<const char *, hipModule_t> in_memory_modules_
       GUARDED_BY(in_memory_modules_mu_);
+
+  // HSACO Binary -> {Hip module, reference count}.
+  std::unordered_map<const void *, std::pair<hipModule_t, uint64>>
+      gpu_binary_to_module_ GUARDED_BY(in_memory_modules_mu_);
 
   // Guards the launched kernel set.
   mutex launched_kernels_mu_;

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -60,11 +60,11 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   bool GetKernel(const MultiKernelLoaderSpec &spec,
                  KernelBase *kernel) override;
 
-  bool LoadModule(const MultiModuleLoaderSpec &spec,
-                  ModuleHandle *module_handle) override;
+  bool LoadModule(const MultiModuleLoaderSpec& spec,
+                  ModuleHandle* module_handle) override;
 
   bool UnloadModule(ModuleHandle module_handle) override;
-  bool UnloadGpuBinary(const void *gpu_binary)
+  bool UnloadGpuBinary(const void* gpu_binary)
       EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
 
   bool Launch(Stream *stream, const ThreadDim &thread_dims,
@@ -233,7 +233,7 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   void VlogOccupancyInfo(const KernelBase &kernel, const ThreadDim &thread_dims,
                          const BlockDim &block_dims);
 
-  bool LoadModuleFromHsaco(const char *hsaco, hipModule_t *module)
+  bool LoadModuleFromHsaco(const char* hsaco, hipModule_t* module)
       EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
 
   // Guards the on-disk-module mapping.
@@ -251,7 +251,7 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
       GUARDED_BY(in_memory_modules_mu_);
 
   // HSACO Binary -> {Hip module, reference count}.
-  std::unordered_map<const void *, std::pair<hipModule_t, uint64>>
+  std::unordered_map<const void*, std::pair<hipModule_t, uint64>>
       gpu_binary_to_module_ GUARDED_BY(in_memory_modules_mu_);
 
   // Guards the launched kernel set.

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -14,7 +14,8 @@ def if_rocm(if_true, if_false = []):
 
 def rocm_default_copts():
     """Default options for all ROCm compilations."""
-    return if_rocm(["-x", "rocm"] + %{rocm_extra_copts})
+    return if_rocm(["-x", "rocm", "-DTENSORFLOW_USE_ROCM=1"] + %{rocm_extra_copts})
+
 
 
 def rocm_is_configured():


### PR DESCRIPTION
Changes include 
1. Changes to load/unload/compile test case objects as HSACO modules
2. Test case changes to invoke ROCM functionality 

Following tests pass
//tensorflow/compiler/xla/tests:llvm_compiler_test
//tensorflow/compiler/xla/tests:constants_test_gpu - ConstantsTest.Empty_3x0x2, ConstantsTest.Empty_0x2

Several other test progress but run into issue with D2D copy 
