### PR TITLE
Update rocm-dnn implementation for staging MIOpen changes

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -388,7 +388,6 @@ miopenConvBwdDataAlgorithm_t ToConvBackwardDataAlgo(
     case miopenConvolutionBwdDataAlgoDirect:
     case miopenConvolutionBwdDataAlgoFFT:
     case miopenConvolutionBwdDataAlgoWinograd:
-    case miopenTransposeBwdDataAlgoGEMM:
       return algo;
     default:
       LOG(FATAL)
@@ -2777,7 +2776,6 @@ bool MIOpenSupport::GetConvolveBackwardDataAlgorithms(
       dnn::AlgorithmDesc(miopenConvolutionBwdDataAlgoDirect, false),
       dnn::AlgorithmDesc(miopenConvolutionBwdDataAlgoFFT, false),
       dnn::AlgorithmDesc(miopenConvolutionBwdDataAlgoWinograd, false),
-      dnn::AlgorithmDesc(miopenTransposeBwdDataAlgoGEMM, false),
       // clang-format on
   });
   return true;


### PR DESCRIPTION
This PR removes reference of miopenTransposeBwdDataAlgoGEMM, to work for the staging changes from MLOpen. 