### PR TITLE
Fix how ROCm platform is initialized and registered

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -4744,39 +4744,43 @@ bool MIOpenSupport::DoFusedBatchNormActivationBackward(
 namespace gpu = ::stream_executor;
 
 void initialize_miopen() {
-  gpu::port::Status status =
-      gpu::PluginRegistry::Instance()
-          ->RegisterFactory<gpu::PluginRegistry::DnnFactory>(
-              gpu::rocm::kROCmPlatformId, gpu::rocm::kMIOpenPlugin, "MIOpen",
-              [](gpu::internal::StreamExecutorInterface*
-                     parent) -> gpu::dnn::DnnSupport* {
-                gpu::rocm::ROCMExecutor* rocm_executor =
-                    dynamic_cast<gpu::rocm::ROCMExecutor*>(parent);
-                if (rocm_executor == nullptr) {
-                  LOG(ERROR)
-                      << "Attempting to initialize an instance of the MIOpen "
-                      << "support library with a non-ROCM StreamExecutor";
-                  return nullptr;
-                }
+  if (!gpu::PluginRegistry::Instance()->HasFactory(gpu::rocm::kROCmPlatformId,
+                                                   gpu::PluginKind::kDnn,
+                                                   gpu::rocm::kMIOpenPlugin)) {
+    gpu::port::Status status =
+        gpu::PluginRegistry::Instance()
+            ->RegisterFactory<gpu::PluginRegistry::DnnFactory>(
+                gpu::rocm::kROCmPlatformId, gpu::rocm::kMIOpenPlugin, "MIOpen",
+                [](gpu::internal::StreamExecutorInterface*
+                       parent) -> gpu::dnn::DnnSupport* {
+                  gpu::rocm::ROCMExecutor* rocm_executor =
+                      dynamic_cast<gpu::rocm::ROCMExecutor*>(parent);
+                  if (rocm_executor == nullptr) {
+                    LOG(ERROR)
+                        << "Attempting to initialize an instance of the MIOpen "
+                        << "support library with a non-ROCM StreamExecutor";
+                    return nullptr;
+                  }
 
-                gpu::rocm::MIOpenSupport* dnn =
-                    new gpu::rocm::MIOpenSupport(rocm_executor);
-                if (!dnn->Init().ok()) {
-                  // Note: Init() will log a more specific error.
-                  delete dnn;
-                  return nullptr;
-                }
-                return dnn;
-              });
+                  gpu::rocm::MIOpenSupport* dnn =
+                      new gpu::rocm::MIOpenSupport(rocm_executor);
+                  if (!dnn->Init().ok()) {
+                    // Note: Init() will log a more specific error.
+                    delete dnn;
+                    return nullptr;
+                  }
+                  return dnn;
+                });
 
-  if (!status.ok()) {
-    LOG(ERROR) << "Unable to register MIOpen factory: "
-               << status.error_message();
+    if (!status.ok()) {
+      LOG(ERROR) << "Unable to register MIOpen factory: "
+                 << status.error_message();
+    }
+
+    gpu::PluginRegistry::Instance()->SetDefaultFactory(
+        gpu::rocm::kROCmPlatformId, gpu::PluginKind::kDnn,
+        gpu::rocm::kMIOpenPlugin);
   }
-
-  gpu::PluginRegistry::Instance()->SetDefaultFactory(gpu::rocm::kROCmPlatformId,
-                                                     gpu::PluginKind::kDnn,
-                                                     gpu::rocm::kMIOpenPlugin);
 }
 
 }  // namespace stream_executor

--- a/tensorflow/stream_executor/rocm/rocm_platform.cc
+++ b/tensorflow/stream_executor/rocm/rocm_platform.cc
@@ -173,7 +173,6 @@ static void InitializeROCmPlatform() {
 REGISTER_MODULE_INITIALIZER(rocm_platform,
                             stream_executor::InitializeROCmPlatform());
 
-DECLARE_MODULE_INITIALIZER(multi_platform_manager);
 // Note that module initialization sequencing is not supported in the
 // open-source project, so this will be a no-op there.
 REGISTER_MODULE_INITIALIZER_SEQUENCE(rocm_platform, multi_platform_manager);


### PR DESCRIPTION
This should remove the benign but alarming messages that ROCm StreamExecutor
components be doubly registered.

@sunway513 Please help check if this patch works fine with `r1.13` branch. It should be better cherry-picked over there.