### PR TITLE
Update doc for ROCm compatibility

### DIFF
--- a/README.ROCm.md
+++ b/README.ROCm.md
@@ -8,7 +8,7 @@ This repository hosts the port of [Tensorflow](https://github.com/tensorflow/ten
 
 For further background information on ROCm, refer [here](https://github.com/RadeonOpenCompute/ROCm/blob/master/README.md).
 
-The project is derived from TensorFlow 1.12.0 and has been verified to work with the latest ROCm 1.9.2 release.
+The project is derived from TensorFlow 1.12.0 and has been verified to work with the latest ROCm2.1 release.
 
 For details on installation and usage, see these links:
 * [Basic installation](rocm_docs/tensorflow-install-basic.md)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ subscribing to
 [announce@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/announce).
 
 **Tensorflow ROCm port**
-This project is based on TensorFlow 1.12.0. It has been verified to work with the latest ROCm1.9.2 release.
+This project is based on TensorFlow 1.12.0. It has been verified to work with the latest ROCm2.1 release.
 Please follow the instructions [here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md) to set up your ROCm stack.
 A docker container: **rocm/tensorflow:latest(https://hub.docker.com/r/rocm/tensorflow/)** is readily available to be used:
 ```


### PR DESCRIPTION
Update the doc on TF ROCm compatibility, as ROCm2.1 is out. 