### PR TITLE
Remove ROCm specific changes for __shared__ variables

### DIFF
--- a/tensorflow/core/kernels/conv_2d_gpu.h
+++ b/tensorflow/core/kernels/conv_2d_gpu.h
@@ -232,7 +232,7 @@ __global__ void SwapDimension1And2InTensor3UsingTiles(
   constexpr int ReadRowPerPass = NumThreads / TileSizeJ;
   constexpr int WriteRowPerPass = NumThreads / TileSizeI;
   // One extra line in the inner dimension to avoid share memory bank conflict.
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || __HIP__
   // This is to mimic the following, but no constructor of T can be invoked.
   //     __shared__ T shared_memory_tile[TileSizeI][TileSizeJ + 1];
   __shared__ __align__(

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -287,7 +287,7 @@ __global__ void ColumnReduceMax16ColumnsKernel(
   // TODO(nluehr) revert to 2D array when compiler is ready.
   // This is to mimic the following, but without any constructors:
   //   __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1)];
-#ifdef GOOGLE_CUDA
+#ifdef GOOGLE_CUDA || __HIP__
   __shared__ __align__(
       alignof(value_type)) char partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1) * sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);
@@ -344,7 +344,7 @@ __global__ void ColumnReduceKernel(
   // TODO(nluehr) revert to 2D array when compiler is ready.
   // This is to mimic the following, but without constructors:
   //     __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1)];
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || __HIP__
   __shared__ __align__(
       alignof(value_type)) char partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1) * sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);


### PR DESCRIPTION
On ROCm the constructor or initializer of __shared__ variables are not really executated.
They are just not diagnosed by HCC. The __shared__ variables still need to be initialized
explicitly in user code the same way as it is done for cuda-clang.

As ROCm migrates to hip-clang, hip-clang diagnoses initialization of __shared__ variables
the same way as cuda-clang. There is no point to keep the original ROCm specific changes
for __shared__ variables. Instead, hip-clang and cuda-clang will share the same code.