### PR TITLE
Remove HIP_AUTO_INCLUDE_HEADER and add HIPCC_COMPILE_FLAGS_APPEND

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -192,7 +192,7 @@ def InvokeHipcc(argv, log=False):
   # TODO(zhengxq): for some reason, 'gcc' needs this help to find 'as'.
   # Need to investigate and fix.
   cmd = 'PATH=' + PREFIX_DIR + ':$PATH '\
-        + HIPCC_ENV + ' '\
+        + HIPCC_ENV.replace(';', ' ') + ' '\
         + cmd
   if log: Log(cmd)
   if VERBOSE: print(cmd)
@@ -229,9 +229,9 @@ def main():
     for flag in gpu_compiler_flags:
       modified_gpu_compiler_flags.append("'" + flag + "'")
 
-    HIPCC_ENV_list = HIPCC_ENV.split('= ')
+    HIPCC_ENV_list = HIPCC_ENV.split('=;')
     HIPCC_ENV_dict = dict(zip(HIPCC_ENV_list[::2],HIPCC_ENV_list[1::2]))
-    cmd = HIPCC_ENV.split() + [HIPCC_PATH] + modified_gpu_compiler_flags
+    cmd = HIPCC_ENV.split(';') + [HIPCC_PATH] + modified_gpu_compiler_flags
     cmd_str = ' '.join(cmd)
     if args.rocm_log: Log('Link with hipcc: %s' %(cmd_str))
     if VERBOSE: print(cmd_str)

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -237,10 +237,10 @@ def _hipcc_env(repository_ctx):
     """
     hipcc_env = ""
     for name in ["HIP_CLANG_PATH", "DEVICE_LIB_PATH", "HIP_VDI_HOME",\
-                 "HIPCC_VERBOSE", "HIP_AUTO_INCLUDE_HEADER"]:
+                 "HIPCC_VERBOSE", "HIPCC_COMPILE_FLAGS_APPEND"]:
         if name in repository_ctx.os.environ:
-            hipcc_env = hipcc_env + " " + name + "=" + \
-                    repository_ctx.os.environ[name].strip()
+            hipcc_env = hipcc_env + " " + name + "=\"" + \
+                    repository_ctx.os.environ[name].strip() + "\";"
     return hipcc_env.strip()
 
 def _crosstool_verbose(repository_ctx):


### PR DESCRIPTION
Since HIP_AUTO_INCLUDE_HEADER was rejected by HIP, need a different way to pre-include hip_runtime.h for hip-clang. HIPCC_COMPILE_FLAGS_APPEND can be used to pass --include=hip/hip_runtime.h to hip-clang.