### PR TITLE
Abstract math device function calls

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/elemental_ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/elemental_ir_emitter.cc
@@ -34,9 +34,9 @@ limitations under the License.
 #include "llvm/IR/Type.h"
 #include "tensorflow/compiler/xla/literal.h"
 #include "tensorflow/compiler/xla/primitive_util.h"
-#include "tensorflow/compiler/xla/service/hlo_opcode.h"
 #include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/target_util.h"
+#include "tensorflow/compiler/xla/service/hlo_opcode.h"
 #include "tensorflow/compiler/xla/service/llvm_ir/ir_array.h"
 #include "tensorflow/compiler/xla/service/llvm_ir/llvm_loop.h"
 #include "tensorflow/compiler/xla/service/llvm_ir/llvm_util.h"
@@ -108,14 +108,9 @@ StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitLibdeviceMathCall(
       return Unimplemented("Bad type for libdevice math call: %s",
                            PrimitiveType_Name(output_type));
   }
-//  llvm::Value* result = EmitMathCall(munged_callee, converted_operands,
-//                                     converted_input_types, output_type)
-//                            .ValueOrDie();
-  llvm::Value* result =  EmitCallToTargetFunction(
-        callee_id,
-        converted_operands,
-        converted_input_types, output_type, {},{}, 
-        b_);
+  llvm::Value* result =
+      EmitCallToTargetFunction(callee_id, converted_operands,
+                               converted_input_types, output_type, {}, {}, b_);
   if (cast_result_to_fp16) {
     result = FPCast(result, b_->getHalfTy());
   }
