### PR TITLE
Adding support for BnA, Add+Relu, AddN+ReluGrad fusions

### DIFF
--- a/tensorflow/core/graph/gpu_fusion_pass.cc
+++ b/tensorflow/core/graph/gpu_fusion_pass.cc
@@ -57,9 +57,12 @@ const OptimizationPassRegistry::Grouping kROCmFusionPassGrouping =
         : OptimizationPassRegistry::POST_PARTITIONING;
 
 // attribute name strings
+const char* kAttr_N = "N";
 const char* kAttr_T = "T";
 const char* kAttr_U = "U";
+
 const char* kAttr_activation_mode = "activation_mode";
+const char* kAttr_bop_type = "bop_type";
 const char* kAttr_data_format = "data_format";
 const char* kAttr_dilations = "dilations";
 const char* kAttr_epsilon = "epsilon";
@@ -164,6 +167,26 @@ inline bool isOpActivation(const Node* n) {
 inline bool isOpBatchNorm(const Node* n) {
   return ((n->type_string() == "FusedBatchNorm") ||
           (n->type_string() == "FusedBatchNormV2"));
+}
+
+// is this node an instance of the "Add" op?
+inline bool isOpAdd(const Node* n) { return (n->type_string() == "Add"); }
+
+// is this node an instance of the "AddN" op?
+inline bool isOpAddN(const Node* n) { return (n->type_string() == "AddN"); }
+
+// is this node an instance of the "Relu" op?
+inline bool isOpRelu(const Node* n) { return (n->type_string() == "Relu"); }
+
+// is this node an instance of the "Relu" op or the "_ROCmFusedAddRelu" op?
+inline bool isOpReluOrFusedAddRelu(const Node* n) {
+  return ((n->type_string() == "Relu") ||
+          (n->type_string() == "_ROCmFusedAddRelu"));
+}
+
+// is this node an instance of the "ReluGrad" op?
+inline bool isOpReluGrad(const Node* n) {
+  return (n->type_string() == "ReluGrad");
 }
 // Util routines - End
 
@@ -301,6 +324,58 @@ class ROCmFusionOpBatchNormActivation : public ROCmFusionOpBase {
 
 //----------------------------------------------------------------------
 
+// Add-Relu Fusion
+class ROCmFusionOpAddRelu : public ROCmFusionOpBase {
+ public:
+  ROCmFusionOpAddRelu(Graph* g, std::set<const Node*>& fn)
+      : ROCmFusionOpBase(g, fn) {}
+
+  // routine to (maybe) do fusion on the given node (+ the nodes preceding
+  // it). will return true if fusion was done, false otherwise
+  bool DoFusion(const Node* n) override;
+
+ protected:
+  struct FusionData {
+    const Node* add;
+    const Node* relu;
+
+    DataType data_type;
+  };
+
+  bool IsFusionEligible(const Node* n, FusionData* d);
+
+  void CreateFusionOp(const FusionData* d);
+};
+
+//----------------------------------------------------------------------
+
+// AddN-Relu-ReluGrad Fusion
+class ROCmFusionOpAddNReluGrad : public ROCmFusionOpBase {
+ public:
+  ROCmFusionOpAddNReluGrad(Graph* g, std::set<const Node*>& fn)
+      : ROCmFusionOpBase(g, fn) {}
+
+  // routine to (maybe) do fusion on the given node (+ the nodes preceding
+  // it). will return true if fusion was done, false otherwise
+  bool DoFusion(const Node* n) override;
+
+ protected:
+  struct FusionData {
+    const Node* addN;
+    const Node* relu;
+    const Node* reluGrad;
+
+    DataType data_type;
+    int num_addN_inputs;
+  };
+
+  bool IsFusionEligible(const Node* n, FusionData* d);
+
+  void CreateFusionOp(const FusionData* d);
+};
+
+//----------------------------------------------------------------------
+
 Status ROCmFusionPass::Run(const GraphOptimizationPassOptions& options) {
   // enable the fusion pass if the env var TF_ROCM_FUSION_ENABLE is set
   const char* enable_fusion = getenv("TF_ROCM_FUSION_ENABLE");
@@ -388,6 +463,8 @@ void ROCmFusionPass::InitializeFusions(
   fusions.emplace_back(
       new ROCmFusionOpConvolutionBiasActivation(g, fused_nodes));
   fusions.emplace_back(new ROCmFusionOpBatchNormActivation(g, fused_nodes));
+  fusions.emplace_back(new ROCmFusionOpAddRelu(g, fused_nodes));
+  fusions.emplace_back(new ROCmFusionOpAddNReluGrad(g, fused_nodes));
 }
 
 //----------------------------------------------------------------------
@@ -956,6 +1033,348 @@ void ROCmFusionOpBatchNormActivation::CreateFusionOp(const FusionData* d) {
   graph_->RemoveNode(const_cast<Node*>(d->norm));
   graph_->RemoveNode(const_cast<Node*>(d->actv));
 }
+//----------------------------------------------------------------------
+
+// ----------------------------------------------
+// ROCmFusionOpAddRelu implementation
+// ----------------------------------------------
+
+bool ROCmFusionOpAddRelu::DoFusion(const Node* n2) {
+  bool did_fusion = false;
+  FusionData d;
+  if (IsFusionEligible(n2, &d)) {
+    CreateFusionOp(&d);
+    did_fusion = true;
+  }
+  return did_fusion;
+}
+
+bool ROCmFusionOpAddRelu::IsFusionEligible(const Node* n2, FusionData* d) {
+  bool is_eligible = false;
+
+  // First check whether we have the right sequence of ops
+  if (isOpRelu(n2)) {  // "Relu" node
+    Node* n1 = nullptr;
+    TF_CHECK_OK(n2->input_node(0, &n1));
+    if (isOpAdd(n1)) {  // preceded by a "Add" op
+      d->add = n1;
+      d->relu = n2;
+
+      DumpNodeList(kVlogLevel,
+                   "Found Fusion Candidate Add+Relu: ", {d->add, d->relu});
+
+      is_eligible = true;
+    }
+  }
+
+  // ensure all the nodes are placed on the same GPU
+  if (is_eligible && !areAssignedToSameGpu({d->add, d->relu})) {
+    is_eligible = false;
+  }
+
+  // Next check if the first output of add node feeds a node other then
+  // the activation node
+  if (is_eligible) {
+    for (const Edge* e : d->add->out_edges()) {
+      if ((e->src_output() == 0) && (e->dst() != d->relu)) {
+        VLOG(kVlogLevel) << "\tSkipping Fusion : "
+                         << "Output from Add also feeds node other then Relu : "
+                         << e->dst()->name();
+        VLOG(kVlogLevel) << "===========";
+        is_eligible = false;
+        break;
+      }
+    }
+  }
+
+  // Next check if the datatype(s) are supported
+  if (is_eligible) {
+    is_eligible = false;
+
+    DataType T_add, T_relu;
+    TF_CHECK_OK(GetNodeAttr(d->add->def(), kAttr_T, &T_add));
+    TF_CHECK_OK(GetNodeAttr(d->relu->def(), kAttr_T, &T_relu));
+
+    // only float type is supported for now
+    if ((T_add == DT_FLOAT) || (T_add == DT_HALF)) {
+      // datatype for add and relu must match
+      if (T_add == T_relu) {
+        d->data_type = T_add;
+        is_eligible = true;
+      } else {
+        VLOG(kVlogLevel) << "\tSkipping Fusion : "
+                         << "\t DataTypes not matching : "
+                         << " " << DataType_Name(T_add) << " "
+                         << DataType_Name(T_relu);
+        VLOG(kVlogLevel) << "===========";
+      }
+    } else {
+      VLOG(kVlogLevel) << "\tSkipping Fusion : "
+                       << " DataType not supported : " << DataType_Name(T_add);
+      VLOG(kVlogLevel) << "===========";
+    }
+  }
+
+  return is_eligible;
+}
+
+void ROCmFusionOpAddRelu::CreateFusionOp(const FusionData* d) {
+  std::vector<const Edge*> add_input_edges;
+  TF_CHECK_OK(d->add->input_edges(&add_input_edges));
+
+  // create an instance of the fusion node
+  string op_name = strings::StrCat(d->add->name(), d->relu->name());
+
+  NodeBuilder nb(op_name, "_ROCmFusedAddRelu");
+
+  // populate input data edges
+
+  // add x
+  nb.Input(add_input_edges[0]->src(), add_input_edges[0]->src_output());
+  // add y
+  nb.Input(add_input_edges[1]->src(), add_input_edges[1]->src_output());
+
+  // populate attributes
+  nb.Attr(kAttr_T, d->data_type);
+
+  // populate the device
+  nb.Device(d->add->def().device());
+
+  // create the new fusion node
+  Node* fusion_node = nullptr;
+  TF_CHECK_OK(nb.Finalize(graph_, &fusion_node));
+
+  // populate the input control edges
+  for (const Edge* e : d->add->in_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    }
+  }
+  for (const Edge* e : d->relu->in_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    }
+  }
+
+  // populate output data and control edges
+  for (const Edge* e : d->add->out_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    }
+  }
+  for (const Edge* e : d->relu->out_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    } else {
+      CHECK_NOTNULL(graph_->AddEdge(fusion_node, 0, e->dst(), e->dst_input()));
+    }
+  }
+
+  // populate the device placement
+  fusion_node->set_assigned_device_name(d->add->assigned_device_name());
+
+  VLOG(kVlogLevel) << "\tCreated Add+Relu Fusion Node: " << fusion_node;
+  VLOG(kVlogLevel) << "===========";
+
+  // add the now redundant nodes to the set of fused nodes
+  fused_nodes_.insert(d->add);
+  fused_nodes_.insert(d->relu);
+
+  // and remove them from the graph
+  graph_->RemoveNode(const_cast<Node*>(d->add));
+  graph_->RemoveNode(const_cast<Node*>(d->relu));
+}
+
+//----------------------------------------------------------------------
+
+// ----------------------------------------------
+// ROCmFusionOpAddNReluGrad implementation
+// ----------------------------------------------
+
+bool ROCmFusionOpAddNReluGrad::DoFusion(const Node* n2) {
+  bool did_fusion = false;
+  FusionData d;
+  if (IsFusionEligible(n2, &d)) {
+    CreateFusionOp(&d);
+    did_fusion = true;
+  }
+  return did_fusion;
+}
+
+bool ROCmFusionOpAddNReluGrad::IsFusionEligible(const Node* n2, FusionData* d) {
+  bool is_eligible = false;
+
+  // First check whether we have the right sequence of ops
+  if (isOpReluGrad(n2)) {  // "ReluGrad" node
+
+    Node* n1_1 = nullptr;
+    TF_CHECK_OK(n2->input_node(0, &n1_1));
+
+    Node* n1_2 = nullptr;
+    TF_CHECK_OK(n2->input_node(1, &n1_2));
+
+    // VLOG(kVlogLevel) << "===========";
+    // DumpNodeList(kVlogLevel, "ReluGrad Inputs: ",
+    // 		 {n1_1, n1_2});
+    // VLOG(kVlogLevel) << "===========";
+
+    if (isOpAddN(n1_1) && isOpReluOrFusedAddRelu(n1_2)) {
+      // preceded by "AddN" and "Relu"/"_ROCmFusedAddRelu" Ops
+
+      d->addN = n1_1;
+      d->relu = n1_2;
+      d->reluGrad = n2;
+
+      DumpNodeList(kVlogLevel, "Found Fusion Candidate AddN+ReluGrad : ",
+                   {d->addN, d->reluGrad});
+
+      is_eligible = true;
+    }
+  }
+
+  // ensure all the nodes are placed on the same GPU
+  if (is_eligible && !areAssignedToSameGpu({d->addN, d->relu, d->reluGrad})) {
+    is_eligible = false;
+  }
+
+  // Next check if the first output of addN node feeds a node other then
+  // the activation node
+  if (is_eligible) {
+    for (const Edge* e : d->addN->out_edges()) {
+      if ((e->src_output() == 0) && (e->dst() != d->reluGrad)) {
+        VLOG(kVlogLevel)
+            << "\tSkipping Fusion : "
+            << "Output from AddN also feeds node other then ReluGrad : "
+            << e->dst()->name();
+        VLOG(kVlogLevel) << "===========";
+        is_eligible = false;
+        break;
+      }
+    }
+  }
+
+  // Next check if the datatype(s) are supported
+  if (is_eligible) {
+    is_eligible = false;
+
+    DataType T_addN, T_relu, T_reluGrad;
+    TF_CHECK_OK(GetNodeAttr(d->addN->def(), kAttr_T, &T_addN));
+    TF_CHECK_OK(GetNodeAttr(d->relu->def(), kAttr_T, &T_relu));
+    TF_CHECK_OK(GetNodeAttr(d->reluGrad->def(), kAttr_T, &T_reluGrad));
+
+    // only float type is supported for now
+    if ((T_addN == DT_FLOAT) || (T_addN == DT_HALF)) {
+      // datatype for binary-op and activation must match
+      if ((T_addN == T_relu) && (T_addN == T_reluGrad)) {
+        d->data_type = T_addN;
+        is_eligible = true;
+      } else {
+        VLOG(kVlogLevel) << "\tSkipping Fusion : "
+                         << "\t DataTypes not matching : "
+                         << " " << DataType_Name(T_addN) << " "
+                         << DataType_Name(T_relu) << " "
+                         << DataType_Name(T_reluGrad);
+        VLOG(kVlogLevel) << "===========";
+      }
+    } else {
+      VLOG(kVlogLevel) << "\tSkipping Fusion : "
+                       << " DataType not supported : " << DataType_Name(T_addN);
+      VLOG(kVlogLevel) << "===========";
+    }
+  }
+
+  // scan in the number of inputs to the AddN node
+  if (is_eligible) {
+    TF_CHECK_OK(GetNodeAttr(d->addN->def(), kAttr_N, &d->num_addN_inputs));
+    if (d->num_addN_inputs != 2) {
+      VLOG(kVlogLevel) << "\tSkipping Fusion : "
+                       << " AddN node has unsupported N value : "
+                       << d->num_addN_inputs;
+      VLOG(kVlogLevel) << "===========";
+    }
+  }
+
+  return is_eligible;
+}
+
+void ROCmFusionOpAddNReluGrad::CreateFusionOp(const FusionData* d) {
+  std::vector<const Edge*> addN_input_edges;
+  TF_CHECK_OK(d->addN->input_edges(&addN_input_edges));
+
+  std::vector<const Edge*> reluGrad_input_edges;
+  TF_CHECK_OK(d->reluGrad->input_edges(&reluGrad_input_edges));
+
+  // create an instance of the fusion node
+  string op_name = strings::StrCat(d->addN->name(), d->reluGrad->name());
+
+  NodeBuilder nb(op_name, "_ROCmFusedAddNReluGrad");
+
+  // populate input data edges
+
+  // add addN inputs
+  std::vector<NodeBuilder::NodeOut> addN_inputs;
+  for (const Edge* e : addN_input_edges) {
+    addN_inputs.push_back(NodeBuilder::NodeOut(e->src(), e->src_output()));
+  }
+  nb.Input(addN_inputs);
+
+  // add the relu output
+  CHECK_EQ(reluGrad_input_edges[1]->src(), d->relu);
+  nb.Input(reluGrad_input_edges[1]->src(),
+           reluGrad_input_edges[1]->src_output());
+
+  // populate attributes
+  nb.Attr(kAttr_T, d->data_type);
+  nb.Attr(kAttr_N, d->num_addN_inputs);
+
+  // populate the device
+  nb.Device(d->addN->def().device());
+
+  // create the new fusion node
+  Node* fusion_node = nullptr;
+  TF_CHECK_OK(nb.Finalize(graph_, &fusion_node));
+
+  // populate the input control edges
+  for (const Edge* e : d->addN->in_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    }
+  }
+  for (const Edge* e : d->reluGrad->in_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    }
+  }
+
+  // populate output data and control edges
+  for (const Edge* e : d->addN->out_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    }
+  }
+  for (const Edge* e : d->reluGrad->out_edges()) {
+    if (e->IsControlEdge()) {
+      CHECK_NOTNULL(graph_->AddControlEdge(e->src(), fusion_node, true));
+    } else {
+      CHECK_NOTNULL(graph_->AddEdge(fusion_node, 0, e->dst(), e->dst_input()));
+    }
+  }
+
+  // populate the device placement
+  fusion_node->set_assigned_device_name(d->addN->assigned_device_name());
+
+  VLOG(kVlogLevel) << "\tCreated AddN+ReluGrad Fusion Node: " << fusion_node;
+  VLOG(kVlogLevel) << "===========";
+
+  // add the now redundant nodes to the set of fused nodes
+  fused_nodes_.insert(d->addN);
+  fused_nodes_.insert(d->reluGrad);
+
+  // and remove them from the graph
+  graph_->RemoveNode(const_cast<Node*>(d->addN));
+  graph_->RemoveNode(const_cast<Node*>(d->reluGrad));
+}
+
 //----------------------------------------------------------------------
 
 }  // namespace gpu_fusion_pass

