### PR TITLE
BnA (inference) fusion + some minor updates for CBA fusion

### DIFF
--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -76,7 +76,8 @@ std::set<string> GetOpsFormatSupported() {
       "MaxPoolGradV2",
       "MaxPoolGradGradV2",
       "SpaceToDepth",
-      "DepthToSpace"};
+      "DepthToSpace",
+      "_ROCmFusedConvolutionBiasActivation"};
   return ops_format_supported;
 }
 

--- a/tensorflow/core/kernels/gpu_fusion_ops_batchnormactv.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_batchnormactv.cc
@@ -1,0 +1,208 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include <string.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_slice.h"
+
+#include "tensorflow/core/kernels/conv_2d.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/gpu_fusion_ops.h"
+
+#include "tensorflow/core/util/activation_mode.h"
+#include "tensorflow/core/util/padding.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+#include "tensorflow/core/platform/stream_executor.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename Device, typename T>
+class ROCmFusionKernelBatchNormActivationInference : public OpKernel {
+ public:
+  explicit ROCmFusionKernelBatchNormActivationInference(
+      OpKernelConstruction* ctx)
+      : OpKernel(ctx) {
+    float epsilon;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("epsilon", &epsilon));
+    epsilon_ = epsilon;
+
+    string data_format_str;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("data_format", &data_format_str));
+    OP_REQUIRES(ctx, FormatFromString(data_format_str, &data_format_),
+                errors::InvalidArgument("Invalid data format"));
+
+    string activation_mode_str;
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("activation_mode", &activation_mode_str));
+    OP_REQUIRES_OK(ctx, GetActivationModeFromString(activation_mode_str,
+                                                    &activation_mode_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& x = ctx->input(0);
+    const Tensor& scale = ctx->input(1);
+    const Tensor& offset = ctx->input(2);
+    const Tensor& mean = ctx->input(3);
+    const Tensor& variance = ctx->input(4);
+
+    OP_REQUIRES(ctx, x.dims() == 4,
+                errors::InvalidArgument("input must be 4-dimensional",
+                                        x.shape().DebugString()));
+    OP_REQUIRES(ctx, scale.dims() == 1,
+                errors::InvalidArgument("scale must be 1-dimensional",
+                                        scale.shape().DebugString()));
+    OP_REQUIRES(ctx, offset.dims() == 1,
+                errors::InvalidArgument("offset must be 1-dimensional",
+                                        offset.shape().DebugString()));
+    OP_REQUIRES(ctx, mean.dims() == 1,
+                errors::InvalidArgument("mean must be 1-dimensional",
+                                        mean.shape().DebugString()));
+    OP_REQUIRES(ctx, variance.dims() == 1,
+                errors::InvalidArgument("variance must be 1-dimensional",
+                                        variance.shape().DebugString()));
+
+    Tensor* y = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, x.shape(), &y));
+
+    const int64 batch_size = GetTensorDim(x, data_format_, 'N');
+    const int64 height = GetTensorDim(x, data_format_, 'H');
+    const int64 width = GetTensorDim(x, data_format_, 'W');
+    const int64 channels = GetTensorDim(x, data_format_, 'C');
+
+    if (x.shape().num_elements() != 0) {
+      Tensor fusion_input = x;
+      Tensor fusion_output = *y;
+
+      // if the data format is NHWC, we need to
+      // 1. convert the input tensor to NCHW format
+      // 2, allocate a temporary tensor to hold the fusion op output (which will
+      // be in NCHW format)
+      if (data_format_ == FORMAT_NHWC) {
+        // allocate a temporary tensor to store the NCHW input
+        Tensor transformed_input;
+        TensorShape nchw_shape_input =
+            ShapeFromFormat(FORMAT_NCHW, batch_size, height, width, channels);
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, nchw_shape_input,
+                                    &transformed_input));
+
+        // convert the input tensor to NCHW format for the GPU
+        functor::NHWCToNCHW<GPUDevice, T, 4>()(
+            ctx->eigen_device<GPUDevice>(),
+            const_cast<const Tensor&>(fusion_input).tensor<T, 4>(),
+            transformed_input.tensor<T, 4>());
+
+        fusion_input = transformed_input;
+
+        // allocate a temporary tensor to store the NCHW output
+        Tensor transformed_output;
+        TensorShape nchw_shape_output =
+            ShapeFromFormat(FORMAT_NCHW, batch_size, height, width, channels);
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, nchw_shape_output,
+                                    &transformed_output));
+
+        fusion_output = transformed_output;
+      }
+
+      se::dnn::BatchDescriptor x_desc;
+      x_desc.set_count(batch_size)
+          .set_feature_map_count(channels)
+          .set_height(height)
+          .set_width(width)
+          .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+      se::dnn::BatchDescriptor scale_offset_mean_variance_desc;
+      scale_offset_mean_variance_desc.set_count(1)
+          .set_feature_map_count(channels)
+          .set_height(1)
+          .set_width(1)
+          .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+      auto x_data = AsDeviceMemory(fusion_input.template flat<T>().data(),
+                                   fusion_input.template flat<T>().size());
+      auto scale_data = AsDeviceMemory(scale.template flat<T>().data(),
+                                       scale.template flat<T>().size());
+
+      auto offset_data = AsDeviceMemory(offset.template flat<T>().data(),
+                                        offset.template flat<T>().size());
+
+      auto mean_data = AsDeviceMemory(mean.template flat<T>().data(),
+                                      mean.template flat<T>().size());
+
+      auto variance_data = AsDeviceMemory(variance.template flat<T>().data(),
+                                          variance.template flat<T>().size());
+
+      auto dnn_activation_mode = GetDnnActivationMode(activation_mode_);
+
+      auto y_data = AsDeviceMemory(fusion_output.template flat<T>().data(),
+                                   fusion_output.template flat<T>().size());
+
+      auto* stream = ctx->op_device_context()->stream();
+
+      bool miopen_status =
+          stream
+              ->ThenFusedBatchNormActivationInference(
+                  x_desc, x_data, scale_offset_mean_variance_desc, scale_data,
+                  offset_data, mean_data, variance_data, epsilon_,
+                  dnn_activation_mode, &y_data)
+              .ok();
+
+      if (!miopen_status) {
+        ctx->SetStatus(
+            errors::Internal("MIOpen BnA (inference) FusionOp launch Failure"));
+      }
+
+      // if the data format is NHWC, we need to convert the fusion op output
+      // back to MHWC format
+      if (data_format_ == FORMAT_NHWC) {
+        functor::NCHWToNHWC<GPUDevice, T, 4>()(
+            ctx->eigen_device<GPUDevice>(),
+            const_cast<const Tensor&>(fusion_output).tensor<T, 4>(),
+            y->tensor<T, 4>());
+      }
+    }
+  }
+
+ private:
+  double epsilon_;
+  TensorFormat data_format_;
+  ActivationMode activation_mode_;
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("_ROCmFusedBatchNormActivationInference")
+        .Device(DEVICE_GPU)
+        .TypeConstraint<float>("T"),
+    ROCmFusionKernelBatchNormActivationInference<GPUDevice, float>);
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -2389,7 +2389,7 @@ REGISTER_OP("_ROCmFusedConvolutionBiasActivation")
     .Attr("padding: {'SAME', 'VALID'}")
     .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
     .Attr("dilations: list(int) = [1, 1, 1, 1]")
