### PR TITLE
Fixes for unit test fails

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -95,7 +95,7 @@ limitations under the License.
 namespace xla {
 namespace gpu {
 
-/* static */ const char* AMDGPUCompiler::kTargetTriple = "amdgcn--amdhsa-amdgiz";
+/* static */ const char* AMDGPUCompiler::kTargetTriple = "amdgcn-amd-amdhsa";
 /* static */ const char* AMDGPUCompiler::kDataLayout =
          "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-p4:32:32-p5:32:32"
          "-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128"

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -990,10 +990,8 @@ Status IrEmitterUnnested::EmitColumnReduction(
 
     llvm::BasicBlock& entry_bb = b_.GetInsertBlock()->getParent()->getEntryBlock();
     auto entry_ip = entry_bb.begin();
-
     for (int i = 0; i != num_reduces; ++i) {
       for (int x_offset = 0; x_offset < kTileWidth; ++x_offset) {
-
         auto old_insert_ip = b_.GetInsertPoint();
         auto old_insert_bb = b_.GetInsertBlock();
         b_.SetInsertPoint(&entry_bb, entry_bb.begin());
@@ -1004,7 +1002,6 @@ Status IrEmitterUnnested::EmitColumnReduction(
         b_.SetInsertPoint(old_insert_bb, old_insert_ip);
         TF_ASSIGN_OR_RETURN(llvm::Value* const init_ir_value,
                             init_value_gens[i](IrArray::Index(index_ty)));
-        b_.SetInsertPoint(old_insert_bb, old_insert_ip);
         Store(init_ir_value, partial_reduction_result_address);
         partial_reduction_result_addresses.push_back(
             partial_reduction_result_address);
@@ -1334,24 +1331,19 @@ Status IrEmitterUnnested::EmitRowReduction(
 
     llvm::BasicBlock& entry_bb = b_.GetInsertBlock()->getParent()->getEntryBlock();
     auto entry_ip = entry_bb.begin();
-
     for (int i = 0; i != num_reduces; ++i) {
       auto old_insert_ip = b_.GetInsertPoint();
       auto old_insert_bb = b_.GetInsertBlock();
       b_.SetInsertPoint(&entry_bb, entry_bb.begin());
-
       llvm::Value* partial_reduction_result_address =
           Alloca(element_ir_type, /*ArraySize=*/nullptr,
                  "partial_reduction_result." + llvm::Twine(i));
-      
       b_.SetInsertPoint(old_insert_bb, old_insert_ip);
-
       TF_ASSIGN_OR_RETURN(llvm::Value* const init_ir_value,
                           init_value_gens[i](IrArray::Index(index_ty)));
       Store(init_ir_value, partial_reduction_result_address);
       partial_reduction_result_addresses.push_back(
           partial_reduction_result_address);
-    
     }
     llvm::Value* z_tile = tile_index[0];
     llvm::Value* y = tile_index[1];

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -993,14 +993,15 @@ Status IrEmitterUnnested::EmitColumnReduction(
 
     for (int i = 0; i != num_reduces; ++i) {
       for (int x_offset = 0; x_offset < kTileWidth; ++x_offset) {
+
         auto old_insert_ip = b_.GetInsertPoint();
         auto old_insert_bb = b_.GetInsertBlock();
-        b_.SetInsertPoint(&entry_bb, entry_ip);
-
+        b_.SetInsertPoint(&entry_bb, entry_bb.begin());
         llvm::Value* partial_reduction_result_address =
             Alloca(element_ir_type, /*ArraySize=*/nullptr,
                    "partial_reduction_result." +
                        llvm::Twine(i * kTileWidth + x_offset));
+        b_.SetInsertPoint(old_insert_bb, old_insert_ip);
         TF_ASSIGN_OR_RETURN(llvm::Value* const init_ir_value,
                             init_value_gens[i](IrArray::Index(index_ty)));
         b_.SetInsertPoint(old_insert_bb, old_insert_ip);
@@ -1337,19 +1338,21 @@ Status IrEmitterUnnested::EmitRowReduction(
     for (int i = 0; i != num_reduces; ++i) {
       auto old_insert_ip = b_.GetInsertPoint();
       auto old_insert_bb = b_.GetInsertBlock();
-      b_.SetInsertPoint(&entry_bb, entry_ip);
+      b_.SetInsertPoint(&entry_bb, entry_bb.begin());
 
       llvm::Value* partial_reduction_result_address =
           Alloca(element_ir_type, /*ArraySize=*/nullptr,
                  "partial_reduction_result." + llvm::Twine(i));
+      
+      b_.SetInsertPoint(old_insert_bb, old_insert_ip);
+
       TF_ASSIGN_OR_RETURN(llvm::Value* const init_ir_value,
                           init_value_gens[i](IrArray::Index(index_ty)));
-      b_.SetInsertPoint(old_insert_bb, old_insert_ip);
       Store(init_ir_value, partial_reduction_result_address);
       partial_reduction_result_addresses.push_back(
           partial_reduction_result_address);
+    
     }
-
     llvm::Value* z_tile = tile_index[0];
     llvm::Value* y = tile_index[1];
     llvm::Value* x_tile = tile_index[2];

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/amdgpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/amdgpu_backend_lib.cc
@@ -254,19 +254,19 @@ std::vector<uint8> EmitModuleToHsaco(Module* module, llvm::TargetMachine* target
   // get creative to add a suffix.
   string module_id(llvm_ir::AsString(module->getModuleIdentifier()));
   IrDumpingPassManager codegen_passes(
-        ReplaceFilenameExtension(tensorflow::io::Basename(module_id),
-                                 "-amdgpu.dummy"),
-                                 "", false);
+      ReplaceFilenameExtension(tensorflow::io::Basename(module_id),
+                               "-amdgpu.dummy"),
+                               "", false);
   codegen_passes.add(new llvm::TargetLibraryInfoWrapperPass(
-                     llvm::Triple(module->getTargetTriple())));
+      llvm::Triple(module->getTargetTriple())));
   llvm::SmallVector<char, 0> stream;
   llvm::raw_svector_ostream pstream(stream);
-  std::unique_ptr<llvm::raw_fd_ostream> isabin_fs(new llvm::raw_fd_ostream(isabin_path, ec, llvm::sys::fs::F_Text));
+  std::unique_ptr<llvm::raw_fd_ostream> isabin_fs(
+      new llvm::raw_fd_ostream(isabin_path, ec, llvm::sys::fs::F_Text));
   target_machine->addPassesToEmitFile(codegen_passes, *isabin_fs, nullptr,
                                       llvm::TargetMachine::CGFT_ObjectFile);
   codegen_passes.run(*module);
   isabin_fs->flush();
-
 
   auto lld_program = llvm::sys::findProgramByName("ld.lld");
   if (!lld_program) {
@@ -281,7 +281,7 @@ std::vector<uint8> EmitModuleToHsaco(Module* module, llvm::TargetMachine* target
     llvm_ir::AsStringRef("isabin_path"),
     llvm_ir::AsStringRef("-o"),
     llvm_ir::AsStringRef("hsaco_path"),
- };
+  };
   if (inject_isa) {
     lld_args[4] = llvm_ir::AsStringRef(inject_isabin_path.c_str());
   } else {

--- a/tensorflow/compiler/xla/tests/llvm_compiler_test.cc
+++ b/tensorflow/compiler/xla/tests/llvm_compiler_test.cc
@@ -18,7 +18,11 @@ limitations under the License.
 #include "tensorflow/compiler/xla/literal_util.h"
 #include "tensorflow/compiler/xla/service/backend.h"
 #include "tensorflow/compiler/xla/service/cpu/cpu_compiler.h"
-#include "tensorflow/compiler/xla/service/gpu/nvptx_compiler.h"
+#if GOOGLE_CUDA
+ #include "tensorflow/compiler/xla/service/gpu/nvptx_compiler.h"
+#elif TENSORFLOW_USE_ROCM
+ #include "tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h"
+#endif 
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/platform_util.h"
 #include "tensorflow/compiler/xla/test_helpers.h"
@@ -137,7 +141,11 @@ class CpuCompilerTest : public LLVMCompilerTest {
 
 class GpuCompilerTest : public LLVMCompilerTest {
  public:
+#if GOOGLE_CUDA
   GpuCompilerTest() : LLVMCompilerTest("CUDA") {}
+#elif TENSORFLOW_USE_ROCM
+  GpuCompilerTest() : LLVMCompilerTest("ROCM") {}
+#endif 
 };
 
 TEST_F(CpuCompilerTest, HooksTest) {
@@ -146,7 +154,11 @@ TEST_F(CpuCompilerTest, HooksTest) {
 }
 
 TEST_F(GpuCompilerTest, HooksTest) {
+#if GOOGLE_CUDA 
   gpu::NVPTXCompiler compiler;
+#elif TENSORFLOW_USE_ROCM
+  gpu::AMDGPUCompiler compiler;
+#endif 
   TestCompilerHooks(&compiler);
 }
 
@@ -156,7 +168,11 @@ TEST_F(CpuCompilerTest, MultiModuleCompilation) {
 }
 
 TEST_F(GpuCompilerTest, MultModuleCompilation) {
+#if GOOGLE_CUDA 
   gpu::NVPTXCompiler compiler;
+#elif TENSORFLOW_USE_ROCM
+  gpu::AMDGPUCompiler compiler;
+#endif 
   TestMultiModuleCompilation(&compiler);
 }
 }  // namespace

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.h
@@ -60,6 +60,13 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   bool GetKernel(const MultiKernelLoaderSpec &spec,
                  KernelBase *kernel) override;
 
+  bool LoadModule(const MultiModuleLoaderSpec &spec,
+                  ModuleHandle *module_handle) override;
+
+  bool UnloadModule(ModuleHandle module_handle) override;
+  bool UnloadGpuBinary(const void *gpu_binary)
+      EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
+
   bool Launch(Stream *stream, const ThreadDim &thread_dims,
               const BlockDim &block_dims, const KernelBase &k,
               const KernelArgsArrayBase &args) override;
@@ -226,6 +233,9 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
   void VlogOccupancyInfo(const KernelBase &kernel, const ThreadDim &thread_dims,
                          const BlockDim &block_dims);
 
+  bool LoadModuleFromHsaco(const char *hsaco, hipModule_t *module)
+      EXCLUSIVE_LOCKS_REQUIRED(in_memory_modules_mu_);
+
   // Guards the on-disk-module mapping.
   mutex disk_modules_mu_;
 
@@ -239,6 +249,10 @@ class ROCMExecutor : public internal::StreamExecutorInterface {
 
   std::map<const char *, hipModule_t> in_memory_modules_
       GUARDED_BY(in_memory_modules_mu_);
+
+  // HSACO Binary -> {Hip module, reference count}.
+  std::unordered_map<const void *, std::pair<hipModule_t, uint64>>
+      gpu_binary_to_module_ GUARDED_BY(in_memory_modules_mu_);
 
   // Guards the launched kernel set.
   mutex launched_kernels_mu_;

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -14,7 +14,8 @@ def if_rocm(if_true, if_false = []):
 
 def rocm_default_copts():
     """Default options for all ROCm compilations."""
-    return if_rocm(["-x", "rocm"] + %{rocm_extra_copts})
+    return if_rocm(["-x", "rocm", "-DTENSORFLOW_USE_ROCM=1"] + %{rocm_extra_copts})
+
 
 
 def rocm_is_configured():


### PR DESCRIPTION
Fixes include
1. Using LLVM APIs to compile to .o 
2. Load/Unload/Compile test case objects 
3. Proper insertion point for alloca/non-alloca instructions 
