### PR TITLE
Feature adopt hipLaunchKernelGGLEx

### DIFF
--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -405,7 +405,6 @@ Status CudaLaunchKernel(void (*function)(Ts...), dim3 grid_dim, dim3 block_dim,
   }
   return Status::OK();
 }
-
 #endif 
 
 }  // namespace tensorflow

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -72,14 +72,11 @@ RUN apt-get update --allow-insecure-repositories && \
 
 # Build HIP from source
 #
-# adopt 2 patches yet merged in HIP:
-# - HIP PR #981: https://github.com/ROCm-Developer-Tools/HIP/pull/981
-#   - This PR addresses missing hipModuleGetGlobal() found in XLA tests
-# - HIP PR #982: https://github.com/ROCm-Developer-Tools/HIP/pull/982
-#   - This PR addresses ROCR runtime issue for 0-size symbols found in XLA tests
-RUN cd $HOME && git clone -b fix_hip_module_get_global https://github.com/ROCm-Developer-Tools/HIP.git && \
+# adopt 1 patches yet merged in HIP:
+# - HIP PR #994 https://github.com/ROCm-Developer-Tools/HIP/pull/994
+#   - This PR introduces hipLaunchKernelGGLEx
+RUN cd $HOME && git clone -b feature-launch-kernel-with-status-code https://github.com/ROCm-Developer-Tools/HIP.git && \
     mkdir HIP/build && cd HIP/build && \
-    git cherry-pick -n d941f19399e9b4f040aec5d41123e7073913cbc3 && \
     cmake .. && make package -j $(nproc) && dpkg -i ./hip*.deb
 
 # Set up paths


### PR DESCRIPTION
This PR attempts to adopt `hipLaunchKernelGGLEx` introduced in https://github.com/ROCm-Developer-Tools/HIP/pull/994 . With the new API it helps to unify kernel launch interface between CUDA and ROCm where kernel dispatching results would always be checked by TensorFlow.

Relevant PR upstream: #24293