### PR TITLE
Update scripts to workaround HIP limitation 

### DIFF
--- a/build_rocm
+++ b/build_rocm
@@ -22,6 +22,6 @@ rm -f $TF_PKG_LOC/tensorflow*.whl
 
 yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
 pip uninstall -y tensorflow || true
-bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+bazel build --config=opt --config=rocm --action_env=HIP_PLATFORM=hcc //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
 pip install $TF_PKG_LOC/tensorflow-1.12.0rc0-cp27-cp27m-linux_x86_64.whl

--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -23,6 +23,6 @@ rm -f $TF_PKG_LOC/tensorflow*.whl
 
 yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
 pip3 uninstall -y tensorflow || true
-bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+bazel build --config=opt --config=rocm --action_env=HIP_PLATFORM=hcc //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
 pip3 install $TF_PKG_LOC/tensorflow*.whl


### PR DESCRIPTION
This PR is to workaround the HIP limitation on automatically detecting the target system when building from Dockerfile. 