### PR TITLE
Updates to fix the `conv_ops_test` unit test

### DIFF
--- a/tensorflow/python/kernel_tests/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_test.py
@@ -163,12 +163,13 @@ def GetTestConfigs():
 class Conv2DTest(test.TestCase):
 
   def _DtypesToTest(self, use_gpu):
+
     if use_gpu and not test_util.GpuSupportsHalfMatMulAndConv():
-      return [dtypes.float32, dtypes.float64]
+      return [dtypes.float32] + ([dtypes.float64] if not test.is_built_with_rocm else [])
     else:
       # It is important that float32 comes before float16 here,
       # as we will be using its gradients as reference for fp16 gradients.
-      return [dtypes.float32, dtypes.float16, dtypes.float64]
+      return [dtypes.float32, dtypes.float16] + ([dtypes.float64] if not test.is_built_with_rocm else [])
 
   def _CreateNumpyTensor(self, shape):
     total_size = 1

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -659,7 +659,11 @@ class ScopedConvolutionDescriptor {
                    &CheckedNarrowing<int64, int>);
     std::transform(padding64.cbegin(), padding64.cend(), padding.begin(),
                    &CheckedNarrowing<int64, int>);
-    std::vector<int> upscale(convolution_descriptor.ndims(), 1);
+
+    std::vector<int> upscale(convolution_descriptor.ndims());
+    const auto& dilations64 = convolution_descriptor.dilations();
+    std::transform(dilations64.cbegin(), dilations64.cend(), upscale.begin(),
+                   &CheckedNarrowing<int64, int>);
 
     status = wrap::miopenInitConvolutionDescriptor(
         handle_, miopenConvolution, padding[0], padding[1], strides[0],


### PR DESCRIPTION
Two commits in this PR

one commit disables subtests that test the double datatype (not supported in MIOpen)
another correctly sets the "dilations" paramter in the convolution descriptor

There are still some `conv_ops_test` subtests that will fail after this PR, but those are due to MIOpen bug(s?) that are fixed in v1.8. When we switch to MIOpen v1.8, we should remove the `no_rocm` tag from the `conv_ops_test` unit test.