### PR TITLE
Fixes for some unit test fails 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2890,7 +2890,7 @@ std::tuple<llvm::Value*, llvm::Value*> CalculateYXCoordinateWithinTile(
 #ifdef GOOGLE_CUDA
   llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x;
 #elif TENSORFLOW_USE_ROCM
-  llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::r600_read_tidig_x;
+  llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::amdgcn_workitem_id_x;
 #endif
   llvm::Value* thread_id =
       llvm_ir::EmitCallToIntrinsic(tid_intrinsic, {}, {}, builder);
@@ -2911,7 +2911,7 @@ llvm::Value* GetBlockIdx(llvm::IRBuilder<>* builder, llvm::Type* index_ty,
   llvm::Intrinsic::ID groupid_intrinsic =
       llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x;
 #elif TENSORFLOW_USE_ROCM
-  llvm::Intrinsic::ID groupid_intrinsic = llvm::Intrinsic::r600_read_tgid_x;
+  llvm::Intrinsic::ID groupid_intrinsic = llvm::Intrinsic::amdgcn_workgroup_id_x;
 #endif
   llvm::Value* block_id =
       llvm_ir::EmitCallToIntrinsic(groupid_intrinsic, {}, {}, builder);

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2891,9 +2891,9 @@ std::tuple<llvm::Value*, llvm::Value*> CalculateYXCoordinateWithinTile(
   llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x;
 #elif TENSORFLOW_USE_ROCM
   llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::r600_read_tidig_x;
-#endif 
-  llvm::Value* thread_id = llvm_ir::EmitCallToIntrinsic(
-      tid_intrinsic, {}, {}, builder);
+#endif
+  llvm::Value* thread_id =
+      llvm_ir::EmitCallToIntrinsic(tid_intrinsic, {}, {}, builder);
   llvm_ir::AddRangeMetadata(0, threads_per_tile,
                             llvm::cast<llvm::Instruction>(thread_id));
   thread_id = builder->CreateIntCast(thread_id, tile_size->getType(),
@@ -2908,12 +2908,13 @@ std::tuple<llvm::Value*, llvm::Value*> CalculateYXCoordinateWithinTile(
 llvm::Value* GetBlockIdx(llvm::IRBuilder<>* builder, llvm::Type* index_ty,
                          int64 num_blocks) {
 #ifdef GOOGLE_CUDA
-  llvm::Intrinsic::ID groupid_intrinsic = llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x;
+  llvm::Intrinsic::ID groupid_intrinsic =
+      llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x;
 #elif TENSORFLOW_USE_ROCM
   llvm::Intrinsic::ID groupid_intrinsic = llvm::Intrinsic::r600_read_tgid_x;
-#endif 
-  llvm::Value* block_id = llvm_ir::EmitCallToIntrinsic(
-      groupid_intrinsic, {}, {}, builder);
+#endif
+  llvm::Value* block_id =
+      llvm_ir::EmitCallToIntrinsic(groupid_intrinsic, {}, {}, builder);
   llvm_ir::AddRangeMetadata(0, num_blocks,
                             llvm::cast<llvm::Instruction>(block_id));
   return builder->CreateIntCast(block_id, index_ty, /*isSigned=*/true,
@@ -3161,13 +3162,11 @@ LaunchDimensions IrEmitterUnnested::EmitHlo021Tile(
   // output before the other thread copies it from input to tile.
   // This is `__syncthreads` in CUDA.
 #ifdef GOOGLE_CUDA
-  llvm::Intrinsic::ID barrier_intrinsic_id = llvm::Intrinsic::nvvm_barrier0;;
-  llvm_ir::EmitCallToIntrinsic(barrier_intrinsic_id, {}, {}, &b_);
+  llvm::Intrinsic::ID barrier_intrinsic_id = llvm::Intrinsic::nvvm_barrier0;
 #elif TENSORFLOW_USE_ROCM
   llvm::Intrinsic::ID barrier_intrinsic_id = llvm::Intrinsic::amdgcn_s_barrier;
+#endif
   llvm_ir::EmitCallToIntrinsic(barrier_intrinsic_id, {}, {}, &b_);
-#endif 
-
 
   llvm_ir::TiledParameterInfo tiled_param_info(param_shmem_buffers, y, x);
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -2887,10 +2887,10 @@ std::tuple<llvm::Value*, llvm::Value*> CalculateYXCoordinateWithinTile(
     int64 threads_per_tile) {
   // Calculate the starting element coordinate within a tile for the current
   // thread, (y, x) from thread_id.
-#ifdef GOOGLE_CUDA
-  llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x;
-#elif TENSORFLOW_USE_ROCM
+#if TENSORFLOW_USE_ROCM
   llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::amdgcn_workitem_id_x;
+#else
+  llvm::Intrinsic::ID tid_intrinsic = llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x;
 #endif
   llvm::Value* thread_id =
       llvm_ir::EmitCallToIntrinsic(tid_intrinsic, {}, {}, builder);
@@ -2907,11 +2907,12 @@ std::tuple<llvm::Value*, llvm::Value*> CalculateYXCoordinateWithinTile(
 // it's in the range [0, num_blocks].
 llvm::Value* GetBlockIdx(llvm::IRBuilder<>* builder, llvm::Type* index_ty,
                          int64 num_blocks) {
-#ifdef GOOGLE_CUDA
+#if TENSORFLOW_USE_ROCM
+  llvm::Intrinsic::ID groupid_intrinsic =
+      llvm::Intrinsic::amdgcn_workgroup_id_x;
+#else
   llvm::Intrinsic::ID groupid_intrinsic =
       llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x;
-#elif TENSORFLOW_USE_ROCM
-  llvm::Intrinsic::ID groupid_intrinsic = llvm::Intrinsic::amdgcn_workgroup_id_x;
 #endif
   llvm::Value* block_id =
       llvm_ir::EmitCallToIntrinsic(groupid_intrinsic, {}, {}, builder);
@@ -3161,10 +3162,10 @@ LaunchDimensions IrEmitterUnnested::EmitHlo021Tile(
   // Wait for all threads to reach this point, lest we copy a value from tile to
   // output before the other thread copies it from input to tile.
   // This is `__syncthreads` in CUDA.
-#ifdef GOOGLE_CUDA
-  llvm::Intrinsic::ID barrier_intrinsic_id = llvm::Intrinsic::nvvm_barrier0;
-#elif TENSORFLOW_USE_ROCM
+#if TENSORFLOW_USE_ROCM
   llvm::Intrinsic::ID barrier_intrinsic_id = llvm::Intrinsic::amdgcn_s_barrier;
+#else
+  llvm::Intrinsic::ID barrier_intrinsic_id = llvm::Intrinsic::nvvm_barrier0;
 #endif
   llvm_ir::EmitCallToIntrinsic(barrier_intrinsic_id, {}, {}, &b_);
 

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/amdgpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/amdgpu_backend_lib.cc
@@ -263,6 +263,7 @@ std::vector<uint8> EmitModuleToHsaco(Module* module, llvm::TargetMachine* target
   llvm::raw_svector_ostream pstream(stream);
   std::unique_ptr<llvm::raw_fd_ostream> isabin_fs(
       new llvm::raw_fd_ostream(isabin_path, ec, llvm::sys::fs::F_Text));
+  module->setDataLayout(target_machine->createDataLayout());
   target_machine->addPassesToEmitFile(codegen_passes, *isabin_fs, nullptr,
                                       llvm::TargetMachine::CGFT_ObjectFile);
   codegen_passes.run(*module);

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -52,7 +52,11 @@ string CanonicalPlatformName(const string& name) {
   }
   // "gpu" and "cuda" mean the same thing.
   if (platform_str == "gpu") {
+#ifdef GOOGLE_CUDA
     platform_str = "cuda";
+#elif TENSORFLOW_USE_ROCM
+    platform_str = "rocm";
+#endif 
   }
   return platform_str;
 }

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -52,10 +52,10 @@ string CanonicalPlatformName(const string& name) {
   }
   // "gpu" and "cuda" mean the same thing.
   if (platform_str == "gpu") {
-#ifdef GOOGLE_CUDA
-    platform_str = "cuda";
-#elif TENSORFLOW_USE_ROCM
+#if TENSORFLOW_USE_ROCM
     platform_str = "rocm";
+#else
+    platform_str = "cuda";
 #endif 
   }
   return platform_str;

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -1741,9 +1741,6 @@ bool MIOpenSupport::DoConvolveImpl(
 
     algo_sz = get_algorithm();
 
-    // MIOpen requires workspace:
-    assert (scratch != nullptr) ;
-
   } else {
     // An algorithm has been specified.
     dnn::AlgorithmDesc algo = algorithm_config.algorithm();

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -722,28 +722,6 @@ bool ROCMExecutor::DeviceMemoryUsage(int64 *free, int64 *total) const {
 
 bool ROCMExecutor::GetSymbol(const string& symbol_name, ModuleHandle module_handle, void **mem,
                              size_t *bytes) {
-/*  {  // give limited scope to mutex_lock
-    mutex_lock lock{disk_modules_mu_};
-    for (auto &it : disk_modules_) {
-      if (ROCMDriver::GetModuleSymbol(device_ordinal_, it.second, symbol_name.c_str(),
-                                      reinterpret_cast<hipDeviceptr_t *>(mem),
-                                      bytes)) {
-        return true;
-      }
-    }
-  }
-
-  {  // give limited scope to mutex_lock
-    mutex_lock lock{in_memory_modules_mu_};
-    for (auto &it : in_memory_modules_) {
-      if (ROCMDriver::GetModuleSymbol(device_ordinal_, it.second, symbol_name.c_str(),
-                                      reinterpret_cast<hipDeviceptr_t *>(mem),
-                                      bytes)) {
-        return true;
-      }
-    }
-  }
-*/
   {  // give limited scope to mutex_lock
     mutex_lock lock{in_memory_modules_mu_};
     if (static_cast<bool>(module_handle)) {

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -222,11 +222,11 @@ bool ROCMExecutor::GetKernel(const MultiKernelLoaderSpec &spec,
     module = in_memory_modules_[hsaco];
 
     if (module == nullptr) {
-      if (!ROCMDriver::LoadHsaco(device_ordinal_, hsaco, &module)) {
+      if (!LoadModuleFromHsaco(hsaco, &module)) {
         LOG(ERROR) << "failed to load HSACO\n";
         return false;
       }
-      in_memory_modules_[hsaco] = module;
+
     }
   } else {
     LOG(WARNING) << "no method of loading ROCM kernel provided";
@@ -355,6 +355,7 @@ bool ROCMExecutor::LoadModuleFromHsaco(const char *hsaco, hipModule_t *module) {
       return false;
     }
     module_refcount = 1;
+    in_memory_modules_[hsaco] = *module;
     VLOG(3) << "Loaded HSACO " << static_cast<const void *>(hsaco)
             << " as module " << *module;
   } else {
@@ -721,7 +722,7 @@ bool ROCMExecutor::DeviceMemoryUsage(int64 *free, int64 *total) const {
 
 bool ROCMExecutor::GetSymbol(const string& symbol_name, ModuleHandle module_handle, void **mem,
                              size_t *bytes) {
-  {  // give limited scope to mutex_lock
+/*  {  // give limited scope to mutex_lock
     mutex_lock lock{disk_modules_mu_};
     for (auto &it : disk_modules_) {
       if (ROCMDriver::GetModuleSymbol(device_ordinal_, it.second, symbol_name.c_str(),
@@ -742,7 +743,7 @@ bool ROCMExecutor::GetSymbol(const string& symbol_name, ModuleHandle module_hand
       }
     }
   }
-
+*/
   {  // give limited scope to mutex_lock
     mutex_lock lock{in_memory_modules_mu_};
     if (static_cast<bool>(module_handle)) {


### PR DESCRIPTION
Fixes include 

1.  Issue with inconsistent loading of kernel modules. Due to how some of the data structures that track which kernels were loaded were not being consistently  updated the kernels were being inconsistently loaded. So cleanup so these data structures are updated in the same manner in different scenarios. 
2. Initialize the llvm module data layout before running the code generation passes
Following fixes are for a convolution unit test 
3. rocm as gpu platform 
4. Use of AMD intrinsics when launching convolution kernels. Previously they were hardcoded as ptx ones 
5. The scratch size requested can be zero in which scratch is nullptr. So assert is not needed 