--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -76,7 +76,8 @@ std::set<string> GetOpsFormatSupported() {
       "MaxPoolGradV2",
       "MaxPoolGradGradV2",
       "SpaceToDepth",
-      "DepthToSpace"};
+      "DepthToSpace",
+      "_ROCmFusedConvolutionBiasActivation"};
   return ops_format_supported;
 }
 

--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -77,7 +77,10 @@ std::set<string> GetOpsFormatSupported() {
       "MaxPoolGradGradV2",
       "SpaceToDepth",
       "DepthToSpace",
-      "_ROCmFusedConvolutionBiasActivation"};
+      "_ROCmFusedConvolutionBiasActivation",
+      "_ROCmFusedBatchNormActivationInference",
+      "_ROCmFusedBatchNormActivationTraining",
+  };
   return ops_format_supported;
 }
 

--- a/tensorflow/core/kernels/gpu_fusion_ops.h
+++ b/tensorflow/core/kernels/gpu_fusion_ops.h
@@ -18,12 +18,31 @@ limitations under the License.
 
 #ifdef TENSORFLOW_USE_ROCM
 
+#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/util/activation_mode.h"
 
 namespace tensorflow {
 
 se::dnn::ActivationMode GetDnnActivationMode(ActivationMode activation_mode);
+
+namespace rocm_kernels {
+
+void FusionAddRelu(OpKernelContext* ctx, const float* in0, const float* in1,
+                   float* out, unsigned N);
+
+void FusionAddRelu(OpKernelContext* ctx, const Eigen::half* in0,
+                   const Eigen::half* in1, Eigen::half* out, unsigned N);
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const float* in0,
+                        const float* in1, const float* in2, float* out,
+                        unsigned N);
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const Eigen::half* in0,
+                        const Eigen::half* in1, const Eigen::half* in2,
+                        Eigen::half* out, unsigned N);
+
+}  // namespace rocm_kernels
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/gpu_fusion_ops_batchnormactv.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_batchnormactv.cc
@@ -1,0 +1,208 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include <string.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_slice.h"
+
+#include "tensorflow/core/kernels/conv_2d.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/gpu_fusion_ops.h"
+
+#include "tensorflow/core/util/activation_mode.h"
+#include "tensorflow/core/util/padding.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+#include "tensorflow/core/platform/stream_executor.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename Device, typename T>
+class ROCmFusionKernelBatchNormActivationInference : public OpKernel {
+ public:
+  explicit ROCmFusionKernelBatchNormActivationInference(
+      OpKernelConstruction* ctx)
+      : OpKernel(ctx) {
+    float epsilon;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("epsilon", &epsilon));
+    epsilon_ = epsilon;
+
+    string data_format_str;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("data_format", &data_format_str));
+    OP_REQUIRES(ctx, FormatFromString(data_format_str, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+
+    string activation_mode_str;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("activation_mode", &activation_mode_str));
+    OP_REQUIRES_OK(ctx, GetActivationModeFromString(activation_mode_str,
+                                                    &activation_mode_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& x = ctx->input(0);
+    const Tensor& scale = ctx->input(1);
+    const Tensor& offset = ctx->input(2);
+    const Tensor& mean = ctx->input(3);
+    const Tensor& variance = ctx->input(4);
+
+    OP_REQUIRES(ctx, x.dims() == 4,
+                errors::InvalidArgument("input must be 4-dimensional",
+                                        x.shape().DebugString()));
+    OP_REQUIRES(ctx, scale.dims() == 1,
+                errors::InvalidArgument("scale must be 1-dimensional",
+                                        scale.shape().DebugString()));
+    OP_REQUIRES(ctx, offset.dims() == 1,
+                errors::InvalidArgument("offset must be 1-dimensional",
+                                        offset.shape().DebugString()));
+    OP_REQUIRES(ctx, mean.dims() == 1,
+                errors::InvalidArgument("mean must be 1-dimensional",
+                                        mean.shape().DebugString()));
+    OP_REQUIRES(ctx, variance.dims() == 1,
+                errors::InvalidArgument("variance must be 1-dimensional",
+                                        variance.shape().DebugString()));
+
+    Tensor* y = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, x.shape(), &y));
+
+    const int64 batch_size = GetTensorDim(x, data_format_, 'N');
+    const int64 height = GetTensorDim(x, data_format_, 'H');
+    const int64 width = GetTensorDim(x, data_format_, 'W');
+    const int64 channels = GetTensorDim(x, data_format_, 'C');
+
+    if (x.shape().num_elements() != 0) {
+      Tensor fusion_input = x;
+      Tensor fusion_output = *y;
+
+      // if the data format is NHWC, we need to
+      // 1. convert the input tensor to NCHW format
+      // 2, allocate a temporary tensor to hold the fusion op output (which will
+      // be in NCHW format)
+      if (data_format_ == FORMAT_NHWC) {
+        // allocate a temporary tensor to store the NCHW input
+        Tensor transformed_input;
+        TensorShape nchw_shape_input =
+            ShapeFromFormat(FORMAT_NCHW, batch_size, height, width, channels);
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, nchw_shape_input,
+                                    &transformed_input));
+
+        // convert the input tensor to NCHW format for the GPU
+        functor::NHWCToNCHW<GPUDevice, T, 4>()(
+            ctx->eigen_device<GPUDevice>(),
+            const_cast<const Tensor&>(fusion_input).tensor<T, 4>(),
+            transformed_input.tensor<T, 4>());
+
+        fusion_input = transformed_input;
+
+        // allocate a temporary tensor to store the NCHW output
+        Tensor transformed_output;
+        TensorShape nchw_shape_output =
+            ShapeFromFormat(FORMAT_NCHW, batch_size, height, width, channels);
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, nchw_shape_output,
+                                    &transformed_output));
+
+        fusion_output = transformed_output;
+      }
+
+      se::dnn::BatchDescriptor x_desc;
+      x_desc.set_count(batch_size)
+          .set_feature_map_count(channels)
+          .set_height(height)
+          .set_width(width)
+          .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+      se::dnn::BatchDescriptor scale_offset_mean_variance_desc;
+      scale_offset_mean_variance_desc.set_count(1)
+          .set_feature_map_count(channels)
+          .set_height(1)
+          .set_width(1)
+          .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+      auto x_data = AsDeviceMemory(fusion_input.template flat<T>().data(),
+                                   fusion_input.template flat<T>().size());
+      auto scale_data = AsDeviceMemory(scale.template flat<T>().data(),
+                                       scale.template flat<T>().size());
+
+      auto offset_data = AsDeviceMemory(offset.template flat<T>().data(),
+                                        offset.template flat<T>().size());
+
+      auto mean_data = AsDeviceMemory(mean.template flat<T>().data(),
+                                      mean.template flat<T>().size());
+
+      auto variance_data = AsDeviceMemory(variance.template flat<T>().data(),
+                                          variance.template flat<T>().size());
+
+      auto dnn_activation_mode = GetDnnActivationMode(activation_mode_);
+
+      auto y_data = AsDeviceMemory(fusion_output.template flat<T>().data(),
+                                   fusion_output.template flat<T>().size());
+
+      auto* stream = ctx->op_device_context()->stream();
+
+      bool miopen_status =
+          stream
+              ->ThenFusedBatchNormActivationInference(
+                  x_desc, x_data, scale_offset_mean_variance_desc, scale_data,
+                  offset_data, mean_data, variance_data, epsilon_,
+                  dnn_activation_mode, &y_data)
+              .ok();
+
+      if (!miopen_status) {
+        ctx->SetStatus(
+            errors::Internal("MIOpen BnA (inference) FusionOp launch Failure"));
+      }
+
+      // if the data format is NHWC, we need to convert the fusion op output
+      // back to MHWC format
+      if (data_format_ == FORMAT_NHWC) {
+        functor::NCHWToNHWC<GPUDevice, T, 4>()(
+            ctx->eigen_device<GPUDevice>(),
+            const_cast<const Tensor&>(fusion_output).tensor<T, 4>(),
+            y->tensor<T, 4>());
+      }
+    }
+  }
+
+ private:
+  double epsilon_;
+  TensorFormat data_format_;
+  ActivationMode activation_mode_;
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("_ROCmFusedBatchNormActivationInference")
+        .Device(DEVICE_GPU)
+        .TypeConstraint<float>("T"),
+    ROCmFusionKernelBatchNormActivationInference<GPUDevice, float>);
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/gpu_fusion_ops_custom.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_custom.cc
@@ -1,0 +1,132 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include <string.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_slice.h"
+
+#include "tensorflow/core/kernels/conv_2d.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/gpu_fusion_ops.h"
+
+#include "tensorflow/core/util/activation_mode.h"
+#include "tensorflow/core/util/padding.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+#include "tensorflow/core/platform/stream_executor.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+//-------------------------------------------------------------------
+
+template <typename Device, typename T>
+class ROCmFusionKernelAddRelu : public OpKernel {
+ public:
+  explicit ROCmFusionKernelAddRelu(OpKernelConstruction* ctx) : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& in0 = ctx->input(0);
+    const Tensor& in1 = ctx->input(1);
+
+    Tensor* out = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, in0.shape(), &out));
+
+    auto in0_data = AsDeviceMemory(in0.template flat<T>().data(),
+                                   in0.template flat<T>().size());
+    auto in1_data = AsDeviceMemory(in1.template flat<T>().data(),
+                                   in1.template flat<T>().size());
+    auto out_data = AsDeviceMemory(out->template flat<T>().data(),
+                                   out->template flat<T>().size());
+
+    rocm_kernels::FusionAddRelu(ctx, static_cast<const T*>(in0_data.opaque()),
+                                static_cast<const T*>(in1_data.opaque()),
+                                static_cast<T*>(out_data.opaque()),
+                                in0.NumElements());
+  }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("_ROCmFusedAddRelu").Device(DEVICE_GPU).TypeConstraint<float>("T"),
+    ROCmFusionKernelAddRelu<GPUDevice, float>);
+
+REGISTER_KERNEL_BUILDER(Name("_ROCmFusedAddRelu")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::half>("T"),
+                        ROCmFusionKernelAddRelu<GPUDevice, Eigen::half>);
+
+//-------------------------------------------------------------------
+
+template <typename Device, typename T>
+class ROCmFusionKernelAddNReluGrad : public OpKernel {
+ public:
+  explicit ROCmFusionKernelAddNReluGrad(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& in0 = ctx->input(0);
+    const Tensor& in1 = ctx->input(1);
+    const Tensor& in2 = ctx->input(2);
+
+    Tensor* out = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, in2.shape(), &out));
+
+    auto in0_data = AsDeviceMemory(in0.template flat<T>().data(),
+                                   in0.template flat<T>().size());
+    auto in1_data = AsDeviceMemory(in1.template flat<T>().data(),
+                                   in1.template flat<T>().size());
+    auto in2_data = AsDeviceMemory(in2.template flat<T>().data(),
+                                   in2.template flat<T>().size());
+    auto out_data = AsDeviceMemory(out->template flat<T>().data(),
+                                   out->template flat<T>().size());
+
+    rocm_kernels::FusionAddNReluGrad(
+        ctx, static_cast<const T*>(in0_data.opaque()),
+        static_cast<const T*>(in1_data.opaque()),
+        static_cast<const T*>(in2_data.opaque()),
+        static_cast<T*>(out_data.opaque()), in0.NumElements());
+  }
+
+ private:
+};
+
+REGISTER_KERNEL_BUILDER(Name("_ROCmFusedAddNReluGrad")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<float>("T"),
+                        ROCmFusionKernelAddNReluGrad<GPUDevice, float>);
+
+REGISTER_KERNEL_BUILDER(Name("_ROCmFusedAddNReluGrad")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::half>("T"),
+                        ROCmFusionKernelAddNReluGrad<GPUDevice, Eigen::half>);
+//-------------------------------------------------------------------
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/gpu_fusion_ops_custom.cu.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_custom.cu.cc
@@ -1,0 +1,119 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/kernels/gpu_fusion_ops.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+
+#include "hip/hip_fp16.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace rocm_kernels {
+
+//-------------------------------------------------------------------
+__global__ void AddReluKernel(int nthreads, const float* in0, const float* in1,
+                              float* out) {
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    out[index] = fmaxf(0.0f, in0[index] + in1[index]);
+  }
+}
+
+void FusionAddRelu(OpKernelContext* ctx, const float* in0, const float* in1,
+                   float* out, unsigned N) {
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(N, d);
+  GPU_LAUNCH_KERNEL(AddReluKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, in0, in1, out);
+}
+
+__global__ void AddReluKernel(int nthreads, const half* in0, const half* in1,
+                              half* out) {
+  half hZero(0.0f16);
+
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    half sum = __hadd(in0[index], in1[index]);
+    out[index] = __hgt(sum, hZero) ? sum : hZero;
+  }
+}
+
+void FusionAddRelu(OpKernelContext* ctx, const Eigen::half* in0,
+                   const Eigen::half* in1, Eigen::half* out, unsigned N) {
+  const half* h_in0 = reinterpret_cast<const half*>(in0);
+  const half* h_in1 = reinterpret_cast<const half*>(in1);
+  half* h_out = reinterpret_cast<half*>(out);
+
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(N, d);
+  GPU_LAUNCH_KERNEL(AddReluKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, h_in0, h_in1, h_out);
+}
+//-------------------------------------------------------------------
+__global__ void AddNReluGradKernel(int nthreads, const float* in0,
+                                   const float* in1, const float* in2,
+                                   float* out) {
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    out[index] = (in2[index] > 0.0f) ? (in0[index] + in1[index]) : 0.0f;
+  }
+}
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const float* in0,
+                        const float* in1, const float* in2, float* out,
+                        unsigned N) {
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(N, d);
+  GPU_LAUNCH_KERNEL(AddNReluGradKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, in0, in1, in2, out);
+}
+
+__global__ void AddNReluGradKernel(int nthreads, const half* in0,
+                                   const half* in1, const half* in2,
+                                   half* out) {
+  half hZero(0.0f16);
+
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    out[index] =
+        __hgt(in2[index], hZero) ? __hadd(in0[index], in1[index]) : hZero;
+  }
+}
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const Eigen::half* in0,
+                        const Eigen::half* in1, const Eigen::half* in2,
+                        Eigen::half* out, unsigned N) {
+  const half* h_in0 = reinterpret_cast<const half*>(in0);
+  const half* h_in1 = reinterpret_cast<const half*>(in1);
+  const half* h_in2 = reinterpret_cast<const half*>(in2);
+  half* h_out = reinterpret_cast<half*>(out);
+
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(N, d);
+  GPU_LAUNCH_KERNEL(AddNReluGradKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, h_in0, h_in1, h_in2, h_out);
+}
+//-------------------------------------------------------------------
+
+}  // namespace rocm_kernels
+
+}  // namespace tensorflow
+
+#endif

