### PR TITLE
Whitelisting failures in the rocm_v2 CI run

### DIFF
--- a/rocm_docs/SYNC_UPSTREAM.md
+++ b/rocm_docs/SYNC_UPSTREAM.md
@@ -87,7 +87,7 @@ git merge upstream/master --no-edit
   unit tests introduced from new commits upstream. Examine the reason behind
   those failed cases.
 - In case those cases can't be easily fixed, modify the bazel target for that
-  test to add the `no_rocm` and/or `no_cuda` tags to it.
+  test to add one more of the`no_rocm`, `no_rocm_v2`, `no_cuda` tags to it.
 
   For example:\
   for the test `//tensorflow/python/kernel_tests:conv_ops_test`\
@@ -95,6 +95,8 @@ git merge upstream/master --no-edit
   `tensorflow/python/kernel_tests/BUILD`.
   - Adding `tags = ["no_rocm",]` to that target, will result in removing this
     test from rocm* CI runs.
+  - Adding `tags = ["no_rocm_v2",]` to that target, will result in removing this
+    test from rocm-v2 CI run.
   - Adding `tags = ["no_cuda",]` to that target, will result in removing this
     test from cuda* CI runs.
   - Adding `tags = ["no_rocm","no_cuda",]` to that target, will result in
@@ -104,6 +106,7 @@ git merge upstream/master --no-edit
   how to add tags to a target
 
   Note that
+  - `no_rocm_v2` tag is for tests that pass when run with TF 1.X, but fail when run with TF 2.X
   - `no_cuda` tag is for "our" consumption only, it should not be upstreamed.
   - `no_gpu` tag is used to indicate which tests are excluded from GPU CI in the
     upstream repo. We should not add this tag to any tests.

--- a/tensorflow/examples/adding_an_op/BUILD
+++ b/tensorflow/examples/adding_an_op/BUILD
@@ -69,7 +69,7 @@ py_test(
     size = "small",
     srcs = ["zero_out_1_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["notap"],
+    tags = ["notap", "no_rocm_v2"],
     deps = [
         ":zero_out_op_1",
         "//tensorflow:tensorflow_py",
@@ -81,7 +81,7 @@ py_test(
     size = "small",
     srcs = ["zero_out_2_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["notap"],
+    tags = ["notap", "no_rocm_v2"],
     deps = [
         ":zero_out_grad_2",
         ":zero_out_op_2",
@@ -94,7 +94,7 @@ py_test(
     size = "small",
     srcs = ["zero_out_3_test.py"],
     srcs_version = "PY2AND3",
-    tags = ["notap"],
+    tags = ["notap", "no_rocm_v2"],
     deps = [
         ":zero_out_op_3",
         "//tensorflow:tensorflow_py",
@@ -134,6 +134,7 @@ py_test(
     srcs = ["fact_test.py"],
     srcs_version = "PY2AND3",
     deps = ["//tensorflow:tensorflow_py"],
+    tags = ["no_rocm_v2"],
 )
 
 tf_cc_binary(

--- a/tensorflow/examples/speech_commands/BUILD
+++ b/tensorflow/examples/speech_commands/BUILD
@@ -35,6 +35,7 @@ tf_py_test(
         ":models",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_library(
@@ -60,6 +61,7 @@ tf_py_test(
         ":models",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_binary(
@@ -92,6 +94,7 @@ tf_py_test(
         ":train",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_binary(
@@ -131,6 +134,7 @@ tf_py_test(
         ":freeze",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_binary(
@@ -170,6 +174,7 @@ tf_py_test(
         ":wav_to_features",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_binary(
@@ -209,6 +214,7 @@ tf_py_test(
         ":generate_streaming_test_wav",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 tf_cc_binary(
@@ -259,6 +265,7 @@ tf_py_test(
         ":label_wav",
         "//tensorflow/python:client_testlib",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 cc_library(

--- a/tensorflow/examples/tutorials/mnist/BUILD
+++ b/tensorflow/examples/tutorials/mnist/BUILD
@@ -106,6 +106,7 @@ py_test(
         ":mnist",
         "//tensorflow:tensorflow_py",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_test(
@@ -121,7 +122,10 @@ py_test(
     ],
     main = "mnist_with_summaries.py",
     srcs_version = "PY2AND3",
-    tags = ["notsan"],  # http://b/29184009
+    tags = [
+        "notsan",  # http://b/29184009
+	"no_rocm_v2",
+    ],
     deps = [
         ":input_data",
         "//tensorflow:tensorflow_py",

--- a/tensorflow/lite/experimental/microfrontend/BUILD
+++ b/tensorflow/lite/experimental/microfrontend/BUILD
@@ -99,5 +99,5 @@ tf_py_test(
         ":audio_microfrontend_py",
         "//tensorflow:tensorflow_py",
     ],
-    tags = ["no_pip"],
+    tags = ["no_pip", "no_rocm_v2"],
 )

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1310,6 +1310,7 @@ tf_py_test(
     main = "framework/contrib_test.py",
     tags = [
         "no_pip",
+	"no_rocm_v2",
     ],
 )
 

--- a/tensorflow/tools/compatibility/BUILD
+++ b/tensorflow/tools/compatibility/BUILD
@@ -111,6 +111,7 @@ py_test(
         "//tensorflow/tools/common:traverse",
         "@six_archive//:six",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 # Keep for reference, this test will succeed in 0.11 but fail in 1.0
@@ -172,6 +173,7 @@ py_test(
     deps = [
         "//tensorflow:tensorflow_py",
     ],
+    tags = ["no_rocm_v2"],
 )
 
 py_test(


### PR DESCRIPTION
 Adding a "no_rocm_v2" tag to the following tests
```
//tensorflow/examples/adding_an_op:fact_test
//tensorflow/examples/adding_an_op:zero_out_1_test
//tensorflow/examples/adding_an_op:zero_out_2_test
//tensorflow/examples/adding_an_op:zero_out_3_test
//tensorflow/examples/speech_commands:freeze_test
//tensorflow/examples/speech_commands:generate_streaming_test_wav_test
//tensorflow/examples/speech_commands:input_data_test
//tensorflow/examples/speech_commands:label_wav_test
//tensorflow/examples/speech_commands:models_test
//tensorflow/examples/speech_commands:train_test
//tensorflow/examples/speech_commands:wav_to_features_test
//tensorflow/examples/tutorials/mnist:fully_connected_feed_test
//tensorflow/examples/tutorials/mnist:mnist_with_summaries_test
//tensorflow/lite/experimental/microfrontend:audio_microfrontend_op_test
//tensorflow/python:contrib_test
//tensorflow/tools/compatibility:test_file_v1_12
//tensorflow/tools/compatibility:tf_upgrade_v2_test
```
Currently all of the above tests are failing (when run with --config=v2, i.e. in TF 2.0 mode).
This is true both in the upstream TF repo and in the ROCm fork repo.
Adding the "no_rocm_v2" tag to them should exclude them from the CI run, enabling the CI run to pass.