### PR TITLE
Fix crosstool to pass environment variable to hipcc

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -229,7 +229,7 @@ def main():
     for flag in gpu_compiler_flags:
       modified_gpu_compiler_flags.append("'" + flag + "'")
 
-    HIPCC_ENV_list = HIPCC_ENV.split('=')
+    HIPCC_ENV_list = HIPCC_ENV.split('= ')
     HIPCC_ENV_dict = dict(zip(HIPCC_ENV_list[::2],HIPCC_ENV_list[1::2]))
     cmd = HIPCC_ENV.split() + [HIPCC_PATH] + modified_gpu_compiler_flags
     cmd_str = ' '.join(cmd)


### PR DESCRIPTION
HIPCC_ENV contains both space and =.