### PR TITLE
[ROCm][XLA][CI] adopt 3 patches for XLA

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/amdgpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/amdgpu_backend_lib.cc
@@ -265,8 +265,10 @@ std::vector<uint8> EmitModuleToHsaco(Module* module, llvm::TargetMachine* target
                                       llvm::TargetMachine::CGFT_ObjectFile);
   codegen_passes.run(*module);
   isabin_fs->flush();
+  const char* lld_path_value = "/opt/rocm/hcc/bin";
+  StringRef lld_path = lld_path_value;
 
-  auto lld_program = llvm::sys::findProgramByName("ld.lld");
+  auto lld_program = llvm::sys::findProgramByName("ld.lld",lld_path);
   if (!lld_program) {
     LOG(FATAL) << "unable to find ld.lld in PATH: "
                << lld_program.getError().message();

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -71,9 +71,15 @@ RUN apt-get update --allow-insecure-repositories && \
 #RUN ln -s /opt/rocm/hcc-1.0 /opt/rocm/hcc
 
 # Build HIP from source
-RUN cd $HOME && git clone https://github.com/ROCm-Developer-Tools/HIP.git && \
+#
+# adopt 2 patches yet merged in HIP:
+# - HIP PR #981: https://github.com/ROCm-Developer-Tools/HIP/pull/981
+#   - This PR addresses missing hipModuleGetGlobal() found in XLA tests
+# - HIP PR #982: https://github.com/ROCm-Developer-Tools/HIP/pull/982
+#   - This PR addresses ROCR runtime issue for 0-size symbols found in XLA tests
+RUN cd $HOME && git clone -b fix_hip_module_get_global https://github.com/ROCm-Developer-Tools/HIP.git && \
     mkdir HIP/build && cd HIP/build && \
-    git checkout -b 2019-03-06 0c4a40efcc974e5a4b2935fb84b3e8d368e9880b && \
+    git cherry-pick -n d941f19399e9b4f040aec5d41123e7073913cbc3 && \
     cmake .. && make package -j $(nproc) && dpkg -i ./hip*.deb
 
 # Set up paths

--- a/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
+++ b/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
@@ -37,5 +37,6 @@ bazel clean
 bazel test --config=rocm --test_tag_filters=-no_gpu,-benchmark-test,-no_oss -k \
     --jobs=${N_JOBS} --test_timeout 300,450,1200,3600 \
     --build_tests_only --test_output=errors --local_test_jobs=1 \
+    --test_sharding_strategy=disabled \
     --config=xla -- \
     //tensorflow/compiler/...


### PR DESCRIPTION
2 patches yet merged in HIP:

- HIP PR 981: https://github.com/ROCm-Developer-Tools/HIP/pull/981
  - This PR addresses missing hipModuleGetGlobal() found in XLA tests
- HIP PR 982: https://github.com/ROCm-Developer-Tools/HIP/pull/982
  - This PR addresses ROCR runtime issue for 0-size symbols found in XLA tests

1 patch introduced in #358 yet merged in TF:
- commit 8b019cd
  - This commit addresses `ld.lld` not found issue on `rocm-xla` CI path