--- a/tensorflow/core/kernels/relu_op.h
+++ b/tensorflow/core/kernels/relu_op.h
@@ -28,6 +28,11 @@ limitations under the License.
 #include "tensorflow/core/kernels/relu_op_functor.h"
 #include "tensorflow/core/lib/core/errors.h"
 
+#ifdef TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/gpu_utils.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#endif
+
 namespace tensorflow {
 
 template <typename Device, typename T>

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -2456,7 +2456,29 @@ REGISTER_OP("_ROCmFusedBatchNormActivationInference")
       using shape_inference::ShapeHandle;
       using shape_inference::DimensionHandle;
 
-      VLOG(-1) << "SetShapFn called for _ROCmFusedBatchNormActivation";
+      ShapeHandle x;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &x));
+
+      string data_format_str;
+      TF_RETURN_IF_ERROR(c->GetAttr("data_format", &data_format_str));
+
+      TensorFormat data_format;
+      FormatFromString(data_format_str, &data_format);
+
+      int channel_dim_index = GetTensorFeatureDimIndex(4, data_format);
+      DimensionHandle channel_dim = c->Dim(x, channel_dim_index);
+
+      // covers scale, offset, mean, variance
+      int number_inputs = 5;
+      for (int i = 1; i < number_inputs; ++i) {
+        ShapeHandle vec;
+        TF_RETURN_IF_ERROR(c->WithRank(c->input(i), 1, &vec));
+        TF_RETURN_IF_ERROR(c->Merge(channel_dim, c->Dim(vec, 0), &channel_dim));
+      }
+
+      ShapeHandle y;
+      TF_RETURN_IF_ERROR(c->ReplaceDim(x, channel_dim_index, channel_dim, &y));
+      c->set_output(0, y);
 
       return Status::OK();
     })
