### PR TITLE
 Use HIP with HIP PR 933 merge (hipMemset*D32 APIs)

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -73,6 +73,11 @@ ENV PATH="$OPENCL_ROOT/bin:${PATH}"
 # Add target file to help determine which device(s) to build for
 RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 
+# Workadround : build HIP from source that has HIP PR 933 merge
+RUN cd $HOME && git clone https://github.com/ROCm-Developer-Tools/HIP.git
+RUN cd $HOME/HIP && git checkout -b master-PR933-merge 23de66bc7e51c80b8254e0fbc91bf75605d86968
+RUN cd $HOME/HIP && mkdir build && cd build && cmake .. && make package -j$(nproc) && dpkg -i *.deb
+
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 ARG DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -73,9 +73,8 @@ ENV PATH="$OPENCL_ROOT/bin:${PATH}"
 # Add target file to help determine which device(s) to build for
 RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 
-# Workadround : build HIP from source that has HIP PR 933 merge
-RUN cd $HOME && git clone https://github.com/ROCm-Developer-Tools/HIP.git
-RUN cd $HOME/HIP && git checkout -b master-PR933-merge 23de66bc7e51c80b8254e0fbc91bf75605d86968
+# Workadround : build HIP from source that has HIP PR 933 + PR 936 merged
+RUN cd $HOME && git clone -b pr_933_936_fixes https://github.com/deven-amd/HIP.git
 RUN cd $HOME/HIP && mkdir build && cd build && cmake .. && make package -j$(nproc) && dpkg -i *.deb
 
 # Copy and run the install scripts.


### PR DESCRIPTION
changing Dockerfile.rocm to explicitly build and use the HIP version with HIP PR 933 merged in. HIP PR 933 is a prequisite to merge TF PR 332, which in turn is needed to fix some XLA unit test failures.