### PR TITLE
Adding MIOpen 3d convolution support

### DIFF
--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -829,8 +829,6 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       device_id,                           // device_id
   };
   AlgorithmConfig algorithm_config;
-  ProfileResult best_result;
-  ProfileResult best_result_no_scratch;
   if (cudnn_use_autotune && !AutoTuneConvBwdFilter::GetInstance()->Find(
                                 conv_parameters, &algorithm_config)) {
 #if GOOGLE_CUDA
@@ -869,6 +867,7 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                            transformed_out_backprop, stream->parent(), results);
     OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
 #elif TENSORFLOW_USE_ROCM
+    ProfileResult best_result;
     LOG(INFO) << "running auto-tune for Backward-Filter";
     DnnScratchAllocator scratch_allocator(
         ConvolveBackwardFilterScratchSize, ctx);

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -2866,7 +2866,6 @@ cuda_py_test(
     ],
     shard_count = 4,
     tags = [
-        "no_rocm",
         "optonly",  # times out
     ],
     xla_enable_strict_auto_jit = True,
@@ -3228,7 +3227,6 @@ cuda_py_test(
         "//tensorflow/python:nn_ops",
     ],
     shard_count = 30,
-    tags = ["no_rocm"],
     xla_enable_strict_auto_jit = True,
 )
 
@@ -3367,7 +3365,7 @@ cuda_py_test(
     ],
     data = ["//tensorflow/python/kernel_tests/testdata:self_adjoint_eig_op_test_files"],
     shard_count = 20,
-    flaky = 1,  # test fails on rocm (on rare occasions) 
+    flaky = 1,  # test fails on rocm (on rare occasions)
     tags = [
         "no_windows",
     ],

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -236,7 +236,7 @@ cuda_py_test(
         "//tensorflow/python/ops/linalg",
     ],
     shard_count = 5,
-    tags = ["no_windows_gpu"],
+    tags = ["no_gpu"],
     xla_enable_strict_auto_jit = True,
 )
 

--- a/tensorflow/python/kernel_tests/conv_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/conv_ops_3d_test.py
@@ -56,9 +56,9 @@ class Conv3DTest(test.TestCase):
       else:
         # It is important that float32 comes before float16 here,
         # as we will be using its gradients as reference for fp16 gradients.
-        return [dtypes.float64, dtypes.float32, dtypes.float16]
+        return [dtypes.float32, dtypes.float16] + ([dtypes.float64] if not test.is_built_with_rocm else [])
     else:
-      return [dtypes.float64, dtypes.float32, dtypes.float16]
+      return [dtypes.float32, dtypes.float16] + ([dtypes.float64] if not test.is_built_with_rocm else [])
 
   def _SetupValuesForDevice(self, tensor_in_sizes, filter_in_sizes, stride,
                             padding, data_format, dtype, use_gpu):

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -1116,7 +1116,7 @@ class SingularGradientOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testGradientAtSingularity(self):
-    if not compat.forward_compatible(2019, 4, 14):
+    if not compat.forward_compatible(2019, 5, 14):
       self.skipTest("Skipping test for future functionality.")
 
     ops_and_singularity = [

--- a/tensorflow/python/kernel_tests/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_test.py
@@ -1017,7 +1017,7 @@ class PoolingTest(test.TestCase):
           output_sizes,
           x_init_value=x_init_value,
           delta=1e-2)
-    tf_logging.info("%s gradient error = " % func_name, err)
+    tf_logging.info("%s gradient error = %.4f" % (func_name, err))
     self.assertLess(err, err_tolerance)
 
   def _ConstructAndTestSecondGradient(self,
@@ -1094,7 +1094,7 @@ class PoolingTest(test.TestCase):
           input_sizes,
           x_init_value=x_init_value,
           delta=1e-2)
-    tf_logging.info("%s second-order gradient error = " % func_name, err)
+    tf_logging.info("%s second-order gradient error = %.4f" % (func_name, err))
     self.assertLess(err, err_tolerance)
 
   def _testMaxPoolGradValidPadding1_1(self, data_format, use_gpu):