@@ -2486,7 +2508,32 @@ REGISTER_OP("_ROCmFusedBatchNormActivationTraining")
       using shape_inference::ShapeHandle;
       using shape_inference::DimensionHandle;
 
-      // VLOG(-1) << "SetShapFn called for _ROCmFusedBatchNormActivation";
+      ShapeHandle x;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4, &x));
+
+      string data_format_str;
+      TF_RETURN_IF_ERROR(c->GetAttr("data_format", &data_format_str));
+      TensorFormat data_format;
+      FormatFromString(data_format_str, &data_format);
+
+      int channel_dim_index = GetTensorFeatureDimIndex(4, data_format);
+      DimensionHandle channel_dim = c->Dim(x, channel_dim_index);
+
+      // covers scale, offset, and if is_training is false, mean, variance
+      int number_inputs = 3;
+      for (int i = 1; i < number_inputs; ++i) {
+        ShapeHandle vec;
+        TF_RETURN_IF_ERROR(c->WithRank(c->input(i), 1, &vec));
+        TF_RETURN_IF_ERROR(c->Merge(channel_dim, c->Dim(vec, 0), &channel_dim));
+      }
+
+      ShapeHandle y;
+      TF_RETURN_IF_ERROR(c->ReplaceDim(x, channel_dim_index, channel_dim, &y));
+      c->set_output(0, y);
+
+      ShapeHandle vector_shape = c->Vector(channel_dim);
+      c->set_output(1, vector_shape);
+      c->set_output(2, vector_shape);
 
       return Status::OK();
     })
