### PR TITLE
Move scratch_size field from AlgorithmDesc to AlgorithmConfig

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.cc
@@ -327,9 +327,10 @@ StatusOr<CudnnConvParams> GetCudnnConvParams(
   params.window = &conv->window();
   params.dnums = &conv->convolution_dimension_numbers();
   params.feature_group_count = conv->feature_group_count();
-  params.algorithm = se::dnn::AlgorithmConfig(se::dnn::AlgorithmDesc(
-      backend_config.algorithm(), backend_config.tensor_ops_enabled(),
-      backend_config.scratch_size()));
+  params.algorithm = se::dnn::AlgorithmConfig(
+      se::dnn::AlgorithmDesc(backend_config.algorithm(),
+                             backend_config.tensor_ops_enabled()),
+      backend_config.scratch_size());
   params.conv_result_scale = backend_config.conv_result_scale();
 
   switch (kind) {

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -717,31 +717,21 @@ class PoolingDescriptor {
 class AlgorithmDesc {
  public:
   typedef int64 Index;
-  AlgorithmDesc()
-      : algo_(-1), tensor_ops_enabled_(true), scratch_size_(0) {}
   AlgorithmDesc(Index a, bool use_tensor_ops)
-      : algo_(a), tensor_ops_enabled_(use_tensor_ops), scratch_size_(0) {
+      : algo_(a), tensor_ops_enabled_(use_tensor_ops) {
     DCHECK_NE(a, -1);
   }
-  AlgorithmDesc(Index a, bool use_tensor_ops, size_t scratch_size)
-      : algo_(a),
-        tensor_ops_enabled_(use_tensor_ops),	
-        scratch_size_(scratch_size) {}
   bool tensor_ops_enabled() const { return tensor_ops_enabled_; }
   Index algo_id() const { return algo_; }
-  size_t scratch_size() const { return scratch_size_; }	
-  void set_scratch_size(size_t val) { scratch_size_ = val; }
   bool operator==(const AlgorithmDesc& other) const {
     return this->algo_ == other.algo_ &&
-           this->tensor_ops_enabled_ == other.tensor_ops_enabled_ &&
-           this->scratch_size_ == other.scratch_size_;
+           this->tensor_ops_enabled_ == other.tensor_ops_enabled_;
   }
   uint64 hash() const;
 
  private:
   Index algo_;
   bool tensor_ops_enabled_;
-  size_t scratch_size_;
 };
 
 // Describes the result from a perf experiment.
@@ -783,6 +773,8 @@ class AlgorithmConfig {
  public:
   AlgorithmConfig() {}
   explicit AlgorithmConfig(AlgorithmDesc algorithm) : algorithm_(algorithm) {}
+  explicit AlgorithmConfig(AlgorithmDesc algorithm, size_t scratch_size)
+      : algorithm_(algorithm), scratch_size_(scratch_size) {}
   AlgorithmConfig(AlgorithmDesc algorithm, AlgorithmDesc algorithm_no_scratch)
       : algorithm_(algorithm), algorithm_no_scratch_(algorithm_no_scratch) {}
   absl::optional<AlgorithmDesc> algorithm() const { return algorithm_; }
@@ -793,9 +785,12 @@ class AlgorithmConfig {
   void set_algorithm_no_scratch(AlgorithmDesc val) {
     algorithm_no_scratch_ = val;
   }
+  absl::optional<size_t> scratch_size() const { return scratch_size_; }
+  void set_scratch_size(size_t val) { scratch_size_ = val; }
   bool operator==(const AlgorithmConfig& other) const {
     return this->algorithm_ == other.algorithm_ &&
-           this->algorithm_no_scratch_ == other.algorithm_no_scratch_;
+           this->algorithm_no_scratch_ == other.algorithm_no_scratch_ &&
+           this->scratch_size_ == other.scratch_size_;
   }
   bool operator!=(const AlgorithmConfig& other) const {
     return !(*this == other);
@@ -805,6 +800,7 @@ class AlgorithmConfig {
  private:
   absl::optional<AlgorithmDesc> algorithm_;
   absl::optional<AlgorithmDesc> algorithm_no_scratch_;
+  absl::optional<size_t> scratch_size_;
 };
 
 // Describes a local response normalization (LRN). LRN is used e.g. in

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2350,7 +2350,7 @@ bool MIOpenSupport::DoConvolveImpl(
   } else {
     // An algorithm has been specified.
     algo_sz.first = ToConvForwardAlgo(*algo_desc);
-    algo_sz.second = algo_desc->scratch_size();
+    algo_sz.second = *(algorithm_config.scratch_size());
 
     size_t size_in_bytes = algo_sz.second;
     if (size_in_bytes != 0) {
@@ -2404,10 +2404,11 @@ bool MIOpenSupport::DoConvolveImpl(
       return false;
     }
     if (status == miopenStatusSuccess) {
-      dnn::AlgorithmDesc algotype(algo_sz.first, false, algo_sz.second);
+      dnn::AlgorithmDesc algotype(algo_sz.first, false);
       output_profile_result->set_algorithm(algotype);
       output_profile_result->set_elapsed_time_in_ms(
           timer->GetElapsedMilliseconds());
+      output_profile_result->set_scratch_size(algo_sz.second);
     }
     timer->Destroy();
   }
@@ -2914,7 +2915,7 @@ bool MIOpenSupport::DoConvolveBackwardDataImpl(
   } else {
     // An algorithm has been specified.
     algo_sz.first = ToConvBackwardDataAlgo(*algo_desc);
-    algo_sz.second = algo_desc->scratch_size();
+    algo_sz.second = *(algorithm_config.scratch_size());
 
     size_t size_in_bytes = algo_sz.second;
     if (size_in_bytes != 0) {
@@ -2968,10 +2969,11 @@ bool MIOpenSupport::DoConvolveBackwardDataImpl(
   if (is_profiling) {
     timer->Stop(AsROCMStream(stream));
     if (status == miopenStatusSuccess) {
-      dnn::AlgorithmDesc algotype(algo_sz.first, false, algo_sz.second);
+      dnn::AlgorithmDesc algotype(algo_sz.first, false);
       output_profile_result->set_algorithm(algotype);
       output_profile_result->set_elapsed_time_in_ms(
           timer->GetElapsedMilliseconds());
+      output_profile_result->set_scratch_size(algo_sz.second);
     }
     timer->Destroy();
   }
@@ -3138,7 +3140,7 @@ bool MIOpenSupport::DoConvolveBackwardFilterImpl(
     // An algorithm has been specified.
     absl::optional<dnn::AlgorithmDesc> algo_desc = algorithm_config.algorithm();
     algo_sz.first = ToConvBackwardFilterAlgo(*algo_desc);
-    algo_sz.second = algo_desc->scratch_size();
+    algo_sz.second = *(algorithm_config.scratch_size());
 
     size_t size_in_bytes = algo_sz.second;
 
@@ -3192,10 +3194,11 @@ bool MIOpenSupport::DoConvolveBackwardFilterImpl(
   if (is_profiling) {
     timer->Stop(AsROCMStream(stream));
     if (status == miopenStatusSuccess) {
-      dnn::AlgorithmDesc algotype(algo_sz.first, false, algo_sz.second);
+      dnn::AlgorithmDesc algotype(algo_sz.first, false);
       output_profile_result->set_algorithm(algotype);
       output_profile_result->set_elapsed_time_in_ms(
           timer->GetElapsedMilliseconds());
+      output_profile_result->set_scratch_size(algo_sz.second);
     }
     timer->Destroy();
   }


### PR DESCRIPTION
This is a precursor to separate scratch memory allocation from actual invoking convolution algorithms in StreamExecutor.