@@ -1442,6 +1442,14 @@ class PoolingTest(test.TestCase):
     if not test.is_gpu_available():
       return
 
+    # The functionality associated with TF_ENABLE_NANPROP is currently
+    # not supported on the ROCm platform, due to MIOpen never supports
+    # the Nan propagation related field before. This means in-determinism
+    # when there is Nan in the input. For details please refer to
+    # discussion at https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/381
+    if test.is_built_with_rocm():
+      return
+
     # Test the GPU implementation that uses cudnn for now.
     saved_nanprop = os.environ.get("TF_ENABLE_MAXPOOL_NANPROP")
     # Do not propagate the diff in cases of NaNs
@@ -1466,28 +1474,23 @@ class PoolingTest(test.TestCase):
           use_gpu=True,
           v2=v2)
 
-    # Propagate the diff in cases of NaNs
-    #
-    # The functionality associated with TF_ENABLE_NANPROP=1 is currently
-    # not supported on the ROCm platform
-    if not test.is_built_with_rocm() :
-      os.environ["TF_ENABLE_MAXPOOL_NANPROP"] = "1"
-      expected_input_backprop_cudnn = expected_input_backprop_tf_cpu
+    os.environ["TF_ENABLE_MAXPOOL_NANPROP"] = "1"
+    expected_input_backprop_cudnn = expected_input_backprop_tf_cpu
 
-      for v2 in [True, False]:
-        self._testMaxPoolGradDirect(
-          input_data,
-          output_backprop,
-          expected_input_backprop_cudnn,
-          input_sizes=[1, 4, 4, 1],
-          output_sizes=[1, 3, 3, 1],
-          window_rows=2,
-          window_cols=2,
-          row_stride=1,
-          col_stride=1,
-          padding="VALID",
-          use_gpu=True,
-          v2=v2)
+    for v2 in [True, False]:
+      self._testMaxPoolGradDirect(
+        input_data,
+        output_backprop,
+        expected_input_backprop_cudnn,
+        input_sizes=[1, 4, 4, 1],
+        output_sizes=[1, 3, 3, 1],
+        window_rows=2,
+        window_cols=2,
+        row_stride=1,
+        col_stride=1,
+        padding="VALID",
+        use_gpu=True,
+        v2=v2)
 
     if saved_nanprop:
       os.environ["TF_ENABLE_MAXPOOL_NANPROP"] = saved_nanprop
@@ -1526,6 +1529,14 @@ class PoolingTest(test.TestCase):
     if not test.is_gpu_available():
       return
 
+    # The functionality associated with TF_ENABLE_NANPROP is currently
+    # not supported on the ROCm platform, due to MIOpen never supports
+    # the Nan propagation related field before. This means in-determinism
+    # when there is Nan in the input. For details please refer to
+    # discussion at https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/381
+    if test.is_built_with_rocm():
+      return
+
     # Test the GPU implementation that uses cudnn for now.
     saved_nanprop = os.environ.get("TF_ENABLE_MAXPOOL_NANPROP")
     # Do not propagate the diff in cases of NaNs
@@ -1550,28 +1561,23 @@ class PoolingTest(test.TestCase):
           use_gpu=True,
           v2=v2)
 
-    # Propagate the diff in cases of NaNs
-    #
-    # The functionality associated with TF_ENABLE_NANPROP=1 is currently
-    # not supported on the ROCm platform
-    if not test.is_built_with_rocm() :
-      os.environ["TF_ENABLE_MAXPOOL_NANPROP"] = "1"
-      expected_input_backprop_cudnn = expected_input_backprop_tf_cpu
+    os.environ["TF_ENABLE_MAXPOOL_NANPROP"] = "1"
+    expected_input_backprop_cudnn = expected_input_backprop_tf_cpu
 