@@ -2495,6 +2542,75 @@ REGISTER_OP("_ROCmFusedBatchNormActivationTraining")
       FusedBatchNorm / FusedBatchNormV2 (training only), followed by
       any activation op (None, Sigmoid, Relu, Relu6, Tanh)
     Supports only tensors of type float.
+)doc");
+
+REGISTER_OP("_ROCmFusedAddRelu")
+
+    .Input("x: T")  // input 0 to Add
+    .Input("y: T")  // input 1 to Add
+
+    .Output("activations: T")  // output 0 from Relu
+
+    .Attr("T: {half, float}")
+
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      using shape_inference::ShapeHandle;
+      using shape_inference::DimensionHandle;
+
+      ShapeHandle x = c->input(0);
+      ShapeHandle y = c->input(1);
+
+      // if either the shape of x or y is not known, then
+      if (!c->RankKnown(x) || !c->RankKnown(y)) {
+        // then set the shape of z to unknown
+        c->set_output(0, c->UnknownShape());
+      } else {
+        // else
+        // check that the shape of x and y matches
+        // and set the shape of z to be that of x
+
+        ShapeHandle z;
+        TF_RETURN_IF_ERROR(c->Merge(x, y, &z));
+        c->set_output(0, z);
+      }
+
+      return Status::OK();
+    })
+    .Doc(R"doc(
+    Computes a fused kernel which implements: 
+      Add op (element-wise), followed by
+      Relu Op
+    Supports only tensors of type {half, float}.
+)doc");
+
+REGISTER_OP("_ROCmFusedAddNReluGrad")
+
+    .Input("inputs: N * T")  // inputs to AddN
+    .Input("features: T")    // input 1 to ReluGrad
+
+    .Output("backprops: T")  // output 0 from ReluGrad
+
+    .Attr("T: {half, float}")
+    .Attr("N: int >= 1")
+
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      using shape_inference::ShapeHandle;
+      using shape_inference::DimensionHandle;
+
+      ShapeHandle out = c->input(0);
+      for (int i = 1; i < c->num_inputs(); i++) {
+        TF_RETURN_IF_ERROR(c->Merge(c->input(i), out, &out));
+      }
+
+      c->set_output(0, out);
+
+      return Status::OK();
+    })
+    .Doc(R"doc(
+    Computes a fused kernel which implements: 
+      AddN Op, Relu Op followed by
+      ReluGrad Op
+    Supports only tensors of type {half, float}.
 )doc");
 
 #endif  //  TENSORFLOW_USE_ROCM

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -2389,7 +2389,7 @@ REGISTER_OP("_ROCmFusedConvolutionBiasActivation")
     .Attr("padding: {'SAME', 'VALID'}")
     .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .Attr("activation_mode: {'Relu', 'None'} = 'Relu'")
