### PR TITLE
"Add+Relu" and "AddN+ReluGrad" fusions (custom HIP kernel implementations)

### DIFF
--- a/tensorflow/core/grappler/optimizers/layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/layout_optimizer.cc
@@ -77,7 +77,10 @@ std::set<string> GetOpsFormatSupported() {
       "MaxPoolGradGradV2",
       "SpaceToDepth",
       "DepthToSpace",
-      "_ROCmFusedConvolutionBiasActivation"};
+      "_ROCmFusedConvolutionBiasActivation",
+      "_ROCmFusedBatchNormActivationInference",
+      "_ROCmFusedBatchNormActivationTraining",
+  };
   return ops_format_supported;
 }
 

--- a/tensorflow/core/kernels/gpu_fusion_ops.h
+++ b/tensorflow/core/kernels/gpu_fusion_ops.h
@@ -18,12 +18,31 @@ limitations under the License.
 
 #ifdef TENSORFLOW_USE_ROCM
 
+#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/util/activation_mode.h"
 
 namespace tensorflow {
 
 se::dnn::ActivationMode GetDnnActivationMode(ActivationMode activation_mode);
+
+namespace rocm_kernels {
+
+void FusionAddRelu(OpKernelContext* ctx, const float* in0, const float* in1,
+                   float* out, unsigned N);
+
+void FusionAddRelu(OpKernelContext* ctx, const Eigen::half* in0,
+                   const Eigen::half* in1, Eigen::half* out, unsigned N);
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const float* in0,
+                        const float* in1, const float* in2, float* out,
+                        unsigned N);
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const Eigen::half* in0,
+                        const Eigen::half* in1, const Eigen::half* in2,
+                        Eigen::half* out, unsigned N);
+
+}  // namespace rocm_kernels
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/gpu_fusion_ops_custom.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_custom.cc
@@ -1,0 +1,132 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include <string.h>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_slice.h"
+
+#include "tensorflow/core/kernels/conv_2d.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/gpu_fusion_ops.h"
+
+#include "tensorflow/core/util/activation_mode.h"
+#include "tensorflow/core/util/padding.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+#include "tensorflow/core/platform/stream_executor.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+//-------------------------------------------------------------------
+
+template <typename Device, typename T>
+class ROCmFusionKernelAddRelu : public OpKernel {
+ public:
+  explicit ROCmFusionKernelAddRelu(OpKernelConstruction* ctx) : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& in0 = ctx->input(0);
+    const Tensor& in1 = ctx->input(1);
+
+    Tensor* out = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, in0.shape(), &out));
+
+    auto in0_data = AsDeviceMemory(in0.template flat<T>().data(),
+                                   in0.template flat<T>().size());
+    auto in1_data = AsDeviceMemory(in1.template flat<T>().data(),
+                                   in1.template flat<T>().size());
+    auto out_data = AsDeviceMemory(out->template flat<T>().data(),
+                                   out->template flat<T>().size());
+
+    rocm_kernels::FusionAddRelu(ctx, static_cast<const T*>(in0_data.opaque()),
+                                static_cast<const T*>(in1_data.opaque()),
+                                static_cast<T*>(out_data.opaque()),
+                                in0.NumElements());
+  }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("_ROCmFusedAddRelu").Device(DEVICE_GPU).TypeConstraint<float>("T"),
+    ROCmFusionKernelAddRelu<GPUDevice, float>);
+
+REGISTER_KERNEL_BUILDER(Name("_ROCmFusedAddRelu")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::half>("T"),
+                        ROCmFusionKernelAddRelu<GPUDevice, Eigen::half>);
+
+//-------------------------------------------------------------------
+
+template <typename Device, typename T>
+class ROCmFusionKernelAddNReluGrad : public OpKernel {
+ public:
+  explicit ROCmFusionKernelAddNReluGrad(OpKernelConstruction* ctx)
+      : OpKernel(ctx) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& in0 = ctx->input(0);
+    const Tensor& in1 = ctx->input(1);
+    const Tensor& in2 = ctx->input(2);
+
+    Tensor* out = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, in2.shape(), &out));
+
+    auto in0_data = AsDeviceMemory(in0.template flat<T>().data(),
+                                   in0.template flat<T>().size());
+    auto in1_data = AsDeviceMemory(in1.template flat<T>().data(),
+                                   in1.template flat<T>().size());
+    auto in2_data = AsDeviceMemory(in2.template flat<T>().data(),
+                                   in2.template flat<T>().size());
+    auto out_data = AsDeviceMemory(out->template flat<T>().data(),
+                                   out->template flat<T>().size());
+
+    rocm_kernels::FusionAddNReluGrad(
+        ctx, static_cast<const T*>(in0_data.opaque()),
+        static_cast<const T*>(in1_data.opaque()),
+        static_cast<const T*>(in2_data.opaque()),
+        static_cast<T*>(out_data.opaque()), in0.NumElements());
+  }
+
+ private:
+};
+
+REGISTER_KERNEL_BUILDER(Name("_ROCmFusedAddNReluGrad")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<float>("T"),
+                        ROCmFusionKernelAddNReluGrad<GPUDevice, float>);
+
+REGISTER_KERNEL_BUILDER(Name("_ROCmFusedAddNReluGrad")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::half>("T"),
+                        ROCmFusionKernelAddNReluGrad<GPUDevice, Eigen::half>);
+//-------------------------------------------------------------------
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/gpu_fusion_ops_custom.cu.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_custom.cu.cc
@@ -1,0 +1,124 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/kernels/gpu_fusion_ops.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+
+#include "hip/hip_fp16.h"
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+namespace rocm_kernels {
+
+//-------------------------------------------------------------------
+__global__ void AddReluKernel(int nthreads, const float* in0, const float* in1,
+                              float* out) {
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    out[index] = fmaxf(0.0f, in0[index] + in1[index]);
+  }
+}
+
+void FusionAddRelu(OpKernelContext* ctx, const float* in0, const float* in1,
+                   float* out, unsigned N) {
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(N, d);
+  GPU_LAUNCH_KERNEL(AddReluKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, in0, in1, out);
+}
+
+__global__ void AddReluKernel(int nthreads, const half2* in0, const half2* in1,
+                              half2* out) {
+  half2 kZero(0.0f16, 0.0f16);
+
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    half2 sum = __hadd2(in0[index], in1[index]);
+    out[index] = __hmul2(__hgt2(sum, kZero), sum);
+  }
+}
+
+void FusionAddRelu(OpKernelContext* ctx, const Eigen::half* in0,
+                   const Eigen::half* in1, Eigen::half* out, unsigned N) {
+  const half2* h_in0 = reinterpret_cast<const half2*>(in0);
+  const half2* h_in1 = reinterpret_cast<const half2*>(in1);
+  half2* h_out = reinterpret_cast<half2*>(out);
+  unsigned h_N = (N + 1) / 2;
+  
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(h_N, d);
+  GPU_LAUNCH_KERNEL(AddReluKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, h_in0, h_in1, h_out);
+}
+
+  
+//-------------------------------------------------------------------
+__global__ void AddNReluGradKernel(int nthreads, const float* in0,
+                                   const float* in1, const float* in2,
+                                   float* out) {
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    out[index] = (in2[index] > 0.0f) ? (in0[index] + in1[index]) : 0.0f;
+  }
+}
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const float* in0,
+                        const float* in1, const float* in2, float* out,
+                        unsigned N) {
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(N, d);
+  GPU_LAUNCH_KERNEL(AddNReluGradKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, in0, in1, in2, out);
+}
+
+__global__ void AddNReluGradKernel(int nthreads, const half2* in0,
+                                   const half2* in1, const half2* in2,
+                                   half2* out) {
+  half2 kZero(0.0f16, 0.0f16);
+
+  GPU_1D_KERNEL_LOOP(index, nthreads) {
+    out[index] =
+      __hmul2(__hgt2(in2[index], kZero), __hadd2(in0[index], in1[index]));
+  }
+}
+
+void FusionAddNReluGrad(OpKernelContext* ctx, const Eigen::half* in0,
+                        const Eigen::half* in1, const Eigen::half* in2,
+                        Eigen::half* out, unsigned N) {
+  const half2* h_in0 = reinterpret_cast<const half2*>(in0);
+  const half2* h_in1 = reinterpret_cast<const half2*>(in1);
+  const half2* h_in2 = reinterpret_cast<const half2*>(in2);
+  half2* h_out = reinterpret_cast<half2*>(out);
+  unsigned h_N = (N + 1) / 2;
+
+  GPUDevice d = ctx->eigen_device<GPUDevice>();
+  GpuLaunchConfig config = GetGpuLaunchConfig(h_N, d);
+  GPU_LAUNCH_KERNEL(AddNReluGradKernel, dim3(config.block_count),
+                    dim3(config.thread_per_block), 0, d.stream(),
+                    config.virtual_thread_count, h_in0, h_in1, h_in2, h_out);
+}
+
+//-------------------------------------------------------------------
+
+}  // namespace rocm_kernels
+
+}  // namespace tensorflow
+
+#endif


### PR DESCRIPTION
use TF_ROCM_FUSION_ENABLE=1 to enable the fusion.

This fusion is specific to the resnet-50 model (i.e. it is designed to target the op sequence seen in the resnet-50 model. However it will kick-in for any other model which has a matching pattern)

This fusion is supported for `float32` and `fp16` types.