@@ -180,10 +175,9 @@ StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitFloatBinaryOp(
 
   switch (op->opcode()) {
     case HloOpcode::kRemainder: {
-
-      return EmitLibdeviceMathCall(TargetFunctionID::kFmod, {lhs_value, rhs_value},
-                                   {lhs_input_type, rhs_input_type},
-                                   output_type);
+      return EmitLibdeviceMathCall(
+          TargetFunctionID::kFmod, {lhs_value, rhs_value},
+          {lhs_input_type, rhs_input_type}, output_type);
     }
     case HloOpcode::kPower: {
       return EmitPowerOp(op, lhs_value, rhs_value);
@@ -208,59 +202,68 @@ StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitPowerOp(
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitErfcInv(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kErfcinv, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kErfcinv, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitLog(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kLog, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kLog, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitLog1p(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kLog1p, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kLog1p, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitSin(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kSin, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kSin, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitCos(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kCos, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kCos, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitExp(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kExp, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kExp, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitExpm1(
     PrimitiveType prim_type, llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kExpm1, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kExpm1, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitPow(
     PrimitiveType prim_type, llvm::Value* lhs, llvm::Value* rhs) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kPow, {lhs, rhs}, {prim_type, prim_type},
-                               prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kPow, {lhs, rhs},
+                               {prim_type, prim_type}, prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitSqrt(PrimitiveType prim_type,
                                                        llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kSqrt, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kSqrt, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitRsqrt(PrimitiveType prim_type,
                                                         llvm::Value* value) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kRsqrt, {value}, {prim_type}, prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kRsqrt, {value}, {prim_type},
+                               prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitAtan2(
     PrimitiveType prim_type, llvm::Value* lhs, llvm::Value* rhs) {
-  return EmitLibdeviceMathCall(TargetFunctionID::kAtan2, {lhs, rhs}, {prim_type, prim_type},
-                               prim_type);
+  return EmitLibdeviceMathCall(TargetFunctionID::kAtan2, {lhs, rhs},
+                               {prim_type, prim_type}, prim_type);
 }
 
 StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitTanh(PrimitiveType prim_type,
@@ -286,7 +289,8 @@ StatusOr<llvm::Value*> GpuElementalIrEmitter::EmitRoundNearestAfz(
     // When the llvm.round is fixed, we may still want to use __nv_round here as
     // expanding the non-trivial implementation early while inlining allows
     // better optimizations.
-    return EmitLibdeviceMathCall(TargetFunctionID::kRound, {value}, {prim_type}, prim_type);
+    return EmitLibdeviceMathCall(TargetFunctionID::kRound, {value}, {prim_type},
+                                 prim_type);
 }
 
 llvm::Value* GpuElementalIrEmitter::EmitDeviceFunctionCall(

--- a/tensorflow/compiler/xla/service/gpu/elemental_ir_emitter.h
+++ b/tensorflow/compiler/xla/service/gpu/elemental_ir_emitter.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Value.h"
 #include "tensorflow/compiler/xla/service/elemental_ir_emitter.h"
+#include "tensorflow/compiler/xla/service/gpu/target_util.h"
 #include "tensorflow/compiler/xla/service/hlo_computation.h"
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
 #include "tensorflow/compiler/xla/service/hlo_module_config.h"
@@ -122,7 +123,7 @@ class GpuElementalIrEmitter : public ElementalIrEmitter {
   // callee_name according to T.  Returns the IR value that represents the
   // return value of the function.
   StatusOr<llvm::Value*> EmitLibdeviceMathCall(
-      const string& callee_name, absl::Span<llvm::Value* const> operands,
+      TargetFunctionID callee_id, absl::Span<llvm::Value* const> operands,
       absl::Span<const PrimitiveType> input_types, PrimitiveType output_type);
 
   // Emits IR to call a function of type [T] -> T.  Does not munge callee_name.

--- a/tensorflow/compiler/xla/service/gpu/target_util.cc
+++ b/tensorflow/compiler/xla/service/gpu/target_util.cc
@@ -57,11 +57,13 @@ struct TargetFunctionInfo {
                      absl::Span<const PrimitiveType> input_types_,
                      const PrimitiveType output_type_, bool use_bitcast_)
       : callee_name(callee_name_),
+        check_signature(true),
         input_types(input_types_),
         result_type(output_type_),
         use_bitcast(use_bitcast_) {}
   // Device function name.
   const string callee_name;
+  absl::optional<bool> check_signature;
   // Inpute types accespted by the device function.
   absl::Span<const PrimitiveType> input_types;
   // Result type of the device function.
@@ -194,6 +196,136 @@ struct TargetInfo GetTargetInfo(TargetFunctionID function_id,
         return TargetInfo(amdgpu_intrinsic_info);
       }
     }
+    case TargetFunctionID::kPow:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_pow" );
+      TargetFunctionInfo nvptx_function_info("__nv_pow" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kErfcinv:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_erfcinv" );
+      TargetFunctionInfo nvptx_function_info("__nv_erfcinv" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kLog:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_log" );
+      TargetFunctionInfo nvptx_function_info("__nv_log" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kLog1p:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_log1p" );
+      TargetFunctionInfo nvptx_function_info("__nv_log1p" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kSin:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_sin" );
+      TargetFunctionInfo nvptx_function_info("__nv_sin" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kCos:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_cos" );
+      TargetFunctionInfo nvptx_function_info("__nv_cos" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kExp:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_exp" );
+      TargetFunctionInfo nvptx_function_info("__nv_exp" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kExpm1:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_expm1" );
+      TargetFunctionInfo nvptx_function_info("__nv_expm1" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kSqrt:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_sqrt" );
+      TargetFunctionInfo nvptx_function_info("__nv_sqrt" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kRsqrt:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_rqsrt" );
+      TargetFunctionInfo nvptx_function_info("__nv_rsqrt" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kAtan2:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_atan2" );
+      TargetFunctionInfo nvptx_function_info("__nv_atan2" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kFmod:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_fmod" );
+      TargetFunctionInfo nvptx_function_info("__nv_fmod" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
+    case TargetFunctionID::kRound:{ 
+      TargetFunctionInfo amdgpu_function_info("__ocml_round" );
+      TargetFunctionInfo nvptx_function_info("__nv_round" );
+      if (target_triple.getArch() == llvm::Triple::nvptx ||
+          target_triple.getArch() == llvm::Triple::nvptx64) {
+         return TargetInfo(nvptx_function_info);
+      } else {
+         return TargetInfo(amdgpu_function_info);
+      }
+    }
   }
 }
 }  // namespace
@@ -216,41 +348,53 @@ llvm::Value* EmitCallToTargetFunction(
   } else {
     std::vector<llvm::Value*> converted_operands;
     std::vector<llvm::Type*> ir_input_types;
-    auto indices = gpu_info.target_function_info->input_types.size();
     PrimitiveType from_type, to_type;
-    CHECK_EQ(input_types.size(),
+    PrimitiveType callee_result_type;
+    if (gpu_info.target_function_info->check_signature) {
+      auto indices = gpu_info.target_function_info->input_types.size();
+      CHECK_EQ(input_types.size(),
              gpu_info.target_function_info->input_types.size());
-    CHECK_EQ(input_types.size(), operands.size());
-    for (unsigned int index = 0; index < operands.size(); ++index){
-      to_type = gpu_info.target_function_info->input_types[index];
-      from_type = input_types[index];
-      if (to_type == PRIMITIVE_TYPE_INVALID) continue;
-      if (from_type == to_type) {
-	converted_operands.push_back(const_cast<llvm::Value*>(operands[index]));
-      } else if (gpu_info.target_function_info->use_bitcast) {
-        converted_operands.push_back(b->CreateBitCast(operands[index],
+      CHECK_EQ(input_types.size(), operands.size());
+      for (unsigned int index = 0; index < operands.size(); ++index){
+        to_type = gpu_info.target_function_info->input_types[index];
+        from_type = input_types[index];
+        if (to_type == PRIMITIVE_TYPE_INVALID) continue;
+        if (from_type == to_type) {
+  	  converted_operands.push_back(const_cast<llvm::Value*>(operands[index]));
+        } else if (gpu_info.target_function_info->use_bitcast) {
+          converted_operands.push_back(b->CreateBitCast(operands[index],
                       llvm_ir::PrimitiveTypeToIrType(to_type, module)));
-      } else if (primitive_util::IsFloatingPointType(from_type) &&
+        } else if (primitive_util::IsFloatingPointType(from_type) &&
                  primitive_util::IsSignedIntegralType(to_type)) {
-        converted_operands.push_back(b->CreateFPToSI(
+          converted_operands.push_back(b->CreateFPToSI(
             operands[index], llvm_ir::PrimitiveTypeToIrType(to_type, module)));
-      } else {
-        LOG(FATAL) << "unhandled conversion operation from "
-                   << PrimitiveType_Name(from_type) << "to"
-                   << PrimitiveType_Name(to_type);
+        } else {
+          LOG(FATAL) << "unhandled conversion operation from "
+                     << PrimitiveType_Name(from_type) << "to"
+                     << PrimitiveType_Name(to_type);
+        }
+        ir_input_types.push_back(
+            llvm_ir::PrimitiveTypeToIrType(to_type, module));
       }
-      ir_input_types.push_back(
-          llvm_ir::PrimitiveTypeToIrType(to_type, module));
+      callee_result_type = gpu_info.target_function_info->result_type;
     }
+   else {
+     converted_operands.assign(operands.begin(), operands.end());
+     for (PrimitiveType input_type : input_types) {
+       ir_input_types.push_back(
+          llvm_ir::PrimitiveTypeToIrType(input_type, module));
+     }
+      callee_result_type = output_type;
+   }
     llvm::FunctionType* callee_type =
         llvm::FunctionType::get(llvm_ir::PrimitiveTypeToIrType(
-                                    gpu_info.target_function_info->result_type,
+                                    callee_result_type,
                                     module),     // Return type.
                                 ir_input_types,  // Parameter types.
                                 false);          // No variadic arguments.
 
     string munged_callee = gpu_info.target_function_info->callee_name;
-    switch (gpu_info.target_function_info->result_type) {
+    switch (callee_result_type) {
       case S32:
         StrAppend(&munged_callee, "_i32");
         break;
@@ -264,7 +408,7 @@ llvm::Value* EmitCallToTargetFunction(
         StrAppend(&munged_callee, "_f64");
         break;
       default:
-        LOG(FATAL) << "Bad Type " << PrimitiveType_Name(output_type) << "\n";
+        LOG(FATAL) << "Bad Type " << PrimitiveType_Name(callee_result_type) << "\n";
     }
     // Declares the callee if it is not declared already.
     llvm::Function* callee = llvm::dyn_cast<llvm::Function>(
@@ -275,8 +419,8 @@ llvm::Value* EmitCallToTargetFunction(
     }
     llvm::Value* result =  b->CreateCall(callee, llvm_ir::AsArrayRef(converted_operands));
 
-    from_type = gpu_info.target_function_info->result_type;
-    to_type = output_type;
+    from_type = callee_result_type;
+    to_type =  output_type;
     if (from_type == to_type){
       return result;
     } else if (gpu_info.target_function_info->use_bitcast) {

--- a/tensorflow/compiler/xla/service/gpu/target_util.cc
+++ b/tensorflow/compiler/xla/service/gpu/target_util.cc
@@ -63,6 +63,7 @@ struct TargetFunctionInfo {
         use_bitcast(use_bitcast_) {}
   // Device function name.
   const string callee_name;
+  // Check signature of the device function and if needed generate casts
   absl::optional<bool> check_signature;
   // Inpute types accespted by the device function.
   absl::Span<const PrimitiveType> input_types;
@@ -196,134 +197,134 @@ struct TargetInfo GetTargetInfo(TargetFunctionID function_id,
         return TargetInfo(amdgpu_intrinsic_info);
       }
     }
-    case TargetFunctionID::kPow:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_pow" );
-      TargetFunctionInfo nvptx_function_info("__nv_pow" );
+    case TargetFunctionID::kPow: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_pow");
+      TargetFunctionInfo nvptx_function_info("__nv_pow");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kErfcinv:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_erfcinv" );
-      TargetFunctionInfo nvptx_function_info("__nv_erfcinv" );
+    case TargetFunctionID::kErfcinv: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_erfcinv");
+      TargetFunctionInfo nvptx_function_info("__nv_erfcinv");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kLog:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_log" );
-      TargetFunctionInfo nvptx_function_info("__nv_log" );
+    case TargetFunctionID::kLog: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_log");
+      TargetFunctionInfo nvptx_function_info("__nv_log");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kLog1p:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_log1p" );
-      TargetFunctionInfo nvptx_function_info("__nv_log1p" );
+    case TargetFunctionID::kLog1p: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_log1p");
+      TargetFunctionInfo nvptx_function_info("__nv_log1p");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kSin:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_sin" );
-      TargetFunctionInfo nvptx_function_info("__nv_sin" );
+    case TargetFunctionID::kSin: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_sin");
+      TargetFunctionInfo nvptx_function_info("__nv_sin");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kCos:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_cos" );
-      TargetFunctionInfo nvptx_function_info("__nv_cos" );
+    case TargetFunctionID::kCos: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_cos");
+      TargetFunctionInfo nvptx_function_info("__nv_cos");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kExp:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_exp" );
-      TargetFunctionInfo nvptx_function_info("__nv_exp" );
+    case TargetFunctionID::kExp: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_exp");
+      TargetFunctionInfo nvptx_function_info("__nv_exp");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kExpm1:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_expm1" );
-      TargetFunctionInfo nvptx_function_info("__nv_expm1" );
+    case TargetFunctionID::kExpm1: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_expm1");
+      TargetFunctionInfo nvptx_function_info("__nv_expm1");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kSqrt:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_sqrt" );
-      TargetFunctionInfo nvptx_function_info("__nv_sqrt" );
+    case TargetFunctionID::kSqrt: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_sqrt");
+      TargetFunctionInfo nvptx_function_info("__nv_sqrt");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kRsqrt:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_rqsrt" );
-      TargetFunctionInfo nvptx_function_info("__nv_rsqrt" );
+    case TargetFunctionID::kRsqrt: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_rsqrt");
+      TargetFunctionInfo nvptx_function_info("__nv_rsqrt");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kAtan2:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_atan2" );
-      TargetFunctionInfo nvptx_function_info("__nv_atan2" );
+    case TargetFunctionID::kAtan2: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_atan2");
+      TargetFunctionInfo nvptx_function_info("__nv_atan2");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kFmod:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_fmod" );
-      TargetFunctionInfo nvptx_function_info("__nv_fmod" );
+    case TargetFunctionID::kFmod: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_fmod");
+      TargetFunctionInfo nvptx_function_info("__nv_fmod");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
-    case TargetFunctionID::kRound:{ 
-      TargetFunctionInfo amdgpu_function_info("__ocml_round" );
-      TargetFunctionInfo nvptx_function_info("__nv_round" );
+    case TargetFunctionID::kRound: {
+      TargetFunctionInfo amdgpu_function_info("__ocml_round");
+      TargetFunctionInfo nvptx_function_info("__nv_round");
       if (target_triple.getArch() == llvm::Triple::nvptx ||
           target_triple.getArch() == llvm::Triple::nvptx64) {
-         return TargetInfo(nvptx_function_info);
+        return TargetInfo(nvptx_function_info);
       } else {
-         return TargetInfo(amdgpu_function_info);
+        return TargetInfo(amdgpu_function_info);
       }
     }
   }
@@ -353,21 +354,24 @@ llvm::Value* EmitCallToTargetFunction(
     if (gpu_info.target_function_info->check_signature) {
       auto indices = gpu_info.target_function_info->input_types.size();
       CHECK_EQ(input_types.size(),
-             gpu_info.target_function_info->input_types.size());
+               gpu_info.target_function_info->input_types.size());
       CHECK_EQ(input_types.size(), operands.size());
-      for (unsigned int index = 0; index < operands.size(); ++index){
+      for (unsigned int index = 0; index < operands.size(); ++index) {
         to_type = gpu_info.target_function_info->input_types[index];
         from_type = input_types[index];
         if (to_type == PRIMITIVE_TYPE_INVALID) continue;
         if (from_type == to_type) {
-  	  converted_operands.push_back(const_cast<llvm::Value*>(operands[index]));
+          converted_operands.push_back(
+              const_cast<llvm::Value*>(operands[index]));
         } else if (gpu_info.target_function_info->use_bitcast) {
-          converted_operands.push_back(b->CreateBitCast(operands[index],
-                      llvm_ir::PrimitiveTypeToIrType(to_type, module)));
+          converted_operands.push_back(b->CreateBitCast(
+              operands[index],
+              llvm_ir::PrimitiveTypeToIrType(to_type, module)));
         } else if (primitive_util::IsFloatingPointType(from_type) &&
-                 primitive_util::IsSignedIntegralType(to_type)) {
-          converted_operands.push_back(b->CreateFPToSI(
-            operands[index], llvm_ir::PrimitiveTypeToIrType(to_type, module)));
+                   primitive_util::IsSignedIntegralType(to_type)) {
+          converted_operands.push_back(
+              b->CreateFPToSI(operands[index],
+                              llvm_ir::PrimitiveTypeToIrType(to_type, module)));
         } else {
           LOG(FATAL) << "unhandled conversion operation from "
                      << PrimitiveType_Name(from_type) << "to"
@@ -377,21 +381,19 @@ llvm::Value* EmitCallToTargetFunction(
             llvm_ir::PrimitiveTypeToIrType(to_type, module));
       }
       callee_result_type = gpu_info.target_function_info->result_type;
-    }
-   else {
-     converted_operands.assign(operands.begin(), operands.end());
-     for (PrimitiveType input_type : input_types) {
-       ir_input_types.push_back(
-          llvm_ir::PrimitiveTypeToIrType(input_type, module));
-     }
+    } else {
+      converted_operands.assign(operands.begin(), operands.end());
+      for (PrimitiveType input_type : input_types) {
+        ir_input_types.push_back(
+            llvm_ir::PrimitiveTypeToIrType(input_type, module));
+      }
       callee_result_type = output_type;
-   }
-    llvm::FunctionType* callee_type =
-        llvm::FunctionType::get(llvm_ir::PrimitiveTypeToIrType(
-                                    callee_result_type,
-                                    module),     // Return type.
-                                ir_input_types,  // Parameter types.
-                                false);          // No variadic arguments.
+    }
+    llvm::FunctionType* callee_type = llvm::FunctionType::get(
+        llvm_ir::PrimitiveTypeToIrType(callee_result_type,
+                                       module),  // Return type.
+        ir_input_types,                          // Parameter types.
+        false);                                  // No variadic arguments.
 
     string munged_callee = gpu_info.target_function_info->callee_name;
     switch (callee_result_type) {
@@ -408,7 +410,8 @@ llvm::Value* EmitCallToTargetFunction(
         StrAppend(&munged_callee, "_f64");
         break;
       default:
-        LOG(FATAL) << "Bad Type " << PrimitiveType_Name(callee_result_type) << "\n";
+        LOG(FATAL) << "Bad Type " << PrimitiveType_Name(callee_result_type)
+                   << "\n";
     }
     // Declares the callee if it is not declared already.
     llvm::Function* callee = llvm::dyn_cast<llvm::Function>(
@@ -420,7 +423,7 @@ llvm::Value* EmitCallToTargetFunction(
     llvm::Value* result =  b->CreateCall(callee, llvm_ir::AsArrayRef(converted_operands));
 
     from_type = callee_result_type;
-    to_type =  output_type;
+    to_type = output_type;
     if (from_type == to_type){
       return result;
     } else if (gpu_info.target_function_info->use_bitcast) {

--- a/tensorflow/compiler/xla/service/gpu/target_util.h
+++ b/tensorflow/compiler/xla/service/gpu/target_util.h
@@ -42,9 +42,9 @@ enum class TargetFunctionID {
   kBlockIdy,
   kBlockIdz,
   kBarrierId,
-  kPow, 
+  kPow,
   kErfcinv,
-  kLog, 
+  kLog,
   kLog1p,
   kSin,
   kCos,
@@ -53,7 +53,7 @@ enum class TargetFunctionID {
   kSqrt,
   kRsqrt,
   kAtan2,
-  kFmod, 
+  kFmod,
   kRound,
 };
 

--- a/tensorflow/compiler/xla/service/gpu/target_util.h
+++ b/tensorflow/compiler/xla/service/gpu/target_util.h
@@ -42,6 +42,19 @@ enum class TargetFunctionID {
   kBlockIdy,
   kBlockIdz,
   kBarrierId,
+  kPow, 
+  kErfcinv,
+  kLog, 
+  kLog1p,
+  kSin,
+  kCos,
+  kExp,
+  kExpm1,
+  kSqrt,
+  kRsqrt,
+  kAtan2,
+  kFmod, 
+  kRound,
 };
 
 // Emits a call to the specified target function  with the given operands.


### PR DESCRIPTION
1. Use abstraction for al math calls 
2. Changes to abstraction framework to accomodate device function calls with no signature check