+    .Attr("activation_mode: {'None','Sigmoid','Relu','Relu6','Tanh'} = 'None'")
 
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       using shape_inference::ShapeHandle;
@@ -2430,8 +2430,70 @@ REGISTER_OP("_ROCmFusedConvolutionBiasActivation")
       return Status::OK();
     })
     .Doc(R"doc(
-    Computes a fused kernel which implements: 2-D convolutions, then adds bias and
-    and then applies the activation function to the result. 
+    Computes a fused kernel which implements: 
+      Conv2D op, followed by
+      BiasAdd op, followed by
+      any activation op (None, Sigmoid, Relu, Relu6, Tanh)
+    Supports only tensors of type float.
+)doc");
+
+REGISTER_OP("_ROCmFusedBatchNormActivationInference")
+
+    .Input("x: T")
+    .Input("scale: T")
+    .Input("offset: T")
+    .Input("mean: T")
+    .Input("variance: T")
+
+    .Output("y: T")
+
+    .Attr("T: {float}")
+    .Attr("epsilon: float = 0.0001")
+    .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
+    .Attr("activation_mode: {'None','Sigmoid','Relu','Relu6','Tanh'} = 'None'")
+
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      using shape_inference::ShapeHandle;
+      using shape_inference::DimensionHandle;
+
+      VLOG(-1) << "SetShapFn called for _ROCmFusedBatchNormActivation";
+
+      return Status::OK();
+    })
+    .Doc(R"doc(
+    Computes a fused kernel which implements: 
+      FusedBatchNorm / FusedBatchNormV2 (inference only), followed by
+      any activation op (None, Sigmoid, Relu, Relu6, Tanh)
+    Supports only tensors of type float.
+)doc");
+
+REGISTER_OP("_ROCmFusedBatchNormActivationTraining")
+
+    .Input("x: T")
+    .Input("scale: T")
+    .Input("offset: T")
+
+    .Output("y: T")
+    .Output("mean: T")
+    .Output("variance: T")
+
+    .Attr("T: {float}")
+    .Attr("epsilon: float = 0.0001")
+    .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
+    .Attr("activation_mode: {'None','Sigmoid','Relu','Relu6','Tanh'} = 'None'")
+
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      using shape_inference::ShapeHandle;
+      using shape_inference::DimensionHandle;
+
+      // VLOG(-1) << "SetShapFn called for _ROCmFusedBatchNormActivation";
+
+      return Status::OK();
+    })
+    .Doc(R"doc(
+    Computes a fused kernel which implements: 
+      FusedBatchNorm / FusedBatchNormV2 (training only), followed by
+      any activation op (None, Sigmoid, Relu, Relu6, Tanh)
     Supports only tensors of type float.
 )doc");
 

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -2361,6 +2361,45 @@ class DnnSupport {
     return false;
   }
 
