### PR TITLE
Ignore HCC runtime library in case hip-clang toolchain is used

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -31,6 +31,7 @@ GCC_HOST_COMPILER_PATH = ('%{gcc_host_compiler_path}')
 HIPCC_PATH = '%{hipcc_path}'
 PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
+HIPCC_IS_HIPCLANG = '%{hipcc_is_hipclang}'=="True"
 HIP_RUNTIME_PATH = '%{hip_runtime_path}'
 HIP_RUNTIME_LIBRARY = '%{hip_runtime_library}'
 HCC_RUNTIME_PATH = '%{hcc_runtime_path}'
@@ -242,9 +243,11 @@ def main():
     gpu_linker_flags.append('-L' + ROCR_RUNTIME_PATH)
     gpu_linker_flags.append('-Wl,-rpath=' + ROCR_RUNTIME_PATH)
     gpu_linker_flags.append('-l' + ROCR_RUNTIME_LIBRARY)
-    gpu_linker_flags.append('-L' + HCC_RUNTIME_PATH)
-    gpu_linker_flags.append('-Wl,-rpath=' + HCC_RUNTIME_PATH)
-    gpu_linker_flags.append('-l' + HCC_RUNTIME_LIBRARY)
+    # do not link with HCC runtime library in case hip-clang toolchain is used
+    if not HIPCC_IS_HIPCLANG:
+      gpu_linker_flags.append('-L' + HCC_RUNTIME_PATH)
+      gpu_linker_flags.append('-Wl,-rpath=' + HCC_RUNTIME_PATH)
+      gpu_linker_flags.append('-l' + HCC_RUNTIME_LIBRARY)
     gpu_linker_flags.append('-L' + HIP_RUNTIME_PATH)
     gpu_linker_flags.append('-Wl,-rpath=' + HIP_RUNTIME_PATH)
     gpu_linker_flags.append('-l' + HIP_RUNTIME_LIBRARY)

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -266,9 +266,19 @@ def _hipcc_is_hipclang(repository_ctx):
         A string "True" if hipcc is based on hip-clang toolchain.
         The functions returns "False" if not (ie: based on HIP/HCC toolchain).
     """
+    #  check user-defined hip-clang environment variables
     for name in ["HIP_CLANG_PATH", "HIP_VDI_HOME"]:
         if name in repository_ctx.os.environ:
             return "True"
+    # grep for "HIP_COMPILER=clang" in /opt/rocm/hip/lib/.hipInfo
+    grep_result = _execute(
+        repository_ctx,
+        ["grep", "HIP_COMPILER=clang", "/opt/rocm/hip/lib/.hipInfo"],
+        empty_stdout_fine = True,
+    )
+    result = grep_result.stdout
+    if result == "HIP_COMPILER=clang":
+        return "True"
     return "False"
 
 def _crosstool_verbose(repository_ctx):

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -265,7 +265,7 @@ def _hipcc_is_hipclang(repository_ctx):
         A string "True" if hipcc is based on hip-clang toolchain.
         The functions returns "False" if not (ie: based on HIP/HCC toolchain).
     """
-    for name in ["HIP_CLANG_PATH", "HIP_VDI_NAME"]:
+    for name in ["HIP_CLANG_PATH", "HIP_VDI_HOME"]:
         if name in repository_ctx.os.environ:
             return "True"
     return "False"

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -171,6 +171,7 @@ def _rocm_include_path(repository_ctx, rocm_config):
     # Add HIP headers
     inc_dirs.append("/opt/rocm/include/hip")
     inc_dirs.append("/opt/rocm/include/hip/hcc_detail")
+    inc_dirs.append("/opt/rocm/hip/include")
 
     # Add rocrand and hiprand headers
     inc_dirs.append("/opt/rocm/rocrand/include")

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -255,6 +255,21 @@ def _hipcc_env(repository_ctx):
                          repository_ctx.os.environ[name].strip() + "\";")
     return hipcc_env.strip()
 
+def _hipcc_is_hipclang(repository_ctx):
+    """Returns if hipcc is based on hip-clang toolchain.
+
+    Args:
+        repository_ctx: The repository context.
+
+    Returns:
+        A string "True" if hipcc is based on hip-clang toolchain.
+        The functions returns "False" if not (ie: based on HIP/HCC toolchain).
+    """
+    for name in ["HIP_CLANG_PATH", "HIP_VDI_NAME"]:
+        if name in repository_ctx.os.environ:
+            return "True"
+    return "False"
+
 def _crosstool_verbose(repository_ctx):
     """Returns the environment variable value CROSSTOOL_VERBOSE.
 
@@ -693,6 +708,7 @@ def _create_local_rocm_repository(repository_ctx):
             "%{cpu_compiler}": str(cc),
             "%{hipcc_path}": "/opt/rocm/bin/hipcc",
             "%{hipcc_env}": _hipcc_env(repository_ctx),
+            "%{hipcc_is_hipclang}": _hipcc_is_hipclang(repository_ctx),
             "%{rocr_runtime_path}": "/opt/rocm/lib",
             "%{rocr_runtime_library}": "hsa-runtime64",
             "%{hip_runtime_path}": "/opt/rocm/hip/lib",


### PR DESCRIPTION
Introduce changes needed for hip-clang toolchain to address SWDEV-184933.