### PR TITLE
Terminology restore cuda_py_test

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -18,8 +18,8 @@ package(
     default_visibility = [":internal"],
 )
 
-load("//tensorflow:tensorflow.bzl", "tf_gpu_cc_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "tf_cuda_cc_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow/compiler/aot:tfcompile.bzl", "tf_library")
 load("//tensorflow/compiler/tests:build_defs.bzl", "tf_xla_py_test")
 load("//tensorflow/compiler/tests:build_defs.bzl", "generate_backend_suites")
@@ -1033,7 +1033,7 @@ tf_xla_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "xla_device_gpu_test",
     size = "small",
     srcs = ["xla_device_gpu_test.py"],
@@ -1047,7 +1047,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "jit_test",
     size = "medium",
     srcs = ["jit_test.py"],
@@ -1066,7 +1066,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dense_layer_test",
     size = "small",
     srcs = ["dense_layer_test.py"],
@@ -1105,7 +1105,7 @@ cc_library(
     ],
 )
 
-tf_gpu_cc_test(
+tf_cuda_cc_test(
     name = "randomized_tests",
     size = "large",
     # This test is randomized, so only run it if explicitly requested.
@@ -1130,7 +1130,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "lstm_test",
     srcs = ["lstm_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/bayesflow/BUILD
+++ b/tensorflow/contrib/bayesflow/BUILD
@@ -12,7 +12,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "bayesflow_py",
@@ -37,7 +37,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "monte_carlo_test",
     size = "small",
     srcs = ["python/kernel_tests/monte_carlo_test.py"],

--- a/tensorflow/contrib/compiler/BUILD
+++ b/tensorflow/contrib/compiler/BUILD
@@ -13,7 +13,7 @@ package_group(
 )
 
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "compiler_py",
@@ -28,7 +28,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "jit_test",
     size = "small",
     srcs = ["jit_test.py"],

--- a/tensorflow/contrib/crf/BUILD
+++ b/tensorflow/contrib/crf/BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//tensorflow:__subpackages__"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 
 py_library(
     name = "crf_py",
@@ -26,7 +26,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "crf_test",
     srcs = ["python/kernel_tests/crf_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/cudnn_rnn/BUILD
+++ b/tensorflow/contrib/cudnn_rnn/BUILD
@@ -9,7 +9,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 tf_custom_op_py_library(
@@ -40,7 +40,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cudnn_rnn_ops_test",
     size = "medium",
     srcs = ["python/kernel_tests/cudnn_rnn_ops_test.py"],
@@ -69,7 +69,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cudnn_rnn_test",
     size = "enormous",
     srcs = ["python/kernel_tests/cudnn_rnn_test.py"],
@@ -96,7 +96,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cudnn_rnn_ops_benchmark",
     size = "small",
     srcs = ["python/kernel_tests/cudnn_rnn_ops_benchmark.py"],

--- a/tensorflow/contrib/data/python/kernel_tests/BUILD
+++ b/tensorflow/contrib/data/python/kernel_tests/BUILD
@@ -4,7 +4,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 
 py_test(

--- a/tensorflow/contrib/distribute/python/BUILD
+++ b/tensorflow/contrib/distribute/python/BUILD
@@ -11,12 +11,12 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 # TODO(priyag): Figure out testonly issues that are preventing us from
 # including our tests in pip for now.
 
-gpu_py_test(
+cuda_py_test(
     name = "values_test",
     srcs = ["values_test.py"],
     additional_deps = [
@@ -75,7 +75,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "parameter_server_strategy_test",
     srcs = ["parameter_server_strategy_test.py"],
     additional_deps = [
@@ -218,7 +218,7 @@ py_test(
 )
 
 # TODO(priyag): Rename this test to mirrored_strategy_test
-gpu_py_test(
+cuda_py_test(
     name = "mirrored_strategy_multigpu_test",
     srcs = ["mirrored_strategy_multigpu_test.py"],
     additional_deps = [
@@ -293,7 +293,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "collective_all_reduce_strategy_test",
     srcs = ["collective_all_reduce_strategy_test.py"],
     additional_deps = [
@@ -347,7 +347,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "minimize_loss_test",
     srcs = ["minimize_loss_test.py"],
     additional_deps = [
@@ -359,7 +359,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "moving_averages_test",
     srcs = ["moving_averages_test.py"],
     additional_deps = [
@@ -377,7 +377,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "optimizer_v2_test",
     srcs = ["optimizer_v2_test.py"],
     additional_deps = [
@@ -396,7 +396,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "estimator_integration_test",
     srcs = ["estimator_integration_test.py"],
     additional_deps = [
@@ -420,7 +420,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "keras_optimizer_v2_test",
     srcs = ["keras_optimizer_v2_test.py"],
     additional_deps = [
@@ -434,7 +434,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "estimator_training_test",
     srcs = ["estimator_training_test.py"],
     additional_deps = [
@@ -497,7 +497,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "step_fn_test",
     srcs = ["step_fn_test.py"],
     additional_deps = [
@@ -519,7 +519,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "monitor_test",
     srcs = ["monitor_test.py"],
     additional_deps = [
@@ -540,7 +540,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cross_device_utils_test",
     srcs = ["cross_device_utils_test.py"],
     additional_deps = [
@@ -558,7 +558,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cross_device_ops_test",
     srcs = ["cross_device_ops_test.py"],
     additional_deps = [
@@ -598,7 +598,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "keras_test",
     srcs = ["keras_test.py"],
     additional_deps = [
@@ -629,7 +629,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "metrics_v1_test",
     srcs = ["metrics_v1_test.py"],
     additional_deps = [
@@ -641,7 +641,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "warm_starting_util_test",
     size = "medium",
     srcs = ["warm_starting_util_test.py"],
@@ -659,7 +659,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "checkpoint_utils_test",
     size = "medium",
     srcs = ["checkpoint_utils_test.py"],

--- a/tensorflow/contrib/distributions/BUILD
+++ b/tensorflow/contrib/distributions/BUILD
@@ -11,7 +11,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "bijectors_py",
@@ -85,7 +85,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "estimator_test",
     size = "small",
     srcs = ["python/kernel_tests/estimator_test.py"],
@@ -104,7 +104,7 @@ gpu_py_test(
     tags = ["no_pip"],  # contrib/learn:head_test is not available in pip.
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "distribution_test",
     size = "medium",
     srcs = ["python/kernel_tests/distribution_test.py"],
@@ -120,7 +120,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conditional_distribution_test",
     size = "medium",
     srcs = [
@@ -140,7 +140,7 @@ gpu_py_test(
     tags = ["no_pip"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "autoregressive_test",
     size = "small",
     srcs = ["python/kernel_tests/autoregressive_test.py"],
@@ -153,7 +153,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "binomial_test",
     size = "small",
     srcs = ["python/kernel_tests/binomial_test.py"],
@@ -167,7 +167,7 @@ gpu_py_test(
     tags = ["notap"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cauchy_test",
     size = "medium",
     srcs = ["python/kernel_tests/cauchy_test.py"],
@@ -184,7 +184,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "chi2_test",
     srcs = ["python/kernel_tests/chi2_test.py"],
     additional_deps = [
@@ -198,7 +198,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "deterministic_test",
     size = "small",
     srcs = ["python/kernel_tests/deterministic_test.py"],
@@ -215,7 +215,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "geometric_test",
     size = "small",
     srcs = ["python/kernel_tests/geometric_test.py"],
@@ -231,7 +231,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "half_normal_test",
     size = "medium",
     srcs = ["python/kernel_tests/half_normal_test.py"],
@@ -249,7 +249,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "inverse_gamma_test",
     srcs = ["python/kernel_tests/inverse_gamma_test.py"],
     additional_deps = [
@@ -264,7 +264,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "kumaraswamy_test",
     srcs = ["python/kernel_tests/kumaraswamy_test.py"],
     additional_deps = [
@@ -279,7 +279,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "moving_stats_test",
     size = "small",
     srcs = ["python/kernel_tests/moving_stats_test.py"],
@@ -297,7 +297,7 @@ gpu_py_test(
     tags = ["nomsan"],  # disable to avoid false positives from scipy.
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mvn_diag_test",
     size = "medium",
     srcs = ["python/kernel_tests/mvn_diag_test.py"],
@@ -314,7 +314,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mvn_diag_plus_low_rank_test",
     size = "medium",
     srcs = ["python/kernel_tests/mvn_diag_plus_low_rank_test.py"],
@@ -331,7 +331,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mvn_full_covariance_test",
     size = "small",
     srcs = ["python/kernel_tests/mvn_full_covariance_test.py"],
@@ -348,7 +348,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mvn_tril_test",
     size = "medium",
     srcs = ["python/kernel_tests/mvn_tril_test.py"],
@@ -366,7 +366,7 @@ gpu_py_test(
     tags = ["nomsan"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mixture_test",
     size = "medium",
     srcs = ["python/kernel_tests/mixture_test.py"],
@@ -388,7 +388,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mixture_same_family_test",
     size = "small",
     srcs = ["python/kernel_tests/mixture_same_family_test.py"],
@@ -401,7 +401,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "negative_binomial_test",
     size = "small",
     srcs = ["python/kernel_tests/negative_binomial_test.py"],
@@ -417,7 +417,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "poisson_test",
     size = "small",
     srcs = ["python/kernel_tests/poisson_test.py"],
@@ -431,7 +431,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "poisson_lognormal_test",
     size = "medium",
     srcs = ["python/kernel_tests/poisson_lognormal_test.py"],
@@ -442,7 +442,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sinh_arcsinh_test",
     size = "medium",
     srcs = ["python/kernel_tests/sinh_arcsinh_test.py"],
@@ -456,7 +456,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "independent_test",
     size = "small",
     srcs = ["python/kernel_tests/independent_test.py"],
@@ -471,7 +471,7 @@ gpu_py_test(
     tags = ["no_windows"],  # TODO: needs investigation on Windows
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "batch_reshape_test",
     size = "medium",
     srcs = ["python/kernel_tests/batch_reshape_test.py"],
@@ -485,7 +485,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sample_stats_test",
     size = "medium",
     srcs = ["python/kernel_tests/sample_stats_test.py"],
@@ -504,7 +504,7 @@ gpu_py_test(
     tags = ["nomsan"],  # disable to avoid false positives from scipy.
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "seed_stream_test",
     size = "small",
     srcs = ["python/kernel_tests/seed_stream_test.py"],
@@ -514,7 +514,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "statistical_testing_test",
     size = "medium",
     srcs = [
@@ -528,7 +528,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "vector_sinh_arcsinh_diag_test",
     size = "medium",
     srcs = ["python/kernel_tests/vector_sinh_arcsinh_diag_test.py"],
@@ -542,7 +542,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "vector_exponential_diag_test",
     size = "medium",
     srcs = ["python/kernel_tests/vector_exponential_diag_test.py"],
@@ -558,7 +558,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "vector_laplace_diag_test",
     size = "medium",
     srcs = ["python/kernel_tests/vector_laplace_diag_test.py"],
@@ -574,7 +574,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "vector_student_t_test",
     size = "medium",
     srcs = ["python/kernel_tests/vector_student_t_test.py"],
@@ -590,7 +590,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "wishart_test",
     size = "medium",
     srcs = ["python/kernel_tests/wishart_test.py"],
@@ -608,7 +608,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "normal_conjugate_posteriors_test",
     size = "small",
     srcs = ["python/kernel_tests/normal_conjugate_posteriors_test.py"],
@@ -623,7 +623,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "quantized_distribution_test",
     size = "medium",
     srcs = ["python/kernel_tests/quantized_distribution_test.py"],
@@ -640,7 +640,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "logistic_test",
     size = "small",
     srcs = ["python/kernel_tests/logistic_test.py"],
@@ -654,7 +654,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "relaxed_bernoulli_test",
     size = "small",
     srcs = ["python/kernel_tests/relaxed_bernoulli_test.py"],
@@ -668,7 +668,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "onehot_categorical_test",
     size = "small",
     srcs = ["python/kernel_tests/onehot_categorical_test.py"],
@@ -682,7 +682,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "relaxed_onehot_categorical_test",
     size = "small",
     srcs = ["python/kernel_tests/relaxed_onehot_categorical_test.py"],
@@ -696,7 +696,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "transformed_distribution_test",
     size = "medium",
     srcs = ["python/kernel_tests/transformed_distribution_test.py"],
@@ -713,7 +713,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "vector_diffeomixture_test",
     size = "medium",
     srcs = ["python/kernel_tests/vector_diffeomixture_test.py"],
@@ -727,7 +727,7 @@ gpu_py_test(
     tags = ["noasan"],  # times out, http://b/78588814
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conditional_transformed_distribution_test",
     size = "medium",
     srcs = [
@@ -747,7 +747,7 @@ gpu_py_test(
     tags = ["no_pip"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "distribution_util_test",
     size = "small",
     srcs = ["python/kernel_tests/distribution_util_test.py"],
@@ -765,7 +765,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "shape_test",
     size = "medium",
     srcs = ["python/kernel_tests/shape_test.py"],
@@ -783,7 +783,7 @@ gpu_py_test(
 
 # === Bijector Tests ==========================================================
 
-gpu_py_test(
+cuda_py_test(
     name = "conditional_bijector_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/conditional_bijector_test.py"],
@@ -802,7 +802,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "absolute_value_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/absolute_value_test.py"],
@@ -820,7 +820,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "affine_test",
     size = "large",
     srcs = ["python/kernel_tests/bijectors/affine_test.py"],
@@ -841,7 +841,7 @@ gpu_py_test(
     tags = ["noasan"],  # times out b/63678675
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "affine_scalar_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/affine_scalar_test.py"],
@@ -860,7 +860,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "affine_linear_operator_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/affine_linear_operator_test.py"],
@@ -879,7 +879,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "batch_normalization_test",
     size = "medium",
     srcs = ["python/kernel_tests/bijectors/batch_normalization_test.py"],
@@ -896,7 +896,7 @@ gpu_py_test(
     tags = ["optonly"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "chain_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/chain_test.py"],
@@ -915,7 +915,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cholesky_outer_product_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/cholesky_outer_product_test.py"],
@@ -934,7 +934,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "exp_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/exp_test.py"],
@@ -953,7 +953,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "fill_triangular_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/fill_triangular_test.py"],
@@ -972,7 +972,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gumbel_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/gumbel_test.py"],
@@ -991,7 +991,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "inline_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/inline_test.py"],
@@ -1010,7 +1010,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "invert_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/invert_test.py"],
@@ -1029,7 +1029,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "kumaraswamy_bijector_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/kumaraswamy_bijector_test.py"],
@@ -1048,7 +1048,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "masked_autoregressive_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/masked_autoregressive_test.py"],
@@ -1064,7 +1064,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_inverse_tril_test",
     size = "medium",
     srcs = ["python/kernel_tests/bijectors/matrix_inverse_tril_test.py"],
@@ -1083,7 +1083,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "real_nvp_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/real_nvp_test.py"],
@@ -1099,7 +1099,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "permute_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/permute_test.py"],
@@ -1115,7 +1115,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "power_transform_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/power_transform_test.py"],
@@ -1134,7 +1134,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reshape_test",
     size = "medium",
     srcs = ["python/kernel_tests/bijectors/reshape_test.py"],
@@ -1150,7 +1150,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "scale_tril_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/scale_tril_test.py"],
@@ -1169,7 +1169,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sigmoid_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/sigmoid_test.py"],
@@ -1190,7 +1190,7 @@ gpu_py_test(
 
 # Tests for SinhArcSinh bijector.  The file name has the extra "_bijector" to
 # avoid BUILD rule name conflicts with the distribution by the same name.
-gpu_py_test(
+cuda_py_test(
     name = "sinh_arcsinh_bijector_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/sinh_arcsinh_bijector_test.py"],
@@ -1210,7 +1210,7 @@ gpu_py_test(
     tags = ["no_windows"],  # TODO: needs investigation on Windows
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "softmax_centered_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/softmax_centered_test.py"],
@@ -1229,7 +1229,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "softplus_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/softplus_test.py"],
@@ -1248,7 +1248,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "softsign_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/softsign_test.py"],
@@ -1267,7 +1267,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "square_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/square_test.py"],
@@ -1286,7 +1286,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "transform_diagonal_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/transform_diagonal_test.py"],
@@ -1305,7 +1305,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "weibull_test",
     size = "small",
     srcs = ["python/kernel_tests/bijectors/weibull_test.py"],

--- a/tensorflow/contrib/eager/python/BUILD
+++ b/tensorflow/contrib/eager/python/BUILD
@@ -3,7 +3,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//tensorflow:internal"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "tfe",
@@ -34,7 +34,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "tfe_test",
     srcs = ["tfe_test.py"],
     additional_deps = [
@@ -66,7 +66,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "datasets_test",
     srcs = ["datasets_test.py"],
     additional_deps = [
@@ -111,7 +111,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "saver_test",
     srcs = ["saver_test.py"],
     additional_deps = [
@@ -250,7 +250,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "remote_test",
     srcs = ["remote_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/eager/python/examples/densenet/BUILD
+++ b/tensorflow/contrib/eager/python/examples/densenet/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_binary(
     name = "densenet",
@@ -14,7 +14,7 @@ py_binary(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "densenet_test",
     size = "large",
     srcs = ["densenet_test.py"],
@@ -29,7 +29,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "densenet_graph_test",
     size = "large",
     srcs = ["densenet_graph_test.py"],

--- a/tensorflow/contrib/eager/python/examples/gan/BUILD
+++ b/tensorflow/contrib/eager/python/examples/gan/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_binary")
 
 py_binary(
@@ -16,7 +16,7 @@ py_binary(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mnist_test",
     srcs = ["mnist_test.py"],
     additional_deps = [
@@ -26,7 +26,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "mnist_graph_test",
     srcs = ["mnist_graph_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/eager/python/examples/l2hmc/BUILD
+++ b/tensorflow/contrib/eager/python/examples/l2hmc/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "neural_nets",
@@ -26,7 +26,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "l2hmc_test",
     size = "large",
     srcs = ["l2hmc_test.py"],

--- a/tensorflow/contrib/eager/python/examples/linear_regression/BUILD
+++ b/tensorflow/contrib/eager/python/examples/linear_regression/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_binary")
 
 py_binary(
@@ -15,7 +15,7 @@ py_binary(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_regression_test",
     size = "small",
     srcs = ["linear_regression_test.py"],
@@ -26,7 +26,7 @@ gpu_py_test(
     tags = ["no_windows"],  # TODO: needs investigation on Windows
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_regression_graph_test",
     size = "small",
     srcs = ["linear_regression_graph_test.py"],

--- a/tensorflow/contrib/eager/python/examples/resnet50/BUILD
+++ b/tensorflow/contrib/eager/python/examples/resnet50/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "resnet50",
@@ -25,7 +25,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "resnet50_test",
     size = "large",
     srcs = ["resnet50_test.py"],
@@ -43,7 +43,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "resnet50_graph_test",
     size = "large",
     srcs = ["resnet50_graph_test.py"],

--- a/tensorflow/contrib/eager/python/examples/revnet/BUILD
+++ b/tensorflow/contrib/eager/python/examples/revnet/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 # Model
 py_library(
@@ -65,7 +65,7 @@ py_library(
 )
 
 # Tests
-gpu_py_test(
+cuda_py_test(
     name = "ops_test",
     size = "large",
     srcs = ["ops_test.py"],
@@ -75,7 +75,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "blocks_test",
     size = "large",
     srcs = ["blocks_test.py"],
@@ -88,7 +88,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "revnet_test",
     size = "large",
     srcs = ["revnet_test.py"],

--- a/tensorflow/contrib/eager/python/examples/rnn_colorbot/BUILD
+++ b/tensorflow/contrib/eager/python/examples/rnn_colorbot/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_binary")
 
 py_binary(
@@ -17,7 +17,7 @@ py_binary(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "rnn_colorbot_test",
     srcs = ["rnn_colorbot_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/eager/python/examples/rnn_ptb/BUILD
+++ b/tensorflow/contrib/eager/python/examples/rnn_ptb/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_binary")
 
 py_binary(
@@ -17,7 +17,7 @@ py_binary(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "rnn_ptb_test",
     srcs = ["rnn_ptb_test.py"],
     additional_deps = [
@@ -27,7 +27,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "rnn_ptb_graph_test",
     srcs = ["rnn_ptb_graph_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/eager/python/examples/sagan/BUILD
+++ b/tensorflow/contrib/eager/python/examples/sagan/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 # Model
 py_library(
@@ -34,7 +34,7 @@ py_library(
 )
 
 # Tests
-gpu_py_test(
+cuda_py_test(
     name = "ops_test",
     size = "small",
     srcs = ["ops_test.py"],
@@ -44,7 +44,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sagan_test",
     size = "large",
     srcs = ["sagan_test.py"],

--- a/tensorflow/contrib/eager/python/examples/spinn/BUILD
+++ b/tensorflow/contrib/eager/python/examples/spinn/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//tensorflow:internal"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 
 py_library(
@@ -24,7 +24,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "spinn_test",
     size = "medium",
     srcs = ["spinn_test.py"],

--- a/tensorflow/contrib/estimator/BUILD
+++ b/tensorflow/contrib/estimator/BUILD
@@ -7,7 +7,7 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 # PLACEHOLDER PIP REQUIREMENTS
 
 py_library(

--- a/tensorflow/contrib/factorization/BUILD
+++ b/tensorflow/contrib/factorization/BUILD
@@ -13,7 +13,7 @@ load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_libs")
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 tf_custom_op_py_library(
@@ -328,7 +328,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "masked_matmul_benchmark",
     srcs = ["python/kernel_tests/masked_matmul_benchmark.py"],
     additional_deps = [

--- a/tensorflow/contrib/framework/BUILD
+++ b/tensorflow/contrib/framework/BUILD
@@ -16,7 +16,7 @@ load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_libs")
 load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 tf_custom_op_py_library(
@@ -170,7 +170,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "critical_section_test",
     size = "medium",
     srcs = ["python/ops/critical_section_test.py"],

--- a/tensorflow/contrib/fused_conv/BUILD
+++ b/tensorflow/contrib/fused_conv/BUILD
@@ -24,7 +24,7 @@ load(
     "tf_gen_op_libs",
     "tf_gen_op_wrapper_py",
 )
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 tf_custom_op_py_library(
@@ -136,7 +136,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "fused_conv2d_bias_activation_op_test",
     size = "large",
     srcs = ["python/ops/fused_conv2d_bias_activation_op_test.py"],
@@ -151,7 +151,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "fused_conv2d_bias_activation_benchmark",
     srcs = ["python/ops/fused_conv2d_bias_activation_benchmark.py"],
     additional_deps = [

--- a/tensorflow/contrib/grid_rnn/BUILD
+++ b/tensorflow/contrib/grid_rnn/BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//tensorflow:__subpackages__"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 
 py_library(
     name = "grid_rnn_py",
@@ -25,7 +25,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "grid_rnn_test",
     srcs = ["python/kernel_tests/grid_rnn_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/image/BUILD
+++ b/tensorflow/contrib/image/BUILD
@@ -16,7 +16,7 @@ load(
     "tf_kernel_library",
     "tf_py_test",
 )
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 tf_custom_op_library(
@@ -95,7 +95,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "image_ops_test",
     size = "medium",
     srcs = ["python/kernel_tests/image_ops_test.py"],
@@ -198,7 +198,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "distort_image_ops_test",
     size = "medium",
     srcs = ["python/kernel_tests/distort_image_ops_test.py"],
@@ -262,7 +262,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sparse_image_warp_test",
     size = "medium",
     srcs = ["python/kernel_tests/sparse_image_warp_test.py"],
@@ -290,7 +290,7 @@ filegroup(
     srcs = glob(["python/kernel_tests/test_data/*.png"]),
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dense_image_warp_test",
     size = "medium",
     srcs = ["python/kernel_tests/dense_image_warp_test.py"],
@@ -311,7 +311,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "interpolate_spline_test",
     size = "medium",
     srcs = ["python/kernel_tests/interpolate_spline_test.py"],
@@ -402,7 +402,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "single_image_random_dot_stereograms_ops_test",
     size = "medium",
     srcs = ["python/kernel_tests/single_image_random_dot_stereograms_ops_test.py"],

--- a/tensorflow/contrib/layers/BUILD
+++ b/tensorflow/contrib/layers/BUILD
@@ -11,7 +11,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
@@ -126,7 +126,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "layers_test",
     size = "medium",
     srcs = ["python/layers/layers_test.py"],

--- a/tensorflow/contrib/legacy_seq2seq/BUILD
+++ b/tensorflow/contrib/legacy_seq2seq/BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 
 py_library(
     name = "seq2seq_py",
@@ -36,7 +36,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "seq2seq_test",
     size = "medium",
     srcs = ["python/kernel_tests/seq2seq_test.py"],

--- a/tensorflow/contrib/memory_stats/BUILD
+++ b/tensorflow/contrib/memory_stats/BUILD
@@ -11,7 +11,7 @@ load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_libs")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 
 tf_custom_op_library(
@@ -68,7 +68,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "memory_stats_ops_test",
     size = "small",
     srcs = ["python/kernel_tests/memory_stats_ops_test.py"],

--- a/tensorflow/contrib/optimizer_v2/BUILD
+++ b/tensorflow/contrib/optimizer_v2/BUILD
@@ -9,7 +9,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 filegroup(
     name = "all_files",
@@ -60,7 +60,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adadelta_test",
     size = "medium",
     srcs = ["adadelta_test.py"],
@@ -78,7 +78,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adagrad_test",
     size = "small",
     srcs = ["adagrad_test.py"],
@@ -94,7 +94,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adam_test",
     size = "small",
     srcs = ["adam_test.py"],
@@ -110,7 +110,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "checkpointable_utils_test",
     srcs = ["checkpointable_utils_test.py"],
     additional_deps = [
@@ -135,7 +135,7 @@ gpu_py_test(
     tags = ["notsan"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradient_descent_test",
     size = "medium",
     srcs = ["gradient_descent_test.py"],
@@ -152,7 +152,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "momentum_test",
     size = "medium",
     srcs = ["momentum_test.py"],
@@ -170,7 +170,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "optimizer_v2_test",
     size = "medium",
     srcs = ["optimizer_v2_test.py"],
@@ -188,7 +188,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "rmsprop_test",
     size = "small",
     srcs = ["rmsprop_test.py"],

--- a/tensorflow/contrib/recurrent/BUILD
+++ b/tensorflow/contrib/recurrent/BUILD
@@ -6,7 +6,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 
 py_library(
     name = "recurrent_py",
@@ -53,7 +53,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "recurrent_ops_test",
     size = "small",
     srcs = ["python/kernel_tests/recurrent_test.py"],
@@ -79,7 +79,7 @@ gpu_py_tests(
     tags = ["nopip"],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "functional_rnn_ops_test",
     size = "small",
     srcs = ["python/kernel_tests/functional_rnn_test.py"],

--- a/tensorflow/contrib/reduce_slice_ops/BUILD
+++ b/tensorflow/contrib/reduce_slice_ops/BUILD
@@ -7,7 +7,7 @@ load("//tensorflow:tensorflow.bzl", "tf_gen_op_libs")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_kernel_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_kernel_tests_linkstatic")
 
@@ -75,7 +75,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reduce_slice_ops_test",
     size = "small",
     srcs = ["python/kernel_tests/reduce_slice_ops_test.py"],

--- a/tensorflow/contrib/resampler/BUILD
+++ b/tensorflow/contrib/resampler/BUILD
@@ -11,7 +11,7 @@ load(
     "tf_gen_op_wrapper_py",
     "tf_kernel_library",
 )
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load("//tensorflow/compiler/tests:build_defs.bzl", "tf_xla_py_test")
 
@@ -86,7 +86,7 @@ tf_gen_op_wrapper_py(
     deps = [":resampler_ops_op_lib"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "resampler_ops_test",
     size = "small",
     srcs = ["python/ops/resampler_ops_test.py"],

--- a/tensorflow/contrib/rnn/BUILD
+++ b/tensorflow/contrib/rnn/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load(
     "//tensorflow:tensorflow.bzl",
@@ -79,7 +79,7 @@ tf_custom_op_py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "rnn_cell_test",
     size = "medium",
     srcs = ["python/kernel_tests/rnn_cell_test.py"],
@@ -102,7 +102,7 @@ gpu_py_tests(
     xla_enabled = True,
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "core_rnn_cell_test",
     size = "medium",
     srcs = ["python/kernel_tests/core_rnn_cell_test.py"],
@@ -121,7 +121,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "rnn_test",
     size = "medium",
     srcs = ["python/kernel_tests/rnn_test.py"],
@@ -143,7 +143,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "core_rnn_test",
     size = "medium",
     srcs = ["python/kernel_tests/core_rnn_test.py"],
@@ -190,7 +190,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "lstm_ops_test",
     size = "medium",
     srcs = ["python/kernel_tests/lstm_ops_test.py"],
@@ -256,7 +256,7 @@ tf_gen_op_wrapper_py(
     deps = [":gru_ops_op_lib"],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "gru_ops_test",
     size = "small",
     srcs = ["python/kernel_tests/gru_ops_test.py"],

--- a/tensorflow/contrib/seq2seq/BUILD
+++ b/tensorflow/contrib/seq2seq/BUILD
@@ -10,7 +10,7 @@ package(default_visibility = [
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load(
     "//tensorflow:tensorflow.bzl",
@@ -103,7 +103,7 @@ tf_kernel_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "loss_test",
     size = "medium",
     srcs = ["python/kernel_tests/loss_test.py"],
@@ -121,7 +121,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "basic_decoder_test",
     size = "medium",
     srcs = ["python/kernel_tests/basic_decoder_test.py"],
@@ -141,7 +141,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "beam_search_ops_test",
     size = "medium",
     srcs = ["python/kernel_tests/beam_search_ops_test.py"],
@@ -155,7 +155,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "decoder_test",
     size = "medium",
     srcs = ["python/kernel_tests/decoder_test.py"],
@@ -175,7 +175,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "beam_search_decoder_test",
     size = "medium",
     srcs = ["python/kernel_tests/beam_search_decoder_test.py"],
@@ -196,7 +196,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "attention_wrapper_test",
     size = "medium",
     srcs = ["python/kernel_tests/attention_wrapper_test.py"],

--- a/tensorflow/contrib/solvers/BUILD
+++ b/tensorflow/contrib/solvers/BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//tensorflow:__subpackages__"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "solvers_py",
@@ -26,7 +26,7 @@ py_library(
 )
 
 # Ops tests
-gpu_py_test(
+cuda_py_test(
     name = "lanczos_test",
     srcs = [
         "python/kernel_tests/lanczos_test.py",
@@ -44,7 +44,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "least_squares_test",
     srcs = [
         "python/kernel_tests/least_squares_test.py",
@@ -61,7 +61,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_equations_test",
     srcs = [
         "python/kernel_tests/linear_equations_test.py",
@@ -78,7 +78,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "util_test",
     srcs = [
         "python/kernel_tests/util_test.py",

--- a/tensorflow/contrib/sparsemax/BUILD
+++ b/tensorflow/contrib/sparsemax/BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 load(
     "//tensorflow:tensorflow.bzl",
     "tf_custom_op_library",
@@ -36,7 +36,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "sparsemax_test",
     size = "medium",
     srcs = ["python/kernel_tests/sparsemax_test.py"],
@@ -51,7 +51,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "sparsemax_loss_test",
     size = "medium",
     srcs = ["python/kernel_tests/sparsemax_loss_test.py"],

--- a/tensorflow/contrib/stateless/BUILD
+++ b/tensorflow/contrib/stateless/BUILD
@@ -6,7 +6,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_gen_op_wrapper_py")
 
 py_library(
@@ -22,7 +22,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stateless_random_ops_test",
     srcs = ["python/kernel_tests/stateless_random_ops_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/tensorrt/BUILD
+++ b/tensorflow/contrib/tensorrt/BUILD
@@ -19,8 +19,8 @@ load(
     "tf_gen_op_libs",
     "tf_gen_op_wrapper_py",
 )
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 load("//tensorflow:tensorflow.bzl", "tf_gpu_cc_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load("//tensorflow:tensorflow.bzl", "tf_py_wrap_cc")
@@ -457,7 +457,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "trt_convert_test",
     srcs = ["python/trt_convert_test.py"],
     additional_deps = [
@@ -482,7 +482,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "tf_trt_integration_test",
     srcs = [
         "test/base_test.py",
@@ -513,7 +513,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "tf_trt_integration_test_no_oss",
     srcs = [
         "test/unary_test.py",
@@ -532,7 +532,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "quantization_mnist_test",
     srcs = ["test/quantization_mnist_test.py"],
     additional_deps = [

--- a/tensorflow/contrib/tensorrt/custom_plugin_examples/BUILD
+++ b/tensorflow/contrib/tensorrt/custom_plugin_examples/BUILD
@@ -16,7 +16,7 @@ load(
     "tf_gen_op_wrapper_py",
     "tf_kernel_library",
 )
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_py_library")
 load(
     "@local_config_tensorrt//:build_defs.bzl",
@@ -98,7 +98,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "plugin_test",
     size = "small",
     srcs = ["plugin_test.py"],

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -33,8 +33,8 @@ load("//tensorflow:tensorflow.bzl", "tf_py_wrap_cc")
 load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
 load("//tensorflow:tensorflow.bzl", "tf_native_cc_binary")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library_additional_deps_impl")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 load("//tensorflow/core:platform/default/build_config.bzl", "pyx_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library")
 load("//tensorflow/core:platform/default/build_config.bzl", "tf_proto_library_py")
@@ -1221,7 +1221,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "framework_function_test",
     size = "medium",
     srcs = ["framework/function_test.py"],
@@ -3205,7 +3205,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "bitwise_ops_test",
     size = "small",
     srcs = ["ops/bitwise_ops_test.py"],
@@ -3218,7 +3218,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "control_flow_ops_test",
     size = "small",
     srcs = ["ops/control_flow_ops_test.py"],
@@ -3242,7 +3242,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradient_checker_test",
     size = "medium",
     srcs = ["ops/gradient_checker_test.py"],
@@ -3258,7 +3258,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradient_checker_v2_test",
     size = "medium",
     srcs = ["ops/gradient_checker_v2_test.py"],
@@ -3274,7 +3274,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradients_test",
     size = "medium",
     srcs = ["ops/gradients_test.py"],
@@ -3306,7 +3306,7 @@ gpu_py_test(
     tags = ["no_oss"],  # b/118709825
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "histogram_ops_test",
     size = "small",
     srcs = ["ops/histogram_ops_test.py"],
@@ -3321,7 +3321,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "image_grad_test",
     size = "medium",
     srcs = ["ops/image_grad_test.py"],
@@ -3334,7 +3334,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "image_ops_test",
     size = "medium",
     srcs = ["ops/image_ops_test.py"],
@@ -3359,7 +3359,7 @@ gpu_py_test(
     shard_count = 5,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "init_ops_test",
     size = "small",
     srcs = ["ops/init_ops_test.py"],
@@ -3373,7 +3373,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "math_grad_test",
     size = "small",
     srcs = ["ops/math_grad_test.py"],
@@ -3387,7 +3387,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "math_ops_test",
     size = "small",
     srcs = ["ops/math_ops_test.py"],
@@ -3405,7 +3405,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nn_batchnorm_test",
     size = "medium",
     srcs = ["ops/nn_batchnorm_test.py"],
@@ -3424,7 +3424,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nn_fused_batchnorm_test",
     size = "large",
     srcs = ["ops/nn_fused_batchnorm_test.py"],
@@ -3440,7 +3440,7 @@ gpu_py_test(
     shard_count = 16,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nn_test",
     size = "medium",
     srcs = ["ops/nn_test.py"],
@@ -3460,7 +3460,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nn_xent_test",
     size = "medium",
     srcs = ["ops/nn_xent_test.py"],
@@ -3474,7 +3474,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "special_math_ops_test",
     size = "small",
     srcs = ["ops/special_math_ops_test.py"],
@@ -3969,7 +3969,7 @@ cc_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "device_lib_test",
     size = "small",
     srcs = [
@@ -4339,7 +4339,7 @@ tf_py_test(
     grpc_enabled = True,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "localhost_cluster_performance_test",
     size = "medium",
     srcs = [
@@ -4508,7 +4508,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "timeline_test",
     size = "small",
     srcs = ["client/timeline_test.py"],
@@ -4521,7 +4521,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "virtual_gpu_test",
     size = "small",
     srcs = ["client/virtual_gpu_test.py"],
@@ -4603,7 +4603,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adam_test",
     size = "small",
     srcs = ["training/adam_test.py"],
@@ -4619,7 +4619,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "moving_averages_test",
     size = "small",
     srcs = [
@@ -4639,7 +4639,7 @@ gpu_py_test(
     tags = ["notsan"],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "training_tests",
     size = "medium",
     srcs = [
@@ -4712,7 +4712,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "saver_test",
     size = "medium",
     srcs = [
@@ -4749,7 +4749,7 @@ gpu_py_test(
     tags = ["multi_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "checkpoint_management_test",
     size = "small",
     srcs = [
@@ -4825,7 +4825,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "session_manager_test",
     size = "medium",  # TODO(irving): Can this be made small?
     srcs = ["training/session_manager_test.py"],
@@ -5256,7 +5256,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "layers_normalization_test",
     size = "medium",
     srcs = ["layers/normalization_test.py"],
@@ -5306,7 +5306,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "accumulate_n_benchmark",
     size = "large",
     srcs = ["ops/accumulate_n_benchmark.py"],
@@ -5325,7 +5325,7 @@ gpu_py_test(
     main = "ops/accumulate_n_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "batch_norm_benchmark",
     srcs = ["ops/batch_norm_benchmark.py"],
     additional_deps = [
@@ -5345,7 +5345,7 @@ gpu_py_test(
     main = "ops/batch_norm_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "concat_benchmark",
     srcs = ["ops/concat_benchmark.py"],
     additional_deps = [
@@ -5362,7 +5362,7 @@ gpu_py_test(
     main = "ops/concat_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "control_flow_ops_benchmark",
     srcs = ["ops/control_flow_ops_benchmark.py"],
     additional_deps = [
@@ -5375,7 +5375,7 @@ gpu_py_test(
     main = "ops/control_flow_ops_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv2d_benchmark",
     size = "large",
     srcs = ["ops/conv2d_benchmark.py"],
@@ -5395,7 +5395,7 @@ gpu_py_test(
     main = "ops/conv2d_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "split_benchmark",
     srcs = ["ops/split_benchmark.py"],
     additional_deps = [
@@ -5413,7 +5413,7 @@ gpu_py_test(
     main = "ops/split_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "transpose_benchmark",
     size = "medium",
     srcs = ["ops/transpose_benchmark.py"],
@@ -5432,7 +5432,7 @@ gpu_py_test(
     main = "ops/transpose_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matmul_benchmark",
     size = "medium",
     srcs = ["ops/matmul_benchmark.py"],
@@ -5453,7 +5453,7 @@ gpu_py_test(
     main = "ops/matmul_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matmul_benchmark_test",
     size = "medium",
     srcs = ["ops/matmul_benchmark_test.py"],
@@ -5475,7 +5475,7 @@ gpu_py_test(
     tags = ["no_pip"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "session_benchmark",
     srcs = ["client/session_benchmark.py"],
     additional_deps = [
@@ -5492,7 +5492,7 @@ gpu_py_test(
     main = "client/session_benchmark.py",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nn_grad_test",
     size = "small",
     srcs = ["ops/nn_grad_test.py"],
@@ -5572,7 +5572,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cluster_test",
     size = "small",
     srcs = [
@@ -5681,7 +5681,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "constant_folding_test",
     size = "medium",
     srcs = [
@@ -5704,7 +5704,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "layout_optimizer_test",
     size = "medium",
     srcs = [
@@ -5840,7 +5840,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nccl_ops_test",
     size = "small",
     srcs = ["ops/nccl_ops_test.py"],

--- a/tensorflow/python/data/experimental/benchmarks/BUILD
+++ b/tensorflow/python/data/experimental/benchmarks/BUILD
@@ -4,7 +4,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 
 py_test(

--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -4,7 +4,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 
 py_test(
@@ -26,7 +26,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "copy_to_device_test",
     size = "small",
     srcs = ["copy_to_device_test.py"],
@@ -445,7 +445,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "prefetch_to_device_test",
     size = "small",
     srcs = ["prefetch_to_device_test.py"],

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -7,7 +7,7 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 tf_py_test(
     name = "batch_test",
@@ -309,7 +309,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "iterator_test",
     size = "medium",
     srcs = ["iterator_test.py"],
@@ -397,7 +397,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "multi_device_iterator_test",
     size = "medium",
     srcs = ["multi_device_iterator_test.py"],
@@ -421,7 +421,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "optional_test",
     size = "small",
     srcs = ["optional_test.py"],

--- a/tensorflow/python/debug/BUILD
+++ b/tensorflow/python/debug/BUILD
@@ -16,7 +16,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "py_binary")
 load("//tensorflow:tensorflow.bzl", "if_not_windows")
@@ -509,7 +509,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "debug_gradients_test",
     size = "small",
     srcs = ["lib/debug_gradients_test.py"],
@@ -598,7 +598,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stepper_test",
     size = "small",
     srcs = ["lib/stepper_test.py"],
@@ -757,7 +757,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "session_debug_file_test",
     size = "small",
     srcs = ["lib/session_debug_file_test.py"],
@@ -774,7 +774,7 @@ gpu_py_test(
     tags = ["notsan"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "debug_graph_reconstruction_test",
     size = "small",
     srcs = ["lib/debug_graph_reconstruction_test.py"],
@@ -791,7 +791,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "session_debug_multi_gpu_test",
     size = "small",
     srcs = ["lib/session_debug_multi_gpu_test.py"],
@@ -903,7 +903,7 @@ py_library(
     srcs_version = "PY2AND3",
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "analyzer_cli_test",
     size = "small",
     srcs = ["cli/analyzer_cli_test.py"],
@@ -953,7 +953,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stepper_cli_test",
     size = "small",
     srcs = ["cli/stepper_cli_test.py"],
@@ -973,7 +973,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "session_debug_grpc_test",
     size = "medium",
     srcs = ["lib/session_debug_grpc_test.py"],
@@ -1000,7 +1000,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "grpc_large_data_test",
     size = "medium",
     srcs = ["lib/grpc_large_data_test.py"],
@@ -1026,7 +1026,7 @@ gpu_py_test(
 )
 
 # TODO(cais): Run the test in OSS, perhaps through a sh_test.
-gpu_py_test(
+cuda_py_test(
     name = "dist_session_debug_grpc_test",
     size = "medium",
     srcs = ["lib/dist_session_debug_grpc_test.py"],

--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -8,7 +8,7 @@ exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "all_reduce",
@@ -93,7 +93,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "device_util_test",
     srcs = ["device_util_test.py"],
     additional_deps = [
@@ -251,7 +251,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "input_ops_test",
     srcs = ["input_ops_test.py"],
     additional_deps = [

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -1,7 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "py_test", "tf_cc_binary")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load(
     "//tensorflow/tools/test:performance.bzl",
     "tf_py_logged_benchmark",
@@ -96,7 +96,7 @@ py_library(
     visibility = ["//tensorflow:internal"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "tensor_test",
     srcs = ["tensor_test.py"],
     additional_deps = [
@@ -107,7 +107,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "backprop_test",
     srcs = ["backprop_test.py"],
     additional_deps = [
@@ -128,7 +128,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "core_test",
     srcs = ["core_test.py"],
     additional_deps = [
@@ -145,7 +145,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "function_argument_naming_test",
     size = "medium",
     srcs = ["function_argument_naming_test.py"],
@@ -159,7 +159,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "function_defun_collection_test",
     size = "medium",
     srcs = ["function_defun_collection_test.py"],
@@ -174,7 +174,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "function_gradients_test",
     size = "medium",
     srcs = ["function_gradients_test.py"],
@@ -191,7 +191,7 @@ gpu_py_test(
     shard_count = 5,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "function_test",
     size = "medium",
     srcs = ["function_test.py"],
@@ -267,7 +267,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "graph_only_ops_test",
     srcs = ["graph_only_ops_test.py"],
     additional_deps = [
@@ -340,7 +340,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "benchmarks_test",
     srcs = ["benchmarks_test.py"],
     additional_deps = [
@@ -379,7 +379,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "ops_test",
     srcs = ["ops_test.py"],
     additional_deps = [
@@ -430,7 +430,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "memory_test",
     size = "medium",
     srcs = ["memory_test.py"],

--- a/tensorflow/python/keras/BUILD
+++ b/tensorflow/python/keras/BUILD
@@ -8,7 +8,7 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 config_setting(
     name = "empty_condition",
@@ -361,7 +361,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cudnn_recurrent_test",
     size = "large",
     srcs = ["layers/cudnn_recurrent_test.py"],
@@ -399,7 +399,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "embeddings_test",
     size = "medium",
     srcs = ["layers/embeddings_test.py"],
@@ -514,7 +514,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "unified_lstm_test",
     size = "medium",
     srcs = ["layers/unified_lstm_test.py"],
@@ -636,7 +636,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "multi_gpu_utils_test",
     srcs = ["utils/multi_gpu_utils_test.py"],
     additional_deps = [
@@ -650,7 +650,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "training_gpu_test",
     size = "small",
     srcs = ["engine/training_gpu_test.py"],

--- a/tensorflow/python/keras/optimizer_v2/BUILD
+++ b/tensorflow/python/keras/optimizer_v2/BUILD
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files(["LICENSE"])
 
 load("//tensorflow:tensorflow.bzl", "py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 py_library(
     name = "optimizer_v2",
@@ -37,7 +37,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adagrad_test",
     size = "medium",
     srcs = ["adagrad_test.py"],
@@ -56,7 +56,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adam_test",
     size = "medium",
     srcs = ["adam_test.py"],
@@ -75,7 +75,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adamax_test",
     size = "medium",
     srcs = ["adamax_test.py"],
@@ -94,7 +94,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "adadelta_test",
     size = "medium",
     srcs = ["adadelta_test.py"],
@@ -113,7 +113,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "ftrl_test",
     size = "medium",
     srcs = ["ftrl_test.py"],
@@ -132,7 +132,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradient_descent_test",
     size = "medium",
     srcs = ["gradient_descent_test.py"],
@@ -151,7 +151,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nadam_test",
     size = "medium",
     srcs = ["nadam_test.py"],
@@ -195,7 +195,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "rmsprop_test",
     size = "medium",
     srcs = ["rmsprop_test.py"],

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -7,12 +7,13 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "sycl_py_test")
+load("//tensorflow:tensorflow.bzl", "gpu_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_custom_op_library")
 
-# CPU only tests should use tf_py_test, GPU tests use gpu_py_test
-# Please avoid the py_tests and gpu_py_tests (plural) while we
+# CPU only tests should use tf_py_test, GPU tests use cuda_py_test
+# Please avoid the py_tests and cuda_py_tests (plural) while we
 # fix the shared/overbroad dependencies.
 
 tf_py_test(
@@ -113,7 +114,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "list_ops_test",
     size = "small",
     srcs = ["list_ops_test.py"],
@@ -133,7 +134,7 @@ gpu_py_test(
     grpc_enabled = True,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "benchmark_test",
     size = "small",
     srcs = ["benchmark_test.py"],
@@ -147,7 +148,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reduce_benchmark_test",
     srcs = ["reduce_benchmark_test.py"],
     additional_deps = [
@@ -210,7 +211,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cholesky_op_test",
     size = "medium",
     srcs = ["cholesky_op_test.py"],
@@ -270,7 +271,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "ctc_loss_op_test",
     size = "small",
     srcs = ["ctc_loss_op_test.py"],
@@ -377,7 +378,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "determinant_op_test",
     size = "small",
     srcs = ["determinant_op_test.py"],
@@ -633,7 +634,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_inverse_op_test",
     size = "small",
     srcs = ["matrix_inverse_op_test.py"],
@@ -647,7 +648,7 @@ gpu_py_test(
     tags = ["optonly"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_solve_ls_op_test",
     size = "medium",
     srcs = ["matrix_solve_ls_op_test.py"],
@@ -661,7 +662,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_square_root_op_test",
     size = "medium",
     srcs = ["matrix_square_root_op_test.py"],
@@ -673,7 +674,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_solve_op_test",
     size = "medium",
     srcs = ["matrix_solve_op_test.py"],
@@ -686,7 +687,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_triangular_solve_op_test",
     size = "small",
     srcs = ["matrix_triangular_solve_op_test.py"],
@@ -697,7 +698,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "parameterized_truncated_normal_op_test",
     size = "medium",
     srcs = ["parameterized_truncated_normal_op_test.py"],
@@ -781,7 +782,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "resource_variable_ops_test",
     size = "small",
     srcs = ["resource_variable_ops_test.py"],
@@ -837,7 +838,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "scatter_nd_ops_test",
     size = "medium",
     srcs = ["scatter_nd_ops_test.py"],
@@ -1127,7 +1128,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "topk_op_test",
     size = "small",
     srcs = ["topk_op_test.py"],
@@ -1142,7 +1143,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "nth_element_op_test",
     size = "small",
     srcs = ["nth_element_op_test.py"],
@@ -1254,7 +1255,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "where_op_test",
     size = "medium",
     srcs = ["where_op_test.py"],
@@ -1266,7 +1267,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cast_op_test",
     size = "small",
     srcs = ["cast_op_test.py"],
@@ -1287,7 +1288,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dense_update_ops_no_tsan_test",
     size = "small",
     srcs = ["dense_update_ops_no_tsan_test.py"],
@@ -1302,7 +1303,7 @@ gpu_py_test(
     tags = ["notsan"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "diag_op_test",
     size = "medium",
     srcs = ["diag_op_test.py"],
@@ -1337,7 +1338,7 @@ tf_py_test(
     data = ["//tensorflow/core:lmdb_testdata"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "aggregate_ops_test",
     size = "small",
     srcs = ["aggregate_ops_test.py"],
@@ -1350,7 +1351,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "argmax_op_test",
     size = "small",
     srcs = ["argmax_op_test.py"],
@@ -1361,7 +1362,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "array_ops_test",
     size = "medium",
     srcs = ["array_ops_test.py"],
@@ -1389,7 +1390,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "broadcast_to_ops_test",
     size = "small",
     srcs = ["broadcast_to_ops_test.py"],
@@ -1401,7 +1402,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "inplace_ops_test",
     size = "small",
     srcs = ["inplace_ops_test.py"],
@@ -1417,7 +1418,7 @@ gpu_py_test(
     shard_count = 10,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "batch_matmul_op_test",
     size = "small",
     srcs = ["batch_matmul_op_test.py"],
@@ -1431,7 +1432,7 @@ gpu_py_test(
     shard_count = 20,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "batchtospace_op_test",
     size = "small",
     srcs = ["batchtospace_op_test.py"],
@@ -1444,7 +1445,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "betainc_op_test",
     size = "small",
     srcs = ["betainc_op_test.py"],
@@ -1458,7 +1459,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "bias_op_test",
     size = "small",
     srcs = ["bias_op_test.py"],
@@ -1473,7 +1474,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "bitcast_op_test",
     size = "small",
     srcs = ["bitcast_op_test.py"],
@@ -1485,7 +1486,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "check_ops_test",
     size = "small",
     srcs = ["check_ops_test.py"],
@@ -1503,7 +1504,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "constant_op_test",
     size = "small",
     srcs = ["constant_op_test.py"],
@@ -1518,7 +1519,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "constant_op_eager_test",
     size = "small",
     srcs = ["constant_op_eager_test.py"],
@@ -1536,7 +1537,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "control_flow_ops_py_test",
     size = "small",
     srcs = ["control_flow_ops_py_test.py"],
@@ -1604,7 +1605,7 @@ tf_py_test(
     tags = ["no_gpu"],  # TODO(b/117796385): runs out of memory
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv1d_test",
     size = "small",
     srcs = ["conv1d_test.py"],
@@ -1616,7 +1617,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv2d_transpose_test",
     size = "small",
     srcs = ["conv2d_transpose_test.py"],
@@ -1630,7 +1631,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv3d_backprop_filter_v2_grad_test",
     size = "small",
     srcs = ["conv3d_backprop_filter_v2_grad_test.py"],
@@ -1644,7 +1645,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cross_grad_test",
     size = "small",
     srcs = ["cross_grad_test.py"],
@@ -1655,7 +1656,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "denormal_test",
     size = "small",
     srcs = ["denormal_test.py"],
@@ -1668,7 +1669,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dense_update_ops_test",
     size = "small",
     srcs = ["dense_update_ops_test.py"],
@@ -1683,7 +1684,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "depthtospace_op_test",
     size = "medium",
     srcs = ["depthtospace_op_test.py"],
@@ -1697,7 +1698,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "division_past_test",
     size = "medium",
     srcs = ["division_past_test.py"],
@@ -1709,7 +1710,7 @@ gpu_py_test(
     tags = ["manual"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dynamic_partition_op_test",
     size = "medium",
     srcs = ["dynamic_partition_op_test.py"],
@@ -1724,7 +1725,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dynamic_stitch_op_test",
     size = "small",
     srcs = ["dynamic_stitch_op_test.py"],
@@ -1738,7 +1739,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "extract_image_patches_op_test",
     size = "small",
     srcs = ["extract_image_patches_op_test.py"],
@@ -1750,7 +1751,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "extract_volume_patches_op_test",
     size = "small",
     srcs = ["extract_volume_patches_op_test.py"],
@@ -1762,7 +1763,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "functional_ops_test",
     size = "small",
     srcs = ["functional_ops_test.py"],
@@ -1788,7 +1789,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gather_nd_op_test",
     size = "small",
     srcs = ["gather_nd_op_test.py"],
@@ -1803,7 +1804,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gather_op_test",
     size = "medium",
     srcs = ["gather_op_test.py"],
@@ -1816,7 +1817,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradient_correctness_test",
     size = "small",
     srcs = ["gradient_correctness_test.py"],
@@ -1829,7 +1830,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "init_ops_test",
     size = "medium",
     srcs = ["init_ops_test.py"],
@@ -1856,7 +1857,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linalg_ops_test",
     size = "medium",
     srcs = ["linalg_ops_test.py"],
@@ -1873,7 +1874,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "lrn_op_test",
     size = "small",
     srcs = ["lrn_op_test.py"],
@@ -1888,7 +1889,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "manip_ops_test",
     size = "small",
     srcs = ["manip_ops_test.py"],
@@ -1901,7 +1902,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matmul_op_test",
     size = "medium",
     srcs = ["matmul_op_test.py"],
@@ -1918,7 +1919,7 @@ gpu_py_test(
     shard_count = 20,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "morphological_ops_test",
     size = "small",
     srcs = ["morphological_ops_test.py"],
@@ -1931,7 +1932,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "numerics_test",
     size = "small",
     srcs = ["numerics_test.py"],
@@ -1946,7 +1947,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "one_hot_op_test",
     size = "small",
     srcs = ["one_hot_op_test.py"],
@@ -1959,7 +1960,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stack_op_test",
     size = "small",
     srcs = ["stack_op_test.py"],
@@ -1973,7 +1974,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "pad_op_test",
     size = "small",
     srcs = ["pad_op_test.py"],
@@ -1985,7 +1986,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "padding_fifo_queue_test",
     size = "small",
     srcs = ["padding_fifo_queue_test.py"],
@@ -1999,7 +2000,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "py_func_test",
     size = "small",
     srcs = ["py_func_test.py"],
@@ -2017,7 +2018,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reduce_join_op_test",
     size = "small",
     srcs = ["reduce_join_op_test.py"],
@@ -2030,7 +2031,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reduction_ops_test",
     size = "medium",
     srcs = ["reduction_ops_test.py"],
@@ -2045,7 +2046,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reduction_ops_test_big",
     size = "medium",
     srcs = ["reduction_ops_test_big.py"],
@@ -2065,7 +2066,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "relu_op_test",
     size = "small",
     srcs = ["relu_op_test.py"],
@@ -2082,7 +2083,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reshape_op_test",
     size = "small",
     srcs = ["reshape_op_test.py"],
@@ -2094,7 +2095,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "reverse_sequence_op_test",
     size = "small",
     srcs = ["reverse_sequence_op_test.py"],
@@ -2106,7 +2107,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "compare_and_bitpack_op_test",
     size = "small",
     srcs = ["compare_and_bitpack_op_test.py"],
@@ -2118,7 +2119,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "scalar_test",
     size = "small",
     srcs = ["scalar_test.py"],
@@ -2136,7 +2137,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "scan_ops_test",
     size = "medium",
     srcs = ["scan_ops_test.py"],
@@ -2149,7 +2150,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "session_ops_test",
     size = "small",
     srcs = ["session_ops_test.py"],
@@ -2161,7 +2162,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "shape_ops_test",
     size = "medium",
     srcs = ["shape_ops_test.py"],
@@ -2177,7 +2178,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "softmax_op_test",
     size = "medium",
     srcs = ["softmax_op_test.py"],
@@ -2191,7 +2192,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "softplus_op_test",
     size = "small",
     srcs = ["softplus_op_test.py"],
@@ -2204,7 +2205,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "softsign_op_test",
     size = "small",
     srcs = ["softsign_op_test.py"],
@@ -2217,7 +2218,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "spacetobatch_op_test",
     size = "small",
     srcs = ["spacetobatch_op_test.py"],
@@ -2232,7 +2233,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "spacetodepth_op_test",
     size = "medium",
     srcs = ["spacetodepth_op_test.py"],
@@ -2276,7 +2277,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sparse_tensor_dense_matmul_grad_test",
     size = "small",
     srcs = ["sparse_tensor_dense_matmul_grad_test.py"],
@@ -2290,7 +2291,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sparse_xent_op_test",
     size = "small",
     srcs = ["sparse_xent_op_test.py"],
@@ -2314,7 +2315,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "split_op_test",
     size = "medium",
     srcs = ["split_op_test.py"],
@@ -2328,7 +2329,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stack_ops_test",
     size = "small",
     srcs = ["stack_ops_test.py"],
@@ -2343,7 +2344,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "string_to_hash_bucket_op_test",
     size = "small",
     srcs = ["string_to_hash_bucket_op_test.py"],
@@ -2355,7 +2356,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "string_to_number_op_test",
     size = "small",
     srcs = ["string_to_number_op_test.py"],
@@ -2367,7 +2368,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "summary_v1_audio_op_test",
     size = "small",
     srcs = ["summary_v1_audio_op_test.py"],
@@ -2380,7 +2381,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "summary_v1_image_op_test",
     size = "small",
     srcs = ["summary_v1_image_op_test.py"],
@@ -2395,7 +2396,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "tensor_array_ops_test",
     size = "small",
     srcs = ["tensor_array_ops_test.py"],
@@ -2425,7 +2426,7 @@ gpu_py_test(
     flaky = 1,  # create_local_cluster sometimes times out.
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "trace_op_test",
     size = "small",
     srcs = ["trace_op_test.py"],
@@ -2437,7 +2438,7 @@ gpu_py_test(
     tags = ["no_windows_gpu"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "transpose_op_test",
     size = "medium",
     srcs = ["transpose_op_test.py"],
@@ -2455,7 +2456,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "unstack_op_test",
     size = "small",
     srcs = ["unstack_op_test.py"],
@@ -2467,7 +2468,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "variable_ops_test",
     size = "small",
     srcs = ["variable_ops_test.py"],
@@ -2484,7 +2485,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "xent_op_test",
     size = "small",
     srcs = ["xent_op_test.py"],
@@ -2500,7 +2501,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "zero_division_test",
     size = "small",
     srcs = ["zero_division_test.py"],
@@ -2511,7 +2512,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "atrous_conv2d_test",
     size = "medium",
     srcs = ["atrous_conv2d_test.py"],
@@ -2530,7 +2531,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "atrous_convolution_test",
     size = "medium",
     srcs = ["atrous_convolution_test.py"],
@@ -2545,7 +2546,7 @@ gpu_py_test(
     tags = ["manual"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "pool_test",
     size = "medium",
     srcs = ["pool_test.py"],
@@ -2558,7 +2559,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv2d_backprop_filter_grad_test",
     size = "medium",
     srcs = ["conv2d_backprop_filter_grad_test.py"],
@@ -2576,7 +2577,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv3d_transpose_test",
     size = "medium",
     srcs = ["conv3d_transpose_test.py"],
@@ -2589,7 +2590,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv_ops_test",
     size = "medium",
     srcs = ["conv_ops_test.py"],
@@ -2617,7 +2618,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "depthwise_conv_op_test",
     size = "medium",  # http://b/30603882
     srcs = ["depthwise_conv_op_test.py"],
@@ -2650,7 +2651,7 @@ tf_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "division_future_test",
     size = "medium",
     srcs = ["division_future_test.py"],
@@ -2662,7 +2663,7 @@ gpu_py_test(
     tags = ["manual"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "pooling_ops_3d_test",
     size = "medium",
     srcs = ["pooling_ops_3d_test.py"],
@@ -2675,7 +2676,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "pooling_ops_test",
     size = "medium",
     srcs = ["pooling_ops_test.py"],
@@ -2693,7 +2694,7 @@ gpu_py_test(
     shard_count = 4,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "rnn_test",
     size = "medium",
     srcs = ["rnn_test.py"],
@@ -2722,7 +2723,7 @@ gpu_py_test(
     shard_count = 10,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "scatter_ops_test",
     size = "medium",  # NOTE: This is not run by default.
     srcs = ["scatter_ops_test.py"],
@@ -2737,7 +2738,7 @@ gpu_py_test(
     tags = ["optonly"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "slice_op_test",
     size = "medium",
     srcs = ["slice_op_test.py"],
@@ -2751,7 +2752,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "huge_slice_op_test",
     size = "medium",
     srcs = ["huge_slice_op_test.py"],
@@ -2767,7 +2768,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sparse_matmul_op_test",
     size = "medium",
     srcs = ["sparse_matmul_op_test.py"],
@@ -2780,7 +2781,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sparse_ops_test",
     size = "medium",
     srcs = ["sparse_ops_test.py"],
@@ -2803,7 +2804,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "sparse_tensor_dense_matmul_op_test",
     size = "medium",
     srcs = ["sparse_tensor_dense_matmul_op_test.py"],
@@ -2824,7 +2825,7 @@ gpu_py_test(
 
 # TODO(gpapan): Revisit the gradient of extract_image_patches_op to resolve
 # http://b/31080670.
-gpu_py_test(
+cuda_py_test(
     name = "extract_image_patches_grad_test",
     size = "medium",
     srcs = ["extract_image_patches_grad_test.py"],
@@ -2838,7 +2839,7 @@ gpu_py_test(
     tags = ["notap"],  # http://b/31080670
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stage_op_test",
     size = "medium",
     srcs = ["stage_op_test.py"],
@@ -2852,7 +2853,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "map_stage_op_test",
     size = "medium",
     srcs = ["map_stage_op_test.py"],
@@ -2866,7 +2867,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "concat_op_test",
     size = "medium",
     srcs = ["concat_op_test.py"],
@@ -2883,7 +2884,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "large_concat_op_test",
     size = "medium",
     srcs = ["large_concat_op_test.py"],
@@ -2898,7 +2899,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "conv_ops_3d_test",
     size = "medium",
     srcs = ["conv_ops_3d_test.py"],
@@ -2911,7 +2912,7 @@ gpu_py_test(
     shard_count = 30,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cwise_ops_test",
     size = "medium",
     srcs = ["cwise_ops_test.py"],
@@ -2931,7 +2932,7 @@ gpu_py_test(
     shard_count = 50,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cwise_ops_binary_test",
     size = "medium",
     srcs = ["cwise_ops_binary_test.py"],
@@ -2951,7 +2952,7 @@ gpu_py_test(
     shard_count = 50,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cwise_ops_unary_test",
     size = "medium",
     srcs = ["cwise_ops_unary_test.py"],
@@ -2971,7 +2972,7 @@ gpu_py_test(
     shard_count = 50,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "embedding_ops_test",
     size = "medium",
     srcs = ["embedding_ops_test.py"],
@@ -2996,7 +2997,7 @@ gpu_py_test(
     shard_count = 20,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linalg_grad_test",
     size = "medium",
     srcs = ["linalg_grad_test.py"],
@@ -3013,7 +3014,7 @@ gpu_py_test(
     shard_count = 20,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "matrix_band_part_op_test",
     size = "medium",
     srcs = ["matrix_band_part_op_test.py"],
@@ -3026,7 +3027,7 @@ gpu_py_test(
     shard_count = 20,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "self_adjoint_eig_op_test",
     size = "medium",
     srcs = ["self_adjoint_eig_op_test.py"],
@@ -3043,7 +3044,7 @@ gpu_py_test(
     tags = ["no_windows"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "qr_op_test",
     size = "medium",
     srcs = ["qr_op_test.py"],
@@ -3058,7 +3059,7 @@ gpu_py_test(
     shard_count = 20,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "svd_op_test",
     size = "medium",
     srcs = ["svd_op_test.py"],
@@ -3077,7 +3078,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "norm_op_test",
     size = "medium",
     srcs = ["norm_op_test.py"],
@@ -3096,7 +3097,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "tensordot_op_test",
     size = "medium",
     srcs = ["tensordot_op_test.py"],
@@ -3335,7 +3336,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "cond_v2_test",
     size = "medium",
     srcs = ["cond_v2_test.py"],
@@ -3357,7 +3358,7 @@ gpu_py_test(
     grpc_enabled = True,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "while_v2_test",
     size = "medium",
     srcs = ["while_v2_test.py"],

--- a/tensorflow/python/kernel_tests/distributions/BUILD
+++ b/tensorflow/python/kernel_tests/distributions/BUILD
@@ -6,9 +6,9 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
-gpu_py_test(
+cuda_py_test(
     name = "bijector_test",
     size = "small",
     srcs = ["bijector_test.py"],
@@ -25,7 +25,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "util_test",
     size = "medium",
     srcs = ["util_test.py"],
@@ -44,7 +44,7 @@ gpu_py_test(
     shard_count = 3,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "kullback_leibler_test",
     size = "small",
     srcs = ["kullback_leibler_test.py"],
@@ -56,7 +56,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "beta_test",
     size = "small",
     srcs = ["beta_test.py"],
@@ -73,7 +73,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "bernoulli_test",
     size = "small",
     srcs = ["bernoulli_test.py"],
@@ -88,7 +88,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "categorical_test",
     size = "small",
     srcs = ["categorical_test.py"],
@@ -107,7 +107,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dirichlet_test",
     size = "small",
     srcs = ["dirichlet_test.py"],
@@ -121,7 +121,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "dirichlet_multinomial_test",
     size = "medium",
     srcs = ["dirichlet_multinomial_test.py"],
@@ -141,7 +141,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "exponential_test",
     srcs = ["exponential_test.py"],
     additional_deps = [
@@ -156,7 +156,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gamma_test",
     srcs = ["gamma_test.py"],
     additional_deps = [
@@ -171,7 +171,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "laplace_test",
     srcs = ["laplace_test.py"],
     additional_deps = [
@@ -186,7 +186,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "multinomial_test",
     srcs = ["multinomial_test.py"],
     additional_deps = [
@@ -202,7 +202,7 @@ gpu_py_test(
     tags = ["manual"],  # b/69001419
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "student_t_test",
     size = "small",
     srcs = ["student_t_test.py"],
@@ -220,7 +220,7 @@ gpu_py_test(
     tags = ["nomsan"],  # disable to avoid false positives from scipy.
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "uniform_test",
     size = "small",
     srcs = ["uniform_test.py"],
@@ -236,7 +236,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "normal_test",
     size = "medium",
     srcs = ["normal_test.py"],
@@ -254,7 +254,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "special_math_test",
     size = "medium",
     srcs = ["special_math_test.py"],
@@ -270,7 +270,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "identity_bijector_test",
     size = "small",
     srcs = ["identity_bijector_test.py"],

--- a/tensorflow/python/kernel_tests/linalg/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/BUILD
@@ -6,9 +6,9 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_test",
     size = "small",
     srcs = ["linear_operator_test.py"],
@@ -24,7 +24,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_addition_test",
     size = "small",
     srcs = ["linear_operator_addition_test.py"],
@@ -40,7 +40,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_adjoint_test",
     size = "medium",
     srcs = ["linear_operator_adjoint_test.py"],
@@ -62,7 +62,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_algebra_test",
     size = "small",
     srcs = ["linear_operator_algebra_test.py"],
@@ -78,7 +78,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_block_diag_test",
     size = "medium",
     srcs = ["linear_operator_block_diag_test.py"],
@@ -100,7 +100,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_composition_test",
     size = "medium",
     srcs = ["linear_operator_composition_test.py"],
@@ -122,7 +122,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_circulant_test",
     size = "medium",
     srcs = ["linear_operator_circulant_test.py"],
@@ -146,7 +146,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_diag_test",
     size = "medium",
     srcs = ["linear_operator_diag_test.py"],
@@ -168,7 +168,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_identity_test",
     size = "medium",
     srcs = ["linear_operator_identity_test.py"],
@@ -189,7 +189,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_inversion_test",
     size = "medium",
     srcs = ["linear_operator_inversion_test.py"],
@@ -211,7 +211,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_full_matrix_test",
     size = "medium",
     srcs = ["linear_operator_full_matrix_test.py"],
@@ -231,7 +231,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_kronecker_test",
     size = "medium",
     srcs = ["linear_operator_kronecker_test.py"],
@@ -253,7 +253,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_lower_triangular_test",
     size = "medium",
     srcs = ["linear_operator_lower_triangular_test.py"],
@@ -272,7 +272,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_low_rank_update_test",
     size = "large",
     srcs = ["linear_operator_low_rank_update_test.py"],
@@ -292,7 +292,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_util_test",
     size = "medium",
     srcs = ["linear_operator_util_test.py"],
@@ -312,7 +312,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "linear_operator_zeros_test",
     size = "medium",
     srcs = ["linear_operator_zeros_test.py"],

--- a/tensorflow/python/kernel_tests/random/BUILD
+++ b/tensorflow/python/kernel_tests/random/BUILD
@@ -7,11 +7,11 @@ package(
 licenses(["notice"])  # Apache 2.0
 
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "sycl_py_test")
 
-# CPU only tests should use tf_py_test, GPU tests use gpu_py_test
-# Please avoid the py_tests and gpu_py_tests (plural) while we
+# CPU only tests should use tf_py_test, GPU tests use cuda_py_test
+# Please avoid the py_tests and cuda_py_tests (plural) while we
 # fix the shared/overbroad dependencies.
 
 tf_py_test(
@@ -29,7 +29,7 @@ tf_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "multinomial_op_test",
     size = "small",
     srcs = ["multinomial_op_test.py"],
@@ -47,7 +47,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "multinomial_op_big_test",
     size = "medium",
     srcs = ["multinomial_op_big_test.py"],
@@ -66,7 +66,7 @@ gpu_py_test(
     shard_count = 3,
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "random_crop_test",
     size = "small",
     srcs = ["random_crop_test.py"],
@@ -77,7 +77,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "random_ops_test",
     size = "medium",
     srcs = ["random_ops_test.py"],
@@ -90,7 +90,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "stateless_random_ops_test",
     size = "medium",
     srcs = ["stateless_random_ops_test.py"],
@@ -105,7 +105,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "random_gamma_test",
     size = "medium",
     srcs = ["random_gamma_test.py"],
@@ -122,7 +122,7 @@ gpu_py_test(
     tags = ["nozapfhahn"],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "random_grad_test",
     size = "small",
     srcs = ["random_grad_test.py"],
@@ -139,7 +139,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "random_poisson_test",
     size = "medium",
     srcs = ["random_poisson_test.py"],

--- a/tensorflow/python/kernel_tests/signal/BUILD
+++ b/tensorflow/python/kernel_tests/signal/BUILD
@@ -4,7 +4,7 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_tests")
+load("//tensorflow:tensorflow.bzl", "cuda_py_tests")
 load("//tensorflow:tensorflow.bzl", "py_test")  # @unused
 
 py_library(
@@ -18,7 +18,7 @@ py_library(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "dct_ops_test",
     srcs = ["dct_ops_test.py"],
     additional_deps = [
@@ -31,7 +31,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "fft_ops_test",
     size = "medium",
     srcs = ["fft_ops_test.py"],
@@ -47,7 +47,7 @@ gpu_py_tests(
     tags = ["optonly"],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "mel_ops_test",
     srcs = ["mel_ops_test.py"],
     additional_deps = [
@@ -58,7 +58,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "mfcc_ops_test",
     srcs = ["mfcc_ops_test.py"],
     additional_deps = [
@@ -72,7 +72,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "reconstruction_ops_test",
     srcs = ["reconstruction_ops_test.py"],
     additional_deps = [
@@ -89,7 +89,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "shape_ops_test",
     srcs = ["shape_ops_test.py"],
     additional_deps = [
@@ -106,7 +106,7 @@ gpu_py_tests(
     ],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "spectral_ops_test",
     size = "large",
     srcs = ["spectral_ops_test.py"],
@@ -127,7 +127,7 @@ gpu_py_tests(
     tags = ["nomac"],
 )
 
-gpu_py_tests(
+cuda_py_tests(
     name = "window_ops_test",
     srcs = ["window_ops_test.py"],
     additional_deps = [

--- a/tensorflow/python/ops/parallel_for/BUILD
+++ b/tensorflow/python/ops/parallel_for/BUILD
@@ -4,7 +4,7 @@ package(
     ],
 )
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -83,7 +83,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "control_flow_ops_test",
     size = "large",
     srcs = ["control_flow_ops_test.py"],
@@ -113,7 +113,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "gradients_test",
     size = "large",
     srcs = ["gradients_test.py"],

--- a/tensorflow/python/profiler/BUILD
+++ b/tensorflow/python/profiler/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
 
@@ -43,7 +43,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "model_analyzer_test",
     srcs = ["model_analyzer_test.py"],
     additional_deps = [
@@ -63,7 +63,7 @@ gpu_py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "profiler_test",
     srcs = ["profiler_test.py"],
     additional_deps = [
@@ -117,7 +117,7 @@ py_library(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "profile_context_test",
     srcs = ["profile_context_test.py"],
     additional_deps = [

--- a/tensorflow/python/profiler/internal/BUILD
+++ b/tensorflow/python/profiler/internal/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//tensorflow/python/profiler:__subpackages__"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("//tensorflow:tensorflow.bzl", "gpu_py_test")
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
 load("//tensorflow:tensorflow.bzl", "py_test")
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
 load("//tensorflow:tensorflow.bzl", "tf_py_wrap_cc")
@@ -54,7 +54,7 @@ py_test(
     ],
 )
 
-gpu_py_test(
+cuda_py_test(
     name = "run_metadata_test",
     srcs = ["run_metadata_test.py"],
     additional_deps = [

--- a/tensorflow/tools/pip_package/check_load_py_test.py
+++ b/tensorflow/tools/pip_package/check_load_py_test.py
@@ -43,7 +43,7 @@ def check_output_despite_error(args):
 
 def main():
   # Get all py_test target, note bazel query result will also include
-  # gpu_py_test etc.
+  # cuda_py_test etc.
   try:
     targets = subprocess.check_output([
         'bazel', 'query',

--- a/tensorflow/tools/test/BUILD
+++ b/tensorflow/tools/test/BUILD
@@ -67,7 +67,7 @@ py_binary(
 
 # Unit test that calls run_and_gather_logs on a benchmark, and
 # prints the result.
-#gpu_py_test(
+#cuda_py_test(
 #    name = "run_and_gather_logs_test",
 #    srcs = ["run_and_gather_logs.py"],
 #    additional_deps = [


### PR DESCRIPTION
For existing test logic in upstream TensorFlow, reinstante cuda_py_test to
ease maintainence efforts in our downstream fork.

For ROCm-specific tests, use gpu_py_test.