### PR TITLE
build RCCL as part of overall build

### DIFF
--- a/tensorflow/contrib/rccl/BUILD
+++ b/tensorflow/contrib/rccl/BUILD
@@ -49,7 +49,7 @@ tf_kernel_library(
     deps = if_rocm_is_configured([
         "//tensorflow/core:gpu_headers_lib",
         "//tensorflow/core:core_cpu_lib",
-        "@local_config_rocm//rocm:rccl",
+        "@rccl_archive//:rccl",
     ]),
     alwayslink = 1,
 )
@@ -66,7 +66,7 @@ tf_custom_op_library(
     deps = if_rocm_is_configured([
         "//tensorflow/core:gpu_headers_lib",
         "//tensorflow/core:core_cpu_lib",
-        "@local_config_rocm//rocm:rccl",
+        "@rccl_archive//:rccl",
     ]),
 )
 
@@ -123,7 +123,7 @@ tf_gpu_cc_test(
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",
-        "@local_config_rocm//rocm:rccl",
+        "@rccl_archive//:rccl",
     ]),
 )
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -80,17 +80,6 @@ ENV PATH="$OPENCL_ROOT/bin:${PATH}"
 RUN cd $HOME && git clone -b roc-1.9.x-reinit https://github.com/whchung/HIP.git
 RUN cd $HOME/HIP && mkdir build && cd build && cmake .. && make -j$(nproc) package && dpkg -i *.deb
 
-# Install RCCL
-RUN cd ~ && \
-git clone https://github.com/ROCmSoftwarePlatform/rccl.git && \
-mkdir rccl_build && \
-cd rccl_build && \
-CXX=/opt/rocm/bin/hcc cmake ../rccl && \
-make package && \
-dpkg -i *.deb && \
-cd ~ && \
-rm -rf rccl
-
 # Add target file to help determine which device(s) to build for
 RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -902,6 +902,17 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
         ],
     )
 
+    tf_http_archive(
+        name = "rccl_archive",
+        build_file = clean_dep("//third_party:rccl.BUILD"),
+        sha256 = "eb6d03bab3a4dfac68e7c85349a7bd9110ebead830f418008dc02cafae009a11",
+        strip_prefix = "rccl-0.6.0-rc1",
+        urls = [
+            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rccl/archive/0.6.0-rc1.tar.gz",
+            "https://github.com/ROCmSoftwarePlatform/rccl/archive/0.6.0-rc1.tar.gz",
+        ],
+    )
+
     ##############################################################################
     # BIND DEFINITIONS
     #

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -84,18 +84,6 @@ cc_library(
 )
 
 cc_library(
-    name = "rccl",
-    srcs = ["rocm/lib/%{rccl_lib}"],
-    data = ["rocm/lib/%{rccl_lib}"],
-    includes = [
-        ".",
-        "rocm/include",
-    ],
-    linkstatic = 1,
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
     name = "rocm",
     visibility = ["//visibility:public"],
     deps = [

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -188,9 +188,6 @@ def _rocm_include_path(repository_ctx, rocm_config):
     inc_dirs.append("/opt/rocm/hcc/compiler/lib/clang/8.0.0/include/")
     inc_dirs.append("/opt/rocm/hcc/lib/clang/8.0.0/include")
 
-    # Add RCCL headers
-    inc_dirs.append("/opt/rocm/rccl/include")
-
     inc_entries = []
     for inc_dir in inc_dirs:
         inc_entries.append("  cxx_builtin_include_directory: \"%s\"" % inc_dir)
@@ -395,12 +392,6 @@ def _find_libs(repository_ctx, rocm_config):
             cpu_value,
             rocm_config.rocm_toolkit_path + "/miopen",
         ),
-        "rccl": _find_rocm_lib(
-            "rccl",
-            repository_ctx,
-            cpu_value,
-            rocm_config.rocm_toolkit_path + "/rccl",
-        ),
     }
 
 def _get_rocm_config(repository_ctx):
@@ -483,7 +474,6 @@ def _create_dummy_repository(repository_ctx):
             "%{hip_lib}": _lib_name("hip", cpu_value),
             "%{rocblas_lib}": _lib_name("rocblas", cpu_value),
             "%{miopen_lib}": _lib_name("miopen", cpu_value),
-            "%{rccl_lib}": _lib_name("rccl", cpu_value),
             "%{rocfft_lib}": _lib_name("rocfft", cpu_value),
             "%{hiprand_lib}": _lib_name("hiprand", cpu_value),
             "%{rocm_include_genrules}": "",
@@ -713,7 +703,6 @@ def _create_local_rocm_repository(repository_ctx):
             "%{rocfft_lib}": rocm_libs["rocfft"].file_name,
             "%{hiprand_lib}": rocm_libs["hiprand"].file_name,
             "%{miopen_lib}": rocm_libs["miopen"].file_name,
-            "%{rccl_lib}": rocm_libs["rccl"].file_name,
             "%{rocm_include_genrules}": "\n".join(genrules),
             "%{rocm_headers}": ('":rocm-include",\n' +
                                 '":rocfft-include",\n' +

--- a/third_party/rccl.BUILD
+++ b/third_party/rccl.BUILD
@@ -1,0 +1,27 @@
+# AMD rccl
+# A package of optimized primitives for collective multi-GPU communication.
+
+licenses(["notice"])  # BSD
+
+exports_files(["LICENSE"])
+
+load("@local_config_rocm//rocm:build_defs.bzl", "rocm_default_copts", "if_rocm")
+
+cc_library(
+    name = "rccl",
+    srcs = if_rocm(glob(["src/*.cpp"]) + glob(["src/*.h"])),
+    hdrs = if_rocm(["inc/rccl/rccl.h"]),
+    copts = [
+        "-Iexternal/rccl_archive/src",
+        "-Iexternal/rccl_archive/inc",
+        "-O3",
+    ] + rocm_default_copts(),
+    linkopts = select({
+        "//conditions:default": [
+            "-lrt",
+        ],
+    }),
+    strip_include_prefix = "inc",
+    visibility = ["//visibility:public"],
+    deps = ["@local_config_rocm//rocm:rocm_headers"],
+)


### PR DESCRIPTION
Instead of assuming RCCL is packaged with ROCm, the RCCL sources are fetched and built as part of the local workspace.