### PR TITLE
Update bazel version in build instructions.

### DIFF
--- a/rocm_docs/tensorflow-build-from-source.md
+++ b/rocm_docs/tensorflow-build-from-source.md
@@ -50,7 +50,7 @@ sudo apt-get update && sudo apt-get install -y \
 echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 sudo apt-get update && sudo apt-get install -y openjdk-8-jdk openjdk-8-jre unzip && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* 
-cd ~/ && wget https://github.com/bazelbuild/bazel/releases/download/0.15.0/bazel-0.15.0-installer-linux-x86_64.sh
+cd ~/ && wget https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh
 sudo bash ~/bazel*.sh
 ```
 


### PR DESCRIPTION
Instruction for building from source worked fine on Ubuntu 16.04, except that I needed bazel 0.21.