-    .Attr("activation_mode: {'Relu', 'None'} = 'Relu'")
+    .Attr("activation_mode: {'None','Sigmoid','Relu','Relu6','Tanh'} = 'None'")
 
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       using shape_inference::ShapeHandle;
@@ -2430,8 +2430,70 @@ REGISTER_OP("_ROCmFusedConvolutionBiasActivation")
       return Status::OK();
     })
     .Doc(R"doc(
-    Computes a fused kernel which implements: 2-D convolutions, then adds bias and
-    and then applies the activation function to the result. 
+    Computes a fused kernel which implements: 
+      Conv2D op, followed by
+      BiasAdd op, followed by
+      any activation op (None, Sigmoid, Relu, Relu6, Tanh)
+    Supports only tensors of type float.
+)doc");
+
+REGISTER_OP("_ROCmFusedBatchNormActivationInference")
+
+    .Input("x: T")
+    .Input("scale: T")
+    .Input("offset: T")
+    .Input("mean: T")
+    .Input("variance: T")
+
+    .Output("y: T")
+
+    .Attr("T: {float}")
+    .Attr("epsilon: float = 0.0001")
+    .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
+    .Attr("activation_mode: {'None','Sigmoid','Relu','Relu6','Tanh'} = 'None'")
+
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      using shape_inference::ShapeHandle;
+      using shape_inference::DimensionHandle;
+
+      VLOG(-1) << "SetShapFn called for _ROCmFusedBatchNormActivation";
+
+      return Status::OK();
+    })
+    .Doc(R"doc(
+    Computes a fused kernel which implements: 
+      FusedBatchNorm / FusedBatchNormV2 (inference only), followed by
+      any activation op (None, Sigmoid, Relu, Relu6, Tanh)
+    Supports only tensors of type float.
+)doc");
+
+REGISTER_OP("_ROCmFusedBatchNormActivationTraining")
+
+    .Input("x: T")
+    .Input("scale: T")
+    .Input("offset: T")
+
+    .Output("y: T")
+    .Output("mean: T")
+    .Output("variance: T")
+
+    .Attr("T: {float}")
+    .Attr("epsilon: float = 0.0001")
+    .Attr("data_format: {'NHWC', 'NCHW'} = 'NHWC'")
+    .Attr("activation_mode: {'None','Sigmoid','Relu','Relu6','Tanh'} = 'None'")
+
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      using shape_inference::ShapeHandle;
+      using shape_inference::DimensionHandle;
+
+      // VLOG(-1) << "SetShapFn called for _ROCmFusedBatchNormActivation";
+
+      return Status::OK();
+    })
+    .Doc(R"doc(
+    Computes a fused kernel which implements: 
+      FusedBatchNorm / FusedBatchNormV2 (training only), followed by
+      any activation op (None, Sigmoid, Relu, Relu6, Tanh)
     Supports only tensors of type float.
 )doc");
 

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -2361,6 +2361,45 @@ class DnnSupport {
     return false;
   }
 
