### PR TITLE
Adding a "no_cuda" tag to mark unit tests that fail the CUDA CI 

### DIFF
--- a/rocm_docs/SYNC_UPSTREAM.md
+++ b/rocm_docs/SYNC_UPSTREAM.md
@@ -87,18 +87,29 @@ git merge upstream/master --no-edit
   unit tests introduced from new commits upstream. Examine the reason behind
   those failed cases.
 - In case those cases can't be easily fixed, modify the bazel target for that
-  test to add the tag "no_rocm" to it.
+  test to add the `no_rocm` and/or `no_cuda` tags to it.
 
-  For example:
-  for the test `//tensorflow/python/kernel_tests:conv_ops_test`
-  the definition for the test-target `conv_ops_test` will be in the file `tensorflow/python/kernel_tests/BUILD`.
-  Adding a "tags = ["no_rocm",]" to that target, will result in removing this test from CI.
-  grep for "tags" in the tensorflow/.../BUILD files for a concrete example
+  For example:\
+  for the test `//tensorflow/python/kernel_tests:conv_ops_test`\
+  the definition for the test-target `conv_ops_test` will be in the file
+  `tensorflow/python/kernel_tests/BUILD`.
+  - Adding `tags = ["no_rocm",]` to that target, will result in removing this
+    test from rocm* CI runs.
+  - Adding `tags = ["no_cuda",]` to that target, will result in removing this
+    test from cuda* CI runs.
+  - Adding `tags = ["no_rocm","no_cuda",]` to that target, will result in
+    removing this test from both the rocm* and cuda* CI runs.
+  
+  grep for "tags" in the tensorflow/.../BUILD files for a concrete example of
+  how to add tags to a target
 
+  Note that
+  - `no_cuda` tag is for "our" consumption only, it should not be upstreamed.
+  - `no_gpu` tag is used to indicate which tests are excluded from GPU CI in the
+    upstream repo. We should not add this tag to any tests.
 
-- Document the list of excluded tests amending the commit. Also update:
-
-  http://confluence.amd.com/display/MLSE/Tensorflow+Unit+Tests+Status
+- Document the list of excluded tests amending the commit.
+  Also update [this  Excel spreadsheet](https://amdcloud-my.sharepoint.com/:x:/r/personal/deven_amd_com/Documents/TF%20CI%20Unit%20Test%20Status.xlsx?d=w42bd3e2e76534209bd0438aa92857fa6&csf=1&e=5zpGPh)
 
 - Push to the working branch once again to let the pull request be tested
   again. Repeat the process until we see a green check mark on the PR.

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -555,7 +555,7 @@ tf_xla_py_test(
     srcs = ["def_function_xla_test.py"],
     tags = [
         "no_pip",
-        "no_gpu",
+        "no_cuda",
         "no_rocm",
         "nomac",
     ],

--- a/tensorflow/python/keras/BUILD
+++ b/tensorflow/python/keras/BUILD
@@ -572,7 +572,7 @@ tf_py_test(
         "//tensorflow/python:client_testlib",
     ],
     tags = [
-	"no_gpu",
+	"no_cuda",
 	"no_rocm",
     ],
     shard_count = 4,

--- a/tensorflow/python/training/tracking/BUILD
+++ b/tensorflow/python/training/tracking/BUILD
@@ -199,7 +199,7 @@ tf_xla_py_test(
     srcs = ["util_xla_test.py"],
     tags = [
         "no_pip",
-        "no_gpu",
+        "no_cuda",
         "no_rocm",
         "nomac",
         "notsan",  # b/74395663

--- a/tensorflow/tools/ci_build/linux/gpu/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/gpu/run_py3_core.sh
@@ -35,7 +35,7 @@ export TF_CUDA_COMPUTE_CAPABILITIES=3.7
 yes "" | $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
-bazel test --config=cuda --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-benchmark-test -k \
+bazel test --config=cuda --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_cuda,-benchmark-test -k \
     --test_lang_filters=py --jobs=${N_JOBS} --test_timeout 300,450,1200,3600 \
     --build_tests_only --test_output=errors --local_test_jobs=8 --config=opt \
     --test_size_filters=small,medium \


### PR DESCRIPTION
I am working on created a excel spreadsheet to track all the CI regressions (i.e. unit tests that pass in the upstream repo, but fail in our repo/fork). 

[Link to Excel Spreadsheet](https://amdcloud-my.sharepoint.com/:x:/r/personal/deven_amd_com/Documents/TF%20CI%20Unit%20Test%20Status.xlsx?d=w42bd3e2e76534209bd0438aa92857fa6&csf=1&e=5zpGPh)

(Everybody should have write access to the file above.)

One of things needed to do the data collection is to identify the tests that pass on the CUDA path in the upstream repo, but fail on the CUDA path in our repo. The `no_cuda` tag should be used to identify such tests. 

Once this PR is merged, the tags of interest to us will be
* `no_gpu` : tests that are excluded from GPU CI in the upstream repo
* `no_rocm` : tests that pass on the CUDA path in the upstream repo, but fail on the ROCM path in our fork
* `no_cuda` : tests that pass on the CUDA path in the upstream repo, but fail on the CUDA path in our fork

Note that
* the `no_cuda` tag is for our consumption, it should not be upstreamed.
* we should not add the `no_gpu` tag to any test (that tag should be added/removed in the upstream repo only). If we have a test that regresses on both the ROCM and CUDA paths in our fork, we should add both the `no_rocm` and `no_cuda` tags to it (instead of the `no_gpu` tag)
* When adding a `no_cuda` tag to a test, please add a `# do not upstream` comment next to it, as a reminder to not upstream that change.....


Currently I am working on classifying the failures in the `rocm` and `cuda` CI runs. Once that is done I will do the same for the `rocm-xla` CI run
