### PR TITLE
__hgt2 fix, env vars to individually disable fusion ops, MNIST testcase fix

### DIFF
--- a/tensorflow/core/graph/gpu_fusion_pass.cc
+++ b/tensorflow/core/graph/gpu_fusion_pass.cc
@@ -205,9 +205,7 @@ class ROCmFusionPass : public GraphOptimizationPass {
 
  private:
   void InitializeFusions(
-      std::vector<std::unique_ptr<ROCmFusionOpBase> >& fusions, Graph* g,
-      std::set<const Node*>& fused_nodes);
-
+      std::vector<std::unique_ptr<ROCmFusionOpBase> >& fusions, Graph* g);
 };
 
 // Register the ROCmFusionPass with the registry.
@@ -222,18 +220,16 @@ REGISTER_OPTIMIZATION(kROCmFusionPassGrouping,  // grouping
 // absract base class for an individual fusion operation
 class ROCmFusionOpBase {
  public:
-  ROCmFusionOpBase(Graph* g, std::set<const Node*>& fn)
-      : graph_(g), fused_nodes_(fn) {}
+  ROCmFusionOpBase(Graph* g) : graph_(g) {}
 
   virtual ~ROCmFusionOpBase() {}
 
   // routine to (maybe) do fusion on the given node (+ the nodes preceding
   // it). will return true if fusion was done, false otherwise
-  virtual bool DoFusion(const Node* n) = 0;
+  virtual bool DoFusion(const Node* n, std::set<const Node*>& fused_nodes) = 0;
 
  protected:
   Graph* graph_;
-  std::set<const Node*>& fused_nodes_;
 };
 
 //----------------------------------------------------------------------
@@ -241,13 +237,12 @@ class ROCmFusionOpBase {
 // Convolution-Bias-BatchNorm-Activation Fusion
 class ROCmFusionOpConvolutionBiasBatchNormActivation : public ROCmFusionOpBase {
  public:
-  ROCmFusionOpConvolutionBiasBatchNormActivation(Graph* g,
-                                                 std::set<const Node*>& fn)
-      : ROCmFusionOpBase(g, fn) {}
+  ROCmFusionOpConvolutionBiasBatchNormActivation(Graph* g)
+      : ROCmFusionOpBase(g) {}
 
   // routine to (maybe) do fusion on the given node (+ the nodes preceding
   // it). will return true if fusion was done, false otherwise
-  bool DoFusion(const Node* n) override;
+  bool DoFusion(const Node* n, std::set<const Node*>& fused_nodes) override;
 
  protected:
   struct FusionData {
@@ -259,7 +254,7 @@ class ROCmFusionOpConvolutionBiasBatchNormActivation : public ROCmFusionOpBase {
 
   bool IsFusionEligible(const Node* n, FusionData* d);
 
-  void CreateFusionOp(const FusionData* d);
+  void CreateFusionOp(const FusionData* d, std::set<const Node*>& fused_nodes);
 };
 
 //----------------------------------------------------------------------
@@ -267,12 +262,11 @@ class ROCmFusionOpConvolutionBiasBatchNormActivation : public ROCmFusionOpBase {
 // Convolution-Bias-Activation Fusion
 class ROCmFusionOpConvolutionBiasActivation : public ROCmFusionOpBase {
  public:
-  ROCmFusionOpConvolutionBiasActivation(Graph* g, std::set<const Node*>& fn)
-      : ROCmFusionOpBase(g, fn) {}
+  ROCmFusionOpConvolutionBiasActivation(Graph* g) : ROCmFusionOpBase(g) {}
 
   // routine to (maybe) do fusion on the given node (+ the nodes preceding
   // it). will return true if fusion was done, false otherwise
-  bool DoFusion(const Node* n) override;
+  bool DoFusion(const Node* n, std::set<const Node*>& fused_nodes) override;
 
  protected:
   struct FusionData {
@@ -290,7 +284,7 @@ class ROCmFusionOpConvolutionBiasActivation : public ROCmFusionOpBase {
 
   bool IsFusionEligible(const Node* n, FusionData* d);
 
-  void CreateFusionOp(const FusionData* d);
+  void CreateFusionOp(const FusionData* d, std::set<const Node*>& fused_nodes);
 };
 
 //----------------------------------------------------------------------
@@ -298,12 +292,11 @@ class ROCmFusionOpConvolutionBiasActivation : public ROCmFusionOpBase {
 // BatchNorm-Activation Fusion
 class ROCmFusionOpBatchNormActivation : public ROCmFusionOpBase {
  public:
-  ROCmFusionOpBatchNormActivation(Graph* g, std::set<const Node*>& fn)
-      : ROCmFusionOpBase(g, fn) {}
+  ROCmFusionOpBatchNormActivation(Graph* g) : ROCmFusionOpBase(g) {}
 
   // routine to (maybe) do fusion on the given node (+ the nodes preceding
   // it). will return true if fusion was done, false otherwise
-  bool DoFusion(const Node* n) override;
+  bool DoFusion(const Node* n, std::set<const Node*>& fused_nodes) override;
 
  protected:
   struct FusionData {
@@ -319,7 +312,7 @@ class ROCmFusionOpBatchNormActivation : public ROCmFusionOpBase {
 
   bool IsFusionEligible(const Node* n, FusionData* d);
 
-  void CreateFusionOp(const FusionData* d);
+  void CreateFusionOp(const FusionData* d, std::set<const Node*>& fused_nodes);
 };
 
 //----------------------------------------------------------------------
@@ -327,12 +320,11 @@ class ROCmFusionOpBatchNormActivation : public ROCmFusionOpBase {
 // Add-Relu Fusion
 class ROCmFusionOpAddRelu : public ROCmFusionOpBase {
  public:
-  ROCmFusionOpAddRelu(Graph* g, std::set<const Node*>& fn)
-      : ROCmFusionOpBase(g, fn) {}
+  ROCmFusionOpAddRelu(Graph* g) : ROCmFusionOpBase(g) {}
 
   // routine to (maybe) do fusion on the given node (+ the nodes preceding
   // it). will return true if fusion was done, false otherwise
-  bool DoFusion(const Node* n) override;
+  bool DoFusion(const Node* n, std::set<const Node*>& fused_nodes) override;
 
  protected:
   struct FusionData {
@@ -344,7 +336,7 @@ class ROCmFusionOpAddRelu : public ROCmFusionOpBase {
 
   bool IsFusionEligible(const Node* n, FusionData* d);
 
-  void CreateFusionOp(const FusionData* d);
+  void CreateFusionOp(const FusionData* d, std::set<const Node*>& fused_nodes);
 };
 
 //----------------------------------------------------------------------
@@ -352,12 +344,11 @@ class ROCmFusionOpAddRelu : public ROCmFusionOpBase {
 // AddN-Relu-ReluGrad Fusion
 class ROCmFusionOpAddNReluGrad : public ROCmFusionOpBase {
  public:
-  ROCmFusionOpAddNReluGrad(Graph* g, std::set<const Node*>& fn)
-      : ROCmFusionOpBase(g, fn) {}
+  ROCmFusionOpAddNReluGrad(Graph* g) : ROCmFusionOpBase(g) {}
 
   // routine to (maybe) do fusion on the given node (+ the nodes preceding
   // it). will return true if fusion was done, false otherwise
-  bool DoFusion(const Node* n) override;
+  bool DoFusion(const Node* n, std::set<const Node*>& fused_nodes) override;
 
  protected:
   struct FusionData {
@@ -371,7 +362,7 @@ class ROCmFusionOpAddNReluGrad : public ROCmFusionOpBase {
 
   bool IsFusionEligible(const Node* n, FusionData* d);
 
-  void CreateFusionOp(const FusionData* d);
+  void CreateFusionOp(const FusionData* d, std::set<const Node*>& fused_nodes);
 };
 
 //----------------------------------------------------------------------
@@ -421,30 +412,27 @@ bool ROCmFusionPass::RunPass(Graph* graph) {
   }
 
   std::vector<std::unique_ptr<ROCmFusionOpBase> > fusions;
-  std::set<const Node*> fused_nodes;
 
   // Initialize a vector of all the fusion operations we currently support
-  InitializeFusions(fusions, graph, fused_nodes);
+  InitializeFusions(fusions, graph);
 
-  std::vector<Node*> order;
-  GetPostOrder(*graph, &order);  // This will give us reverse topological sort.
+  for (auto& fusion : fusions) {
+    std::vector<Node*> order;
+    GetPostOrder(*graph,
+                 &order);  // This will give us reverse topological sort.
 
-  for (const Node* n : order) {
+    std::set<const Node*> fused_nodes;
 
-    if (fused_nodes.count(n)) {
-      // We have fused already this node...skip it
-      // Note that we are traversing nodes in reverse topological order, and
-      // matches are found by comparing node sequences from back to front, so
-      // we will hit nodes that we have already fused into a fusion operation.
-      continue;
-    }
-
-    for (auto& fusion : fusions) {
-      if (fusion->DoFusion(n)) {
-        // bail out after the first successful fusion ...
-        // cannot do more than one fusions on a op
-        break;
+    for (const Node* n : order) {
+      if (fused_nodes.count(n)) {
+        // We have fused already this node...skip it
+        // Note that we are traversing nodes in reverse topological order, and
+        // matches are found by comparing node sequences from back to front, so
+        // we will hit nodes that we have already fused into a fusion operation.
+        continue;
       }
+
+      fusion->DoFusion(n, fused_nodes);
     }
   }
 
@@ -456,15 +444,26 @@ bool ROCmFusionPass::RunPass(Graph* graph) {
 }
 
 void ROCmFusionPass::InitializeFusions(
-    std::vector<std::unique_ptr<ROCmFusionOpBase> >& fusions, Graph* g,
-    std::set<const Node*>& fused_nodes) {
-  fusions.emplace_back(
-      new ROCmFusionOpConvolutionBiasBatchNormActivation(g, fused_nodes));
-  fusions.emplace_back(
-      new ROCmFusionOpConvolutionBiasActivation(g, fused_nodes));
-  fusions.emplace_back(new ROCmFusionOpBatchNormActivation(g, fused_nodes));
-  fusions.emplace_back(new ROCmFusionOpAddRelu(g, fused_nodes));
-  fusions.emplace_back(new ROCmFusionOpAddNReluGrad(g, fused_nodes));
+    std::vector<std::unique_ptr<ROCmFusionOpBase> >& fusions, Graph* g) {
+  if (!getenv("TF_ROCM_FUSION_DISABLE_CBNA")) {
+    fusions.emplace_back(new ROCmFusionOpConvolutionBiasBatchNormActivation(g));
+  }
+
+  if (!getenv("TF_ROCM_FUSION_DISABLE_CBA")) {
+    fusions.emplace_back(new ROCmFusionOpConvolutionBiasActivation(g));
+  }
+
+  if (!getenv("TF_ROCM_FUSION_DISABLE_BNA")) {
+    fusions.emplace_back(new ROCmFusionOpBatchNormActivation(g));
+  }
+
+  if (!getenv("TF_ROCM_FUSION_DISABLE_ADDRELU")) {
+    fusions.emplace_back(new ROCmFusionOpAddRelu(g));
+  }
+
+  if (!getenv("TF_ROCM_FUSION_DISABLE_ADDNRELUGRAD")) {
+    fusions.emplace_back(new ROCmFusionOpAddNReluGrad(g));
+  }
 }
 
 //----------------------------------------------------------------------
@@ -472,11 +471,12 @@ void ROCmFusionPass::InitializeFusions(
 // -------------------------------------------------------------
 // ROCmFusionOpConvolutionBiasBatchNormActivation implementation
 // -------------------------------------------------------------
-bool ROCmFusionOpConvolutionBiasBatchNormActivation::DoFusion(const Node* n4) {
+bool ROCmFusionOpConvolutionBiasBatchNormActivation::DoFusion(
+    const Node* n4, std::set<const Node*>& fused_nodes) {
   bool did_fusion = false;
   FusionData d;
   if (IsFusionEligible(n4, &d)) {
-    CreateFusionOp(&d);
+    CreateFusionOp(&d, fused_nodes);
     did_fusion = true;
   }
   return did_fusion;
@@ -521,7 +521,7 @@ bool ROCmFusionOpConvolutionBiasBatchNormActivation::IsFusionEligible(
 }
 
 void ROCmFusionOpConvolutionBiasBatchNormActivation::CreateFusionOp(
-    const FusionData* d) {
+    const FusionData* d, std::set<const Node*>& fused_nodes) {
   // todo
 }
 //----------------------------------------------------------------------
@@ -529,11 +529,12 @@ void ROCmFusionOpConvolutionBiasBatchNormActivation::CreateFusionOp(
 // ----------------------------------------------------
 // ROCmFusionOpConvolutionBiasActivation implementation
 // ----------------------------------------------------
-bool ROCmFusionOpConvolutionBiasActivation::DoFusion(const Node* n3) {
+bool ROCmFusionOpConvolutionBiasActivation::DoFusion(
+    const Node* n3, std::set<const Node*>& fused_nodes) {
   bool did_fusion = false;
   FusionData d;
   if (IsFusionEligible(n3, &d)) {
-    CreateFusionOp(&d);
+    CreateFusionOp(&d, fused_nodes);
     did_fusion = true;
   }
   return did_fusion;
@@ -707,7 +708,7 @@ bool ROCmFusionOpConvolutionBiasActivation::IsFusionEligible(const Node* n3,
 }
 
 void ROCmFusionOpConvolutionBiasActivation::CreateFusionOp(
-    const FusionData* d) {
+    const FusionData* d, std::set<const Node*>& fused_nodes) {
   std::vector<const Edge*> conv_input_edges;
   TF_CHECK_OK(d->conv->input_edges(&conv_input_edges));
 
@@ -784,9 +785,9 @@ void ROCmFusionOpConvolutionBiasActivation::CreateFusionOp(
   VLOG(kVlogLevel) << "===========";
 
   // add the now redundant nodes to the set of fused nodes
-  fused_nodes_.insert(d->conv);
-  fused_nodes_.insert(d->bias);
-  fused_nodes_.insert(d->actv);
+  fused_nodes.insert(d->conv);
+  fused_nodes.insert(d->bias);
+  fused_nodes.insert(d->actv);
 
   // and remove them from the graph
   graph_->RemoveNode(const_cast<Node*>(d->conv));
@@ -800,11 +801,12 @@ void ROCmFusionOpConvolutionBiasActivation::CreateFusionOp(
 // ROCmFusionOpBatchNormActivation implementation
 // ----------------------------------------------
 
-bool ROCmFusionOpBatchNormActivation::DoFusion(const Node* n2) {
+bool ROCmFusionOpBatchNormActivation::DoFusion(
+    const Node* n2, std::set<const Node*>& fused_nodes) {
   bool did_fusion = false;
   FusionData d;
   if (IsFusionEligible(n2, &d)) {
-    CreateFusionOp(&d);
+    CreateFusionOp(&d, fused_nodes);
     did_fusion = true;
   }
   return did_fusion;
@@ -941,7 +943,8 @@ bool ROCmFusionOpBatchNormActivation::IsFusionEligible(const Node* n2,
   return is_eligible;
 }
 
-void ROCmFusionOpBatchNormActivation::CreateFusionOp(const FusionData* d) {
+void ROCmFusionOpBatchNormActivation::CreateFusionOp(
+    const FusionData* d, std::set<const Node*>& fused_nodes) {
   std::vector<const Edge*> norm_input_edges;
   TF_CHECK_OK(d->norm->input_edges(&norm_input_edges));
 
@@ -1026,8 +1029,8 @@ void ROCmFusionOpBatchNormActivation::CreateFusionOp(const FusionData* d) {
   VLOG(kVlogLevel) << "===========";
 
   // add the now redundant nodes to the set of fused nodes
-  fused_nodes_.insert(d->norm);
-  fused_nodes_.insert(d->actv);
+  fused_nodes.insert(d->norm);
+  fused_nodes.insert(d->actv);
 
   // and remove them from the graph
   graph_->RemoveNode(const_cast<Node*>(d->norm));
@@ -1039,11 +1042,12 @@ void ROCmFusionOpBatchNormActivation::CreateFusionOp(const FusionData* d) {
 // ROCmFusionOpAddRelu implementation
 // ----------------------------------------------
 
-bool ROCmFusionOpAddRelu::DoFusion(const Node* n2) {
+bool ROCmFusionOpAddRelu::DoFusion(const Node* n2,
+                                   std::set<const Node*>& fused_nodes) {
   bool did_fusion = false;
   FusionData d;
   if (IsFusionEligible(n2, &d)) {
-    CreateFusionOp(&d);
+    CreateFusionOp(&d, fused_nodes);
     did_fusion = true;
   }
   return did_fusion;
@@ -1118,7 +1122,8 @@ bool ROCmFusionOpAddRelu::IsFusionEligible(const Node* n2, FusionData* d) {
   return is_eligible;
 }
 
-void ROCmFusionOpAddRelu::CreateFusionOp(const FusionData* d) {
+void ROCmFusionOpAddRelu::CreateFusionOp(const FusionData* d,
+                                         std::set<const Node*>& fused_nodes) {
   std::vector<const Edge*> add_input_edges;
   TF_CHECK_OK(d->add->input_edges(&add_input_edges));
 
@@ -1177,8 +1182,8 @@ void ROCmFusionOpAddRelu::CreateFusionOp(const FusionData* d) {
   VLOG(kVlogLevel) << "===========";
 
   // add the now redundant nodes to the set of fused nodes
-  fused_nodes_.insert(d->add);
-  fused_nodes_.insert(d->relu);
+  fused_nodes.insert(d->add);
+  fused_nodes.insert(d->relu);
 
   // and remove them from the graph
   graph_->RemoveNode(const_cast<Node*>(d->add));
@@ -1191,11 +1196,12 @@ void ROCmFusionOpAddRelu::CreateFusionOp(const FusionData* d) {
 // ROCmFusionOpAddNReluGrad implementation
 // ----------------------------------------------
 
-bool ROCmFusionOpAddNReluGrad::DoFusion(const Node* n2) {
+bool ROCmFusionOpAddNReluGrad::DoFusion(const Node* n2,
+                                        std::set<const Node*>& fused_nodes) {
   bool did_fusion = false;
   FusionData d;
   if (IsFusionEligible(n2, &d)) {
-    CreateFusionOp(&d);
+    CreateFusionOp(&d, fused_nodes);
     did_fusion = true;
   }
   return did_fusion;
@@ -1297,7 +1303,8 @@ bool ROCmFusionOpAddNReluGrad::IsFusionEligible(const Node* n2, FusionData* d) {
   return is_eligible;
 }
 
-void ROCmFusionOpAddNReluGrad::CreateFusionOp(const FusionData* d) {
+void ROCmFusionOpAddNReluGrad::CreateFusionOp(
+    const FusionData* d, std::set<const Node*>& fused_nodes) {
   std::vector<const Edge*> addN_input_edges;
   TF_CHECK_OK(d->addN->input_edges(&addN_input_edges));
 
@@ -1367,8 +1374,8 @@ void ROCmFusionOpAddNReluGrad::CreateFusionOp(const FusionData* d) {
   VLOG(kVlogLevel) << "===========";
 
   // add the now redundant nodes to the set of fused nodes
-  fused_nodes_.insert(d->addN);
-  fused_nodes_.insert(d->reluGrad);
+  fused_nodes.insert(d->addN);
+  fused_nodes.insert(d->reluGrad);
 
   // and remove them from the graph
   graph_->RemoveNode(const_cast<Node*>(d->addN));

--- a/tensorflow/core/kernels/gpu_fusion_ops.h
+++ b/tensorflow/core/kernels/gpu_fusion_ops.h
@@ -34,6 +34,13 @@ void FusionAddRelu(OpKernelContext* ctx, const float* in0, const float* in1,
 void FusionAddRelu(OpKernelContext* ctx, const Eigen::half* in0,
                    const Eigen::half* in1, Eigen::half* out, unsigned N);
 
+void FusionAddReluBcast(OpKernelContext* ctx, const float* in0,
+                        const float* in1, float* out, unsigned N, unsigned M);
+
+void FusionAddReluBcast(OpKernelContext* ctx, const Eigen::half* in0,
+                        const Eigen::half* in1, Eigen::half* out, unsigned N,
+                        unsigned M);
+
 void FusionAddNReluGrad(OpKernelContext* ctx, const float* in0,
                         const float* in1, const float* in2, float* out,
                         unsigned N);

--- a/tensorflow/core/kernels/gpu_fusion_ops_custom.cu.cc
+++ b/tensorflow/core/kernels/gpu_fusion_ops_custom.cu.cc
@@ -28,6 +28,20 @@ typedef Eigen::GpuDevice GPUDevice;
 namespace rocm_kernels {
 
 //-------------------------------------------------------------------
+
+// The "__hgt2" routine seems to return a '-1' for 'true' instead of '+1'
+// Also there is no 'abs' routine for 'half2', which we can use to convert the
+// '-1' to a '+1'. Since the RHS op in both instances of our usage of the __hgt2
+// is 0, creating a custom "> 0" routine for half2 that will return '+1' for
+// true
+
+inline __device__ half2 greaterThanZero(half2 in) {
+  return half2(static_cast<__half2_raw>(in).data.x > 0.0f16,
+               static_cast<__half2_raw>(in).data.y > 0.0f16);
+}
+
+//-------------------------------------------------------------------
+
 __global__ void AddReluKernel(int nthreads, const float* in0, const float* in1,
                               float* out) {
   GPU_1D_KERNEL_LOOP(index, nthreads) {
@@ -46,11 +60,9 @@ void FusionAddRelu(OpKernelContext* ctx, const float* in0, const float* in1,
 
 __global__ void AddReluKernel(int nthreads, const half2* in0, const half2* in1,
                               half2* out) {
-  half2 kZero(0.0f16, 0.0f16);
-
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     half2 sum = __hadd2(in0[index], in1[index]);
-    out[index] = __hmul2(__hgt2(sum, kZero), sum);
+    out[index] = __hmul2(greaterThanZero(sum), sum);
   }
 }
 
@@ -67,9 +79,9 @@ void FusionAddRelu(OpKernelContext* ctx, const Eigen::half* in0,
                     dim3(config.thread_per_block), 0, d.stream(),
                     config.virtual_thread_count, h_in0, h_in1, h_out);
 }
-
   
 //-------------------------------------------------------------------
+
 __global__ void AddNReluGradKernel(int nthreads, const float* in0,
                                    const float* in1, const float* in2,
                                    float* out) {
@@ -91,11 +103,9 @@ void FusionAddNReluGrad(OpKernelContext* ctx, const float* in0,
 __global__ void AddNReluGradKernel(int nthreads, const half2* in0,
                                    const half2* in1, const half2* in2,
                                    half2* out) {
-  half2 kZero(0.0f16, 0.0f16);
-
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     out[index] =
-      __hmul2(__hgt2(in2[index], kZero), __hadd2(in0[index], in1[index]));
+        __hmul2(greaterThanZero(in2[index]), __hadd2(in0[index], in1[index]));
   }
 }
 


### PR DESCRIPTION
PR Contents:
-------------------------------
workaround for the issue where __hgt2 returns -1 (instead of 1) for true

-------------------------------
 ROCm Fusion Pass updates

1. change the pass to traverse the TF graph individually for each fusion

2. add env vars to disable fusions on an individual basis (to help with debug / perf measurements)

   By default, ROCm FUSION is turned OFF
     - Setting the env var TF_ROCM_FUSION_ENABLE (to any value) turns ALL the fusion ops ON

   When the env var TF_ROCM_FUSION_ENABLE is set
   - set `TF_ROCM_FUSION_DISABLE_<type>` to disable `<type>` fusion, where <type> can be
     - `CBA` : Conv+Bias+Actv
     - `BNA` : BatchNorm+Actv
     - `ADDRELU` : Add+Relu
     - `ADDNRELUGRAD` - AddN+ReluGrad

-------------------------------

 AddRelu Kernel implementation updates

1. added to check to error out when assumptions regarding the shape of the input tensors are not correct

2. added a simple "broadcast" version of the AddRelu Kernel to make the models/image/tutorial/mnist testcase work correctly
   the mnist testcase was giving incorrect results because the "Add" operation requires broadcasting.
   the "Add" operation in the resenet50 model is element-wise (i.e. does not require any broadcast) so this change does not affect it all.
-------------------------------