+  // Enqueues a fused batchnorm+activation (inference) operation onto the
+  // stream.
+  //
+  // Arguments (all borrowed):
+  //
+  //  stream: borrowed pointer to the stream that the 'fusion' operation should
+  //  be enqueued onto.
+  //
+  //  x_descriptor: dimensions of the batchnorm input layer.
+  //  x_data: device memory which contains the batchnorm input.
+  //
+  //  scale_offset_mean_variance_descriptor:
+  //      dimensions of the scale/offset/mean/variance tensor.
+  //  scale_data: device memory which contains the scale input.
+  //  offset_data: device memory which contains the offset input.
+  //  mean_data: device memory which contains the mean input.
+  //  variance_data: device memory which contains the variance input.
+  //  epsilon : the epsilon value to use in batchnorm calculation
+  //
+  //  activation_mode: Type of activation to perform.
+  //
+  //  y_data: device memory region in which to place the fusion result.
+  //
+  //  output_profile_result: the output profile result for this call.
+  //         The profiling is only enabled when this is not nullptr.
+  //
+  virtual bool DoFusedBatchNormActivationInference(
+      Stream* stream, const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data,
+      dnn::ProfileResult* output_profile_result) {
+    return false;
+  }
+
  private:
   SE_DISALLOW_COPY_AND_ASSIGN(DnnSupport);
 };

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -642,6 +642,17 @@ class MIOpenSupport : public dnn::DnnSupport {
       DeviceMemory<float>* output_data,
       dnn::ProfileResult* output_profile_result) override;
 
