### PR TITLE
Develop upstream pr 22747

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3093,7 +3093,7 @@ tf_gpu_library(
         "platform/device_tracer.h",
     ],
     copts = tf_copts(),
-    gpu_deps = if_cuda_is_configured(tf_additional_cupti_wrapper_deps() + tf_additional_device_tracer_cuda_deps()),
+    cuda_deps = if_cuda_is_configured(tf_additional_cupti_wrapper_deps() + tf_additional_device_tracer_cuda_deps()),
     visibility = [
         "//tensorflow:internal",
     ],

--- a/tensorflow/core/grappler/BUILD
+++ b/tensorflow/core/grappler/BUILD
@@ -50,7 +50,7 @@ tf_gpu_library(
     name = "devices",
     srcs = ["devices.cc"],
     hdrs = ["devices.h"],
-    gpu_deps = [
+    cuda_deps = [
         "//tensorflow/core:gpu_init",
         "//tensorflow/core:stream_executor",
     ],

--- a/tensorflow/core/grappler/clusters/BUILD
+++ b/tensorflow/core/grappler/clusters/BUILD
@@ -20,7 +20,7 @@ tf_gpu_library(
     name = "utils",
     srcs = ["utils.cc"],
     hdrs = ["utils.h"],
-    gpu_deps = [
+    cuda_deps = [
         "@local_config_cuda//cuda:cudnn_header",
     ],
     visibility = ["//visibility:public"],

--- a/tensorflow/core/grappler/costs/BUILD
+++ b/tensorflow/core/grappler/costs/BUILD
@@ -132,7 +132,7 @@ tf_gpu_library(
     name = "utils",
     srcs = ["utils.cc"],
     hdrs = ["utils.h"],
-    gpu_deps = [
+    cuda_deps = [
         "@local_config_cuda//cuda:cudnn_header",
     ],
     visibility = ["//visibility:public"],

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -313,7 +313,7 @@ tf_gpu_library(
     testonly = 1,
     srcs = ["ops_testutil.cc"],
     hdrs = ["ops_testutil.h"],
-    gpu_deps = [
+    cuda_deps = [
         "//tensorflow/core:gpu_lib",
         "//tensorflow/core:gpu_runtime",
     ],

--- a/tensorflow/core/platform/default/build_config_root.bzl
+++ b/tensorflow/core/platform/default/build_config_root.bzl
@@ -5,6 +5,10 @@
 def tf_gpu_tests_tags():
     return ["requires-gpu", "local", "gpu"]
 
+# terminology changes: saving tf_cuda_* for compatibility
+def tf_cuda_tests_tags():
+    return tf_gpu_tests_tags()
+
 def tf_sycl_tests_tags():
     return ["requires-gpu", "local", "gpu"]
 

--- a/tensorflow/core/platform/default/gpu/BUILD
+++ b/tensorflow/core/platform/default/gpu/BUILD
@@ -13,7 +13,7 @@ tf_gpu_library(
         "cupti_wrapper.h",
     ],
     copts = tf_copts(),
-    gpu_deps = [
+    cuda_deps = [
         "//tensorflow/core:stream_executor",
         "@local_config_cuda//cuda:cupti_headers",
     ],

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -9,6 +9,7 @@ load(
     "tf_additional_grpc_deps_py",
     "tf_additional_xla_deps_py",
     "tf_gpu_tests_tags",
+    "tf_cuda_tests_tags",
     "tf_sycl_tests_tags",
 )
 load(
@@ -859,11 +860,45 @@ def tf_gpu_cc_test(
             "@local_config_cuda//cuda:using_clang": 1,
             "//conditions:default": 0,
         }),
-        suffix = "_gpu",
         tags = tags + tf_gpu_tests_tags(),
-        deps = deps + [ 
-            clean_dep("//tensorflow/core:gpu_runtime"),
-        ],
+        data = data,
+        size = size,
+        extra_copts = extra_copts,
+        linkopts = linkopts,
+        args = args,
+        kernels = kernels,
+    )
+
+register_extension_info(
+    extension_name = "tf_gpu_cc_test",
+    label_regex_for_dep = "{extension_name}",
+)
+
+# terminology changes: saving tf_cuda_* definition for compatibility
+def tf_cuda_cc_test(
+        name,
+        srcs = [],
+        deps = [],
+        tags = [],
+        data = [],
+        size = "medium",
+        extra_copts = [],
+        linkstatic = 0,
+        args = [],
+        kernels = [],
+        linkopts = []):
+    tf_gpu_cc_test(
+        name,
+        srcs = srcs,
+        deps = deps,
+        tags = tags,
+        data = data,
+        size = size,
+        extra_copts = extra_copts,
+        linkstatic = linkstatic,
+        linkopts = linkopts,
+        args = args,
+        kernels = kernels,
     )
 
 register_extension_info(
@@ -906,6 +941,36 @@ def tf_gpu_only_cc_test(
             "//conditions:default": 0,
         }),
         tags = tags + tf_gpu_tests_tags(),
+    )
+
+register_extension_info(
+    extension_name = "tf_gpu_only_cc_test",
+    label_regex_for_dep = "{extension_name}_gpu",
+)
+
+# terminology changes: saving tf_cuda_* definition for compatibility
+def tf_cuda_only_cc_test(
+        name,
+        srcs = [],
+        deps = [],
+        tags = [],
+        data = [],
+        size = "medium",
+        linkstatic = 0,
+        args = [],
+        kernels = [],
+        linkopts = []):
+    tf_gpu_only_cc_test(
+        name,
+        srcs = srcs,
+        deps = deps,
+        tags = tags,
+        data = data,
+        size = size,
+        linkstatic = linkstatic,
+        args = args,
+        kernels = kernels,
+        linkopts = linkopts,
     )
 
 register_extension_info(
@@ -1011,6 +1076,29 @@ def tf_gpu_cc_tests(
             deps = deps,
         )
 
+# terminology changes: saving tf_cuda_* definition for compatibility
+def tf_cuda_cc_tests(
+        srcs,
+        deps,
+        name = "",
+        tags = [],
+        size = "medium",
+        linkstatic = 0,
+        args = None,
+        kernels = [],
+        linkopts = []):
+    tf_gpu_cc_tests(
+        srcs,
+        deps,
+        name = name,
+        tags = tags,
+        size = size,
+        linkstatic = linkstatic,
+        args = args,
+        kernels = kernels,
+        linkopts = linkopts,
+    )
+
 def tf_java_test(
         name,
         srcs = [],
@@ -1088,7 +1176,7 @@ register_extension_info(
     label_regex_for_dep = "{extension_name}",
 )
 
-def tf_gpu_library(deps = None, gpu_deps = None, copts = tf_copts(), **kwargs):
+def tf_gpu_library(deps = None, cuda_deps = None, copts = tf_copts(), **kwargs):
     """Generate a cc_library with a conditional set of CUDA dependencies.
 
     When the library is built with --config=cuda:
@@ -1126,6 +1214,20 @@ def tf_gpu_library(deps = None, gpu_deps = None, copts = tf_copts(), **kwargs):
 
 register_extension_info(
     extension_name = "tf_gpu_library",
+    label_regex_for_dep = "{extension_name}",
+)
+
+# terminology changes: saving tf_cuda_* definition for compatibility
+def tf_cuda_library(deps = None, cuda_deps = None, copts = tf_copts(), **kwargs):
+    tf_gpu_library(
+        deps = deps,
+        cuda_deps = cuda_deps,
+        copts = copts,
+        **kwargs
+    )
+
+register_extension_info(
+    extension_name = "tf_cuda_library",
     label_regex_for_dep = "{extension_name}",
 )
 
@@ -1857,6 +1959,42 @@ register_extension_info(
     label_regex_map = {"additional_deps": "additional_deps:{extension_name}"},
 )
 
+# terminology changes: saving cuda_* definition for compatibility
+def cuda_py_test(
+        name,
+        srcs,
+        size = "medium",
+        data = [],
+        main = None,
+        args = [],
+        shard_count = 1,
+        additional_deps = [],
+        kernels = [],
+        tags = [],
+        flaky = 0,
+        xla_enabled = False,
+        grpc_enabled = False):
+    gpu_py_test(
+        name = name,
+        srcs = srcs,
+        size = size,
+        data = data,
+        main = main,
+        args = args,
+        shard_count = shard_count,
+        additional_deps = additional_deps,
+        kernels = kernels,
+        tags = tags,
+        flaky = flaky,
+        xla_enabled = xla_enabled,
+        grpc_enabled = grpc_enabled,
+    )
+
+register_extension_info(
+    extension_name = "cuda_py_test",
+    label_regex_map = {"additional_deps": "additional_deps:{extension_name}"},
+)
+
 def sycl_py_test(
         name,
         srcs,
@@ -1948,6 +2086,33 @@ def gpu_py_tests(
         shard_count = shard_count,
         tags = test_tags,
         xla_enabled = xla_enabled,
+    )
+
+# terminology changes: saving cuda_* definition for compatibility
+def cuda_py_tests(
+        name,
+        srcs,
+        size = "medium",
+        additional_deps = [],
+        kernels = [],
+        data = [],
+        shard_count = 1,
+        tags = [],
+        prefix = "",
+        xla_enabled = False,
+        grpc_enabled = False):
+    gpu_py_tests(
+        name,
+        srcs,
+        size = size,
+        additional_deps = additional_deps,
+        kernels = kernels,
+        data = data,
+        shard_count = shard_count,
+        tags = tags,
+        prefix = prefix,
+        xla_enabled = xla_enabled,
+        grpc_enabled = grpc_enabled,
     )
 
 # Creates a genrule named <name> for running tools/proto_text's generator to


### PR DESCRIPTION
This PR merges back upstream#22747 from @parallelo back to develop-upstream branch. It provides backward compatibility to tf_cuda* and cuda_py* terminologies. 
Upstream PR link:
https://github.com/tensorflow/tensorflow/pull/22747