-      for v2 in [True, False]:
-        self._testMaxPoolGradDirect(
-          input_data,
-          output_backprop,
-          expected_input_backprop_cudnn,
-          input_sizes=[1, 4, 4, 1],
-          output_sizes=[1, 3, 3, 1],
-          window_rows=2,
-          window_cols=2,
-          row_stride=1,
-          col_stride=1,
-          padding="VALID",
-          use_gpu=True,
-          v2=v2)
+    for v2 in [True, False]:
+      self._testMaxPoolGradDirect(
+        input_data,
+        output_backprop,
+        expected_input_backprop_cudnn,
+        input_sizes=[1, 4, 4, 1],
+        output_sizes=[1, 3, 3, 1],
+        window_rows=2,
+        window_cols=2,
+        row_stride=1,
+        col_stride=1,
+        padding="VALID",
+        use_gpu=True,
+        v2=v2)
 
     if saved_nanprop:
       os.environ["TF_ENABLE_MAXPOOL_NANPROP"] = saved_nanprop

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -470,7 +470,7 @@ def _SqrtGradGrad(op, grad):
   a = op.inputs[0]
   y = op.outputs[0]  # y = 0.5 * b / conj(a)
   with ops.control_dependencies([grad]):
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       ga = gen_math_ops.xdivy(grad, a)
       return -gen_math_ops.mul_no_nan(y, math_ops.conj(ga)), 0.5 * ga
     else:
@@ -504,7 +504,7 @@ def _ExpGrad(op, grad):
   y = op.outputs[0]  # y = e^x
   with ops.control_dependencies([grad]):
     y = math_ops.conj(y)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(y, grad)
     else:
       return grad * y
@@ -517,7 +517,7 @@ def _Expm1Grad(op, grad):
   with ops.control_dependencies([grad]):
     x = math_ops.conj(x)
     y = math_ops.exp(x)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(y, grad)
     else:
       return grad * y
@@ -529,7 +529,7 @@ def _LogGrad(op, grad):
   x = op.inputs[0]
   with ops.control_dependencies([grad]):
     x = math_ops.conj(x)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return gen_math_ops.xdivy(grad, x)
     else:
       return grad * math_ops.reciprocal(x)
@@ -541,7 +541,7 @@ def _Log1pGrad(op, grad):
   x = op.inputs[0]
   with ops.control_dependencies([grad]):
     x = math_ops.conj(x)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return gen_math_ops.xdivy(grad, 1 + x)
     else:
       return grad * math_ops.reciprocal(1 + x)
@@ -623,7 +623,7 @@ def _AcoshGrad(op, grad):
   y = op.outputs[0]
   with ops.control_dependencies([grad]):
     y = math_ops.conj(y)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.xdivy(grad, math_ops.sinh(y))
     else:
       return grad / math_ops.sinh(y)
@@ -676,7 +676,7 @@ def _LgammaGrad(op, grad):
   x = op.inputs[0]
   with ops.control_dependencies([grad]):
     x = math_ops.conj(x)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(math_ops.digamma(x), grad)
     else:
       return grad * math_ops.digamma(x)
@@ -689,7 +689,7 @@ def _DigammaGrad(op, grad):
   with ops.control_dependencies([grad]):
     x = math_ops.conj(x)
     partial_x = math_ops.polygamma(array_ops.constant(1, dtype=x.dtype), x)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(partial_x, grad)
     else:
       return grad * partial_x
@@ -702,7 +702,7 @@ def _BesselI0eGrad(op, grad):
   y = op.outputs[0]
   with ops.control_dependencies([grad]):
     partial_x = (math_ops.bessel_i1e(x) - math_ops.sign(x) * y)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(partial_x, grad)
     else:
       return grad * partial_x
@@ -726,7 +726,7 @@ def _BesselI1eGrad(op, grad):
     dy_dx = math_ops.bessel_i0e(safe_x) - y * (
         math_ops.sign(safe_x) + math_ops.reciprocal(safe_x))
     dy_dx = array_ops.where(x_is_not_tiny, dy_dx, 0.5 + zeros)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(dy_dx, grad)
     else:
       return grad * dy_dx