+  // Enqueues a fused batchnorm+activation (inference) operation onto the
+  // stream.
+  //
+  // Arguments (all borrowed):
+  //
+  //  stream: borrowed pointer to the stream that the 'fusion' operation should
+  //  be enqueued onto.
+  //
+  //  x_descriptor: dimensions of the batchnorm input layer.
+  //  x_data: device memory which contains the batchnorm input.
+  //
+  //  scale_offset_mean_variance_descriptor:
+  //      dimensions of the scale/offset/mean/variance tensor.
+  //  scale_data: device memory which contains the scale input.
+  //  offset_data: device memory which contains the offset input.
+  //  mean_data: device memory which contains the mean input.
+  //  variance_data: device memory which contains the variance input.
+  //  epsilon : the epsilon value to use in batchnorm calculation
+  //
+  //  activation_mode: Type of activation to perform.
+  //
+  //  y_data: device memory region in which to place the fusion result.
+  //
+  //  output_profile_result: the output profile result for this call.
+  //         The profiling is only enabled when this is not nullptr.
+  //
+  virtual bool DoFusedBatchNormActivationInference(
+      Stream* stream, const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data,
+      dnn::ProfileResult* output_profile_result) {
+    return false;
+  }
+
  private:
   SE_DISALLOW_COPY_AND_ASSIGN(DnnSupport);
 };

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -642,6 +642,17 @@ class MIOpenSupport : public dnn::DnnSupport {
       DeviceMemory<float>* output_data,
       dnn::ProfileResult* output_profile_result) override;
 