+  bool DoFusedBatchNormActivationInference(
+      Stream* stream, const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data,
+      dnn::ProfileResult* output_profile_result) override;
+
   ROCMExecutor* GetParentExecutor() { return parent_; }
 
  private:
@@ -803,6 +814,17 @@ class MIOpenSupport : public dnn::DnnSupport {
       const DeviceMemory<T>& bias_data, dnn::ActivationMode activation_mode,
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<T>* output_data, dnn::ProfileResult* output_profile_result);
+
+  template <typename T>
+  bool DoFusedBatchNormActivationInferenceImpl(
+      Stream* stream,
+      int miopen_type,  // Actually miopenDataType_t.
+      const dnn::BatchDescriptor& x_descriptor, const DeviceMemory<T>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<T>& scale_data, const DeviceMemory<T>& offset_data,
+      const DeviceMemory<T>& mean_data, const DeviceMemory<T>& variance_data,
+      double epsilon, dnn::ActivationMode activation_mode,
+      DeviceMemory<T>* y_data, dnn::ProfileResult* output_profile_result);
 
   SE_DISALLOW_COPY_AND_ASSIGN(MIOpenSupport);
 };

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -5496,6 +5496,34 @@ Stream& Stream::ThenFusedConvolutionBiasActivation(
   return *this;
 }
 
+Stream& Stream::ThenFusedBatchNormActivationInference(
+    const dnn::BatchDescriptor& x_descriptor, const DeviceMemory<float>& x_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data,
+    const DeviceMemory<float>& mean_data,
+    const DeviceMemory<float>& variance_data, double epsilon,
+    dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data) {
+  VLOG_CALL(PARAM(x_descriptor), PARAM(x_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(mean_data), PARAM(variance_data),
+            PARAM(epsilon), PARAM(activation_mode), PARAM(y_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationInference(
+          this, x_descriptor, x_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, mean_data, variance_data, epsilon,
+          activation_mode, y_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
 port::Status Stream::BlockHostUntilDone() {
   VLOG_CALL();
 

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -2016,6 +2016,17 @@ class Stream {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<float>* output_data);
 
+  // Fused Convolution+Bias+Activation (float)
+  Stream& ThenFusedBatchNormActivationInference(
+      const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data);
+
   // (Synchronously) block the host code waiting for the operations
   // entrained on the stream (enqueued to this point in program
   // execution) to complete.


### PR DESCRIPTION
This PR adds support for the following fusions

1. BatchNorm+Activation (inference) 
    The implementation leverages the fused BnA inference kernel provided by the MIOpen fusion API. Currently only the float datatype is supported. Support for BnA (training) and for fp16 datatype, will be added once the same becomes available in the MIOpen fusion API.

2. Add+Relu
    The implementation leverages a custom HIP kernel, and is available for the float and fp16 datatypes.

3. AddN+ReluGrad
    The implementation leverages a custom HIP kernel, and is available for the float and fp16 datatypes.


Set the env var `TF_ROCM_FUSION_ENABLE=1` to enable the fusion.

Currently fusion related `VLOG` messages will get printed by default, when fusion is enabled. This will be disabled in the near future.



