### PR TITLE
Re-enable MaxPoolGrad and MaxPoolGradV2 on ROCm

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/pooling_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/pooling_ops.cc
@@ -358,15 +358,11 @@ class MaxPool2DGradOp : public MaxPoolGradOp {
                 errors::InvalidArgument("Invalid data format"));
   }
 };
-// disable MaxPoolGrad and MaxPoolGradV2 on ROCm to avoid a limitation imposed
-// by LLVM AMDGPU compiler for LLVM ptrtoint and inttoptr IRs
-#if !TENSORFLOW_USE_ROCM
 REGISTER_XLA_OP(Name("MaxPoolGrad"), MaxPool2DGradOp);
 REGISTER_XLA_OP(Name("MaxPoolGradV2")
                     .CompileTimeConstInput("ksize")
                     .CompileTimeConstInput("strides"),
                 MaxPool2DGradOp);
-#endif
 
 class MaxPool3DGradOp : public MaxPoolGradOp {
  public:


### PR DESCRIPTION
Fixed atomic CAS fp16 IR emitter on AMD GPU.