+  bool DoFusedBatchNormActivationInference(
+      Stream* stream, const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data,
+      dnn::ProfileResult* output_profile_result) override;
+
   ROCMExecutor* GetParentExecutor() { return parent_; }
 
  private:
@@ -803,6 +814,17 @@ class MIOpenSupport : public dnn::DnnSupport {
       const DeviceMemory<T>& bias_data, dnn::ActivationMode activation_mode,
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<T>* output_data, dnn::ProfileResult* output_profile_result);
+
+  template <typename T>
+  bool DoFusedBatchNormActivationInferenceImpl(
+      Stream* stream,
+      int miopen_type,  // Actually miopenDataType_t.
+      const dnn::BatchDescriptor& x_descriptor, const DeviceMemory<T>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<T>& scale_data, const DeviceMemory<T>& offset_data,
+      const DeviceMemory<T>& mean_data, const DeviceMemory<T>& variance_data,
+      double epsilon, dnn::ActivationMode activation_mode,
+      DeviceMemory<T>* y_data, dnn::ProfileResult* output_profile_result);
 
   SE_DISALLOW_COPY_AND_ASSIGN(MIOpenSupport);
 };

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -5496,6 +5496,34 @@ Stream& Stream::ThenFusedConvolutionBiasActivation(
   return *this;
 }
 
+Stream& Stream::ThenFusedBatchNormActivationInference(
+    const dnn::BatchDescriptor& x_descriptor, const DeviceMemory<float>& x_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data,
+    const DeviceMemory<float>& mean_data,
+    const DeviceMemory<float>& variance_data, double epsilon,
+    dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data) {
+  VLOG_CALL(PARAM(x_descriptor), PARAM(x_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(mean_data), PARAM(variance_data),
+            PARAM(epsilon), PARAM(activation_mode), PARAM(y_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationInference(
+          this, x_descriptor, x_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, mean_data, variance_data, epsilon,
+          activation_mode, y_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
 port::Status Stream::BlockHostUntilDone() {
   VLOG_CALL();
 

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -2016,6 +2016,17 @@ class Stream {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<float>* output_data);
 
+  // Fused Convolution+Bias+Activation (float)
+  Stream& ThenFusedBatchNormActivationInference(
+      const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data);
+
   // (Synchronously) block the host code waiting for the operations
   // entrained on the stream (enqueued to this point in program
   // execution) to complete.


### PR DESCRIPTION
This PR adds support for the     BatchNorm+Activation (inference) fusion

The implementation leverages the fused BnA inference kernel provided by the MIOpen fusion API. Currently only the float datatype is supported. Support for BnA (training) and for fp16 datatype, will be added once the same becomes available in the MIOpen fusion API.

Set the env var TF_ROCM_FUSION_ENABLE=1 to enable the fusion.

Currently fusion related VLOG messages will get printed by default, when fusion is enabled. This will be disabled in the near future.

---------------------------------

The following env vars are temporary, used primarily for debug purposes. The functionality associated with them is not expected to persist long term.

1. Set the env var TF_ROCM_FUSION_PASS_POST_PARTITION=1 to change the grouping where the ROCM Fusion Pass runs. By default it runs as part of the "post placement" grouping (i.e. after op placement has been done, but before the graph has been partitioned into per device subgraphs). Setting the env var will change the grouping to "post partitioning". 

2. Set the env var TF_ROCM_FUSION_DUMP_GRAPH_BEFORE=1 to dump the TF graph to stdout *before* the ROCm FUSION Pass is run

3. Set the env var TF_ROCM_FUSION_DUMP_GRAPH_AFTER=1 to dump the TF graph to stdout *after* the ROCm FUSION Pass is run