@@ -747,7 +747,7 @@ def _IgammaGrad(op, grad):
     # and Gamma'(a) can grow large.
     partial_x = math_ops.exp(-x + (a - 1) * math_ops.log(x) -
                              math_ops.lgamma(a))
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return (array_ops.reshape(
           math_ops.reduce_sum(math_ops.mul_no_nan(partial_a, grad), ra), sa),
               array_ops.reshape(
@@ -786,7 +786,7 @@ def _BetaincGrad(op, grad):
                            (a - 1) * math_ops.log(x) - log_beta)
 
   # TODO(b/36815900): Mark None return values as NotImplemented
-  if compat.forward_compatible(2019, 4, 14):
+  if compat.forward_compatible(2019, 5, 14):
     return (
         None,  # da
         None,  # db
@@ -815,7 +815,7 @@ def _ZetaGrad(op, grad):
     q = math_ops.conj(q)
     partial_q = -x * math_ops.zeta(x + 1, q)
     # TODO(b/36815900): Mark None return values as NotImplemented
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return (None,
               array_ops.reshape(
                   math_ops.reduce_sum(math_ops.mul_no_nan(partial_q, grad), rq),
@@ -841,7 +841,7 @@ def _PolygammaGrad(op, grad):
     x = math_ops.conj(x)
     partial_x = math_ops.polygamma(n + 1, x)
     # TODO(b/36815900): Mark None return values as NotImplemented
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return (None,
               array_ops.reshape(
                   math_ops.reduce_sum(math_ops.mul_no_nan(partial_x, grad), rx),
@@ -902,7 +902,7 @@ def _TanGrad(op, grad):
     x = math_ops.conj(x)
     secx = math_ops.reciprocal(math_ops.cos(x))
     secx2 = math_ops.square(secx)
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.mul_no_nan(secx2, grad)
     else:
       return secx2 * grad
@@ -917,7 +917,7 @@ def _AsinGrad(op, grad):
     x2 = math_ops.square(x)
     one = constant_op.constant(1, dtype=grad.dtype)
     den = math_ops.sqrt(math_ops.subtract(one, x2))
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return math_ops.xdivy(grad, den)
     else:
       inv = math_ops.reciprocal(den)
@@ -933,7 +933,7 @@ def _AcosGrad(op, grad):
     x2 = math_ops.square(x)
     one = constant_op.constant(1, dtype=grad.dtype)
     den = math_ops.sqrt(math_ops.subtract(one, x2))
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       return -math_ops.xdivy(grad, den)
     else:
       inv = math_ops.reciprocal(den)
@@ -958,7 +958,7 @@ def _Atan2Grad(op, grad):
   y = op.inputs[0]
   x = op.inputs[1]
   with ops.control_dependencies([grad]):
-    if compat.forward_compatible(2019, 4, 14):
+    if compat.forward_compatible(2019, 5, 14):
       grad_inv = math_ops.xdivy(grad, (math_ops.square(x) + math_ops.square(y)))
     else:
       grad_inv = grad / (math_ops.square(x) + math_ops.square(y))
@@ -1078,7 +1078,7 @@ def _DivGrad(op, grad):
   rx, ry = gen_array_ops.broadcast_gradient_args(sx, sy)
   x = math_ops.conj(x)
   y = math_ops.conj(y)
-  if compat.forward_compatible(2019, 4, 14):
+  if compat.forward_compatible(2019, 5, 14):
     return (array_ops.reshape(
         math_ops.reduce_sum(math_ops.xdivy(grad, y), rx), sx),
             array_ops.reshape(
@@ -1131,7 +1131,7 @@ def _RealDivGrad(op, grad):
   rx, ry = gen_array_ops.broadcast_gradient_args(sx, sy)
   x = math_ops.conj(x)
   y = math_ops.conj(y)
-  if compat.forward_compatible(2019, 4, 14):
+  if compat.forward_compatible(2019, 5, 14):
     return (array_ops.reshape(
         math_ops.reduce_sum(math_ops.xdivy(grad, y), rx), sx),
             array_ops.reshape(
@@ -1158,7 +1158,7 @@ def _DivNoNanGrad(op, grad):
   rx, ry = gen_array_ops.broadcast_gradient_args(sx, sy)
   x = math_ops.conj(x)
   y = math_ops.conj(y)
-  if compat.forward_compatible(2019, 4, 14):
+  if compat.forward_compatible(2019, 5, 14):
     return (array_ops.reshape(
         math_ops.reduce_sum(math_ops.div_no_nan(grad, y), rx), sx),
             array_ops.reshape(
@@ -1188,7 +1188,7 @@ def _PowGrad(op, grad):
   y = math_ops.conj(y)
   z = math_ops.conj(z)
 
-  if compat.forward_compatible(2019, 4, 14):
+  if compat.forward_compatible(2019, 5, 14):
     gx = array_ops.reshape(
         math_ops.reduce_sum(
             gen_math_ops.mul_no_nan(y * math_ops.pow(x, y - 1), grad), rx), sx)
@@ -1204,7 +1204,7 @@ def _PowGrad(op, grad):
     mask = x > 0
   safe_x = array_ops.where(mask, x, array_ops.ones_like(x))
   log_x = array_ops.where(mask, math_ops.log(safe_x), array_ops.zeros_like(x))
-  if compat.forward_compatible(2019, 4, 14):
+  if compat.forward_compatible(2019, 5, 14):
     gy = array_ops.reshape(
         math_ops.reduce_sum(gen_math_ops.mul_no_nan(z * log_x, grad), ry), sy)
   else:

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -185,6 +185,7 @@ static port::ThreadPool* GetROCmThreadpool() {
   __macro(miopenBatchNormalizationForwardInference)        \
   __macro(miopenBatchNormalizationForwardTraining)         \
   __macro(miopenGetConvolutionForwardOutputDim)            \
+  __macro(miopenGetConvolutionNdForwardOutputDim)          \
   __macro(miopenFindConvolutionForwardAlgorithm)           \
   __macro(miopenCreateTensorDescriptor)                    \
   __macro(miopenDestroyTensorDescriptor)                   \
@@ -206,7 +207,9 @@ static port::ThreadPool* GetROCmThreadpool() {
   __macro(miopenConvolutionBackwardBias)                   \
   __macro(miopenConvolutionForwardGetWorkSpaceSize)        \
   __macro(miopenInitConvolutionDescriptor)                 \
+  __macro(miopenInitConvolutionNdDescriptor)               \
   __macro(miopenGetConvolutionDescriptor)                  \
+  __macro(miopenGetConvolutionNdDescriptor)                \
   __macro(miopenSetConvolutionGroupCount)                  \
   __macro(miopenSet4dTensorDescriptor)                     \
   __macro(miopenGetTensorDescriptor)                       \
@@ -306,22 +309,24 @@ uint64 GetHashValue(miopenTensorDescriptor_t tensor_desc) {
 
 uint64 GetHashValue(miopenConvolutionDescriptor_t conv_desc) {
   miopenConvolutionMode_t c_mode = miopenConvolution;
-  int pad_h = 0, pad_w = 0, u = 0, v = 0, dilation_h = 0, dilation_w = 0;
-  wrap::miopenGetConvolutionDescriptor(conv_desc, &c_mode, &pad_h,
-                                                   &pad_w, &u, &v, &dilation_h,
-                                                   &dilation_w);
+  int nd = 0;
+  wrap::miopenGetConvolutionNdDescriptor(conv_desc, &c_mode, &nd,
+      nullptr, nullptr, nullptr);
+
+  std::vector<int> stride(nd);
+  std::vector<int> pad(nd);
+  std::vector<int> dilation(nd);
+
+  wrap::miopenGetConvolutionNdDescriptor(conv_desc, &c_mode, &nd,
+      pad.data(), stride.data(), dilation.data());
 
   uint64 hashValue = tensorflow::hash<int>()(c_mode);
-  hashValue =
-      tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(pad_h));
-  hashValue =
-      tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(pad_w));
-  hashValue = tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(u));
-  hashValue = tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(v));
-  hashValue =
-      tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(dilation_h));
-  hashValue =
-      tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(dilation_w));
+  auto hash64Combine = [&hashValue](int element){
+      tensorflow::Hash64Combine(hashValue, tensorflow::hash<int>()(element));
+  };
+  std::for_each(pad.begin(), pad.end(), hash64Combine);
+  std::for_each(stride.begin(), stride.end(), hash64Combine);
+  std::for_each(dilation.begin(), dilation.end(), hash64Combine);
 
   return hashValue;
 }
@@ -566,9 +571,6 @@ class ScopedTensorDescriptor {
       case dnn::DataLayout::kBatchYXDepth:
       case dnn::DataLayout::kBatchDepthYX: {
         const int nd = batch_descriptor.ndims() + 2;
-        if (nd != 4) {
-          LOG(FATAL) << "miopen only supports 4D tensors, dim=" << nd << " not allowed";
-        }
 
         // MIOpen requires the strides and dims to be ordered as BDYX.
         std::vector<int64> strides64 =
@@ -583,8 +585,8 @@ class ScopedTensorDescriptor {
                        &CheckedNarrowing<int64, int>);
         std::transform(dims64.cbegin(), dims64.cend(), dims.begin(),
                        &CheckedNarrowing<int64, int>);
-        status = wrap::miopenSet4dTensorDescriptor(handle_, elem_type, dims[0],
-                                                   dims[1], dims[2], dims[3]);
+        status = wrap::miopenSetTensorDescriptor(handle_, elem_type, nd,
+                                                   dims.data(), strides.data());
 
         if (status != miopenStatusSuccess) {
           LOG(FATAL) << "could not convert BatchDescriptor "
@@ -631,19 +633,14 @@ class ScopedFilterDescriptor {
 
     const int nd = batch_descriptor.ndims() + 2;
 
-    if (nd != 4) {
-      LOG(FATAL) << "miopen only supports 4D filters, dim=" << nd
-                 << "not allowed" << ToString(status);
-    }
-
     std::vector<int> dims(2 + filter_descriptor.ndims());
     dims[0] = filter_descriptor.output_feature_map_count();
     dims[1] = filter_descriptor.input_feature_map_count();
     const auto& spatial_dims = filter_descriptor.input_filter_dims();
     std::copy(spatial_dims.begin(), spatial_dims.end(), dims.begin() + 2);
 
-    status = wrap::miopenSet4dTensorDescriptor(handle_, elem_type, dims[0],
-                                               dims[1], dims[2], dims[3]);
+    status = wrap::miopenSetTensorDescriptor(handle_, elem_type, nd,
+                                               dims.data(), nullptr);
     if (status != miopenStatusSuccess) {
       LOG(FATAL) << "could not set miopen filter descriptor: "
                  << ToString(status);
@@ -700,9 +697,9 @@ class ScopedConvolutionDescriptor {
     std::transform(dilations64.cbegin(), dilations64.cend(), upscale.begin(),
                    &CheckedNarrowing<int64, int>);
 
-    status = wrap::miopenInitConvolutionDescriptor(
-        handle_, miopenConvolution, padding[0], padding[1], strides[0],
-        strides[1], upscale[0], upscale[1]);
+    status = wrap::miopenInitConvolutionNdDescriptor(
+        handle_, miopenConvolution, convolution_descriptor.ndims(),
+        padding.data(), strides.data(), upscale.data());
     if (status != miopenStatusSuccess) {
       LOG(FATAL) << "could not set miopen convolution descriptor: "
                  << ToString(status);
@@ -4021,9 +4018,9 @@ bool MIOpenSupport::DeriveOutputBatchDescriptor(
 
   int dn = batch_descriptor.ndims() + 2;
   std::vector<int> dims(dn);  // in BDYX
-  auto status = wrap::miopenGetConvolutionForwardOutputDim(
-      conv.handle(), input_nd.handle(), filter.handle(), &dims[0], &dims[1],
-      &dims[2], &dims[3]);
+  auto status = wrap::miopenGetConvolutionNdForwardOutputDim(
+      conv.handle(), input_nd.handle(), filter.handle(),
+      &dn, dims.data());
   if (status != miopenStatusSuccess) {
     LOG(ERROR) << "could not get output tensor for convolution: "
                << ToString(status);

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -310,15 +310,15 @@ uint64 GetHashValue(miopenTensorDescriptor_t tensor_desc) {
 uint64 GetHashValue(miopenConvolutionDescriptor_t conv_desc) {
   miopenConvolutionMode_t c_mode = miopenConvolution;
   int nd = 0;
-  wrap::miopenGetConvolutionNdDescriptor(conv_desc, &c_mode, &nd,
-      nullptr, nullptr, nullptr);
+  wrap::miopenGetConvolutionNdDescriptor(conv_desc, 0, &nd,
+      nullptr, nullptr, nullptr, &c_mode);
 
   std::vector<int> stride(nd);
   std::vector<int> pad(nd);
   std::vector<int> dilation(nd);
 
-  wrap::miopenGetConvolutionNdDescriptor(conv_desc, &c_mode, &nd,
-      pad.data(), stride.data(), dilation.data());
+  wrap::miopenGetConvolutionNdDescriptor(conv_desc, nd, &nd,
+      pad.data(), stride.data(), dilation.data(), &c_mode);
 
   uint64 hashValue = tensorflow::hash<int>()(c_mode);
   auto hash64Combine = [&hashValue](int element){
@@ -698,8 +698,8 @@ class ScopedConvolutionDescriptor {
                    &CheckedNarrowing<int64, int>);
 
     status = wrap::miopenInitConvolutionNdDescriptor(
-        handle_, miopenConvolution, convolution_descriptor.ndims(),
-        padding.data(), strides.data(), upscale.data());
+        handle_, convolution_descriptor.ndims(), padding.data(),
+        strides.data(), upscale.data(), miopenConvolution);
     if (status != miopenStatusSuccess) {
       LOG(FATAL) << "could not set miopen convolution descriptor: "
                  << ToString(status);

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -1,5 +1,5 @@
-# This Dockerfile provides a starting point for a ROCm installation of 
-# MIOpen and tensorflow.  
+# This Dockerfile provides a starting point for a ROCm installation of
+# MIOpen and tensorflow.
 FROM ubuntu:xenial
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
@@ -9,7 +9,7 @@ ARG ROCM_PATH=/opt/rocm
 ENV DEBIAN_FRONTEND noninteractive
 ENV TF_NEED_ROCM 1
 ENV HOME /root/
-RUN apt update && apt install -y wget software-properties-common 
+RUN apt update && apt install -y wget software-properties-common
 
 # Add rocm repository
 RUN apt-get clean all
@@ -95,8 +95,8 @@ RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 #  - rocfft-0.8.9.0-Linux.deb
 #  - rocrand-1.8.2-Linux.deb
 # Grab deb packages with pr318 and shfl implementation used by xla
-RUN cd $HOME && wget https://www.dropbox.com/s/z8b4ek3z0k7ir8v/tf-pr318-shfl-deb-pkgs.tar.gz && \
-    tar xzf tf-pr318-shfl-deb-pkgs.tar.gz && dpkg -i ./tf-pr318-shfl-deb-pkgs/*.deb
+RUN cd $HOME && wget https://www.dropbox.com/s/frfjh6y0v2itqt8/tf-pr381-3dconv-deb-pkgs.tar.gz && \
+    tar xzf tf-pr381-3dconv-deb-pkgs.tar.gz && dpkg -i ./tf-pr381-3dconv-deb-pkgs/*.deb
 
 # Build rocBLAS from source
 #RUN cd $HOME && git clone -b master-rocm-2.1 https://github.com/ROCmSoftwarePlatform/rocBLAS.git && cd rocBLAS && ./install.sh -id


### PR DESCRIPTION
This pull request add ROCm 3d convolution support by pulling in newest 3d convolution APIs from MIOpen. The newly added APIs are: 

- [miopenInitConvolutionNdDescriptor](https://github.com/AMDComputeLibraries/MLOpen/blob/develop/include/miopen/miopen.h#L623)
- [miopenGetConvolutionNdDescriptor](https://github.com/AMDComputeLibraries/MLOpen/blob/develop/include/miopen/miopen.h#L665)
- [miopenGetConvolutionNdForwardOutputDim ](https://github.com/AMDComputeLibraries/MLOpen/blob/develop/include/miopen/miopen.h#L759)
- [miopenSetTransposeConvNdOutputPadding](https://github.com/AMDComputeLibraries/MLOpen/blob/develop/include/miopen/miopen.h#L715)

Test run:
- Regressed all currently running conv2d tests and all are passing
- Regressed conv3d tests and are all passing


