### PR TITLE
Do not commit the tf_configure.bazelrc line

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,4 +93,3 @@ build --define=LIBDIR=$(PREFIX)/lib
 build --define=INCLUDEDIR=$(PREFIX)/include
 
 # Do not commit the tf_configure.bazelrc line
-import %workspace%/.tf_configure.bazelrc


### PR DESCRIPTION
It's not clear whether the change to `.bazel.rc` affected our builds.  However, following the advice from the comment in the file, we should revert having committed the last line of the file.