### PR TITLE
Adding Cuda alias to Gpu functions

### DIFF
--- a/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
+++ b/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
@@ -231,7 +231,7 @@ void LSTMBlockCellFpropWithCUDA(
     typename TTypes<T>::Matrix co, typename TTypes<T>::Matrix icfo,
     typename TTypes<T>::Matrix h, int batch_size, int cell_size,
     int input_size) {
-  const cudaStream_t& cu_stream = GetGpuStream(ctx);
+  const cudaStream_t& cu_stream = GetCudaStream(ctx);
 
   // Concatenate xh = [x, h].
   //
@@ -370,7 +370,7 @@ void LSTMBlockCellBpropWithCUDA(
     typename TTypes<T>::Vec wci_grad, typename TTypes<T>::Vec wcf_grad,
     typename TTypes<T>::Vec wco_grad, const int batch_size, const int cell_size,
     const bool use_peephole) {
-  const cudaStream_t& cu_stream = GetGpuStream(ctx);
+  const cudaStream_t& cu_stream = GetCudaStream(ctx);
 
   dim3 block_dim_2d(std::min(batch_size, 8), 32);
   dim3 grid_dim_2d(Eigen::divup(batch_size, static_cast<int>(block_dim_2d.x)),

--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -65,7 +65,7 @@ struct BincountFunctor<GPUDevice, T> {
     int32 lower_level = 0;
     int32 upper_level = output.size();
     int num_samples = arr.size();
-    const gpuStream_t& stream = GetGPUStream(context);
+    const gpuStream_t& stream = GetGpuStream(context);
 
     // The first HistogramEven is to obtain the temp storage size required
     // with d_temp_storage = NULL passed to the call.

--- a/tensorflow/core/kernels/dynamic_partition_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/dynamic_partition_op_gpu.cu.cc
@@ -336,7 +336,7 @@ class DynamicPartitionOpGPU : public AsyncOpKernel {
                  Tensor* indices_out, DoneCallback done) {
     int32 N = partitions->NumElements();
     const GPUDevice& device = c->eigen_device<GPUDevice>();
-    const gpuStream_t& cu_stream = GetGPUStream(c);
+    const gpuStream_t& cu_stream = GetGpuStream(c);
 
     // Initialize the indices_in tensor using the Range GPU kernel.
     RangeInit(device, 0, 1, N, indices_in->flat<int32>());
@@ -369,7 +369,7 @@ class DynamicPartitionOpGPU : public AsyncOpKernel {
                          Tensor* partition_count, Tensor* indices_out,
                          DoneCallback done) {
     const GPUDevice& device = c->eigen_device<GPUDevice>();
-    const gpuStream_t& cu_stream = GetGPUStream(c);
+    const gpuStream_t& cu_stream = GetGpuStream(c);
     int32 N = partitions->NumElements();
     Tensor indices_in;
     Tensor partitions_out;

--- a/tensorflow/core/kernels/histogram_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/histogram_op_gpu.cu.cc
@@ -76,7 +76,7 @@ struct HistogramFixedWidthFunctor<GPUDevice, T, Tout> {
     int num_levels = levels.size();
     T* d_levels = levels.data();
     int num_samples = values.size();
-    const gpuStream_t& stream = GetGPUStream(context);
+    const gpuStream_t& stream = GetGpuStream(context);
 
     // The first HistogramRange is to obtain the temp storage size required
     // with d_temp_storage = NULL passed to the call.

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -827,7 +827,7 @@ void ReduceImpl(OpKernelContext* ctx, OUT_T out, IN_T in, int in_rank,
                 int in_dim0, int in_dim1, int in_dim2, int out_rank,
                 const ReductionAxes& reduction_axes, Op op) {
   T init = reduction_op_helper::IdentityValue<T, Op>()();
-  const gpuStream_t& cu_stream = GetGPUStream(ctx);
+  const gpuStream_t& cu_stream = GetGpuStream(ctx);
   if (out_rank == 0) {
     const int in_size = in_dim0 * in_dim1 * in_dim2;
     LaunchScalarReduction(ctx, out, in, in_size, op, init, cu_stream);

--- a/tensorflow/core/kernels/softmax_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/softmax_op_gpu.cu.cc
@@ -148,7 +148,7 @@ class SoftmaxOpGPU : public OpKernel {
     OP_REQUIRES_OK(context, context->forward_input_or_allocate_output(
                                 {0}, 0, logits_in_.shape(), &softmax_out));
 
-    const gpuStream_t& cu_stream = GetGPUStream(context);
+    const gpuStream_t& cu_stream = GetGpuStream(context);
     if (logits_in_.NumElements() > 0) {
       Tensor max_logits;
       Tensor sum_probs;

--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -436,7 +436,7 @@ Status LaunchSortKernel(OpKernelContext* ctx, const T* input, int num_rows,
                         typename TTypes<T, 2>::Tensor values,
                         TTypes<int, 2>::Tensor indices) {
   const GPUDevice& d = ctx->eigen_device<GPUDevice>();
-  const cudaStream_t& cu_stream = GetGpuStream(ctx);
+  const cudaStream_t& cu_stream = GetCudaStream(ctx);
   size_t temp_storage_bytes = -1;
 
   // TODO(ebrevdo): Once cub supports iterators for ValueT replace that tensor
@@ -550,7 +550,7 @@ struct TopKFunctor<GPUDevice, T> {
       return impl::LaunchSortKernel(context, input.data(), num_rows, num_cols,
                                     k, values, indices);
     } else {
-      const cudaStream_t& cu_stream = GetGpuStream(context);
+      const cudaStream_t& cu_stream = GetCudaStream(context);
       auto err = impl::LaunchTopKKernel(cu_stream, /* num_shards */ 0,
                                         input.data(), num_rows, num_cols, k,
                                         sorted, values.data(), indices.data());

--- a/tensorflow/core/kernels/where_op_gpu.cu.h
+++ b/tensorflow/core/kernels/where_op_gpu.cu.h
@@ -149,7 +149,7 @@ struct NumTrue<GPUDevice, T, TIndex> {
       OpKernelContext* ctx, const GPUDevice& d,
       typename TTypes<T>::ConstFlat input,
       typename TTypes<TIndex>::Scalar num_true) {
-    const gpuStream_t& cu_stream = GetGPUStream(ctx);
+    const gpuStream_t& cu_stream = GetGpuStream(ctx);
 
     std::size_t temp_storage_bytes = 0;
     const T* input_data = input.data();
@@ -277,7 +277,7 @@ struct Where<GPUDevice, NDIM, T, TIndex> {
       return Status::OK();
     }
 
-    const gpuStream_t& cu_stream = GetGPUStream(ctx);
+    const gpuStream_t& cu_stream = GetGpuStream(ctx);
 
     std::size_t temp_storage_bytes = 0;
 

--- a/tensorflow/core/util/gpu_cuda_alias.h
+++ b/tensorflow/core/util/gpu_cuda_alias.h
@@ -1,0 +1,47 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+namespace tensorflow {
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_HOST_FUNCTION_ALIAS(func, cuda_alias) \
+  template <typename... Args> \
+  auto cuda_alias(Args&&... args) -> decltype(func(std::forward<Args>(args)...)) { \
+    return func(std::forward<Args>(args)...); \
+  }
+#else
+  #define CREATE_CUDA_HOST_FUNCTION_ALIAS(func, cuda_alias)
+#endif
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_DEVICE_FUNCTION_ALIAS(func, cuda_alias) \
+  template <typename... Args> \
+  __device__ auto cuda_alias(Args&&... args) -> decltype(func(std::forward<Args>(args)...)) { \
+    return func(std::forward<Args>(args)...); \
+  }
+#else
+  #define CREATE_CUDA_DEVICE_FUNCTION_ALIAS(func, cuda_alias)
+#endif
+
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias) \
+  using cuda_alias = type;
+#else
+  #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias)
+#endif
+}
+
+

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -70,8 +70,6 @@ using gpuStream_t = hipStream_t;
 using gpuError_t = hipError_t;
 #endif
 
-#define GetGPUStream(context) context->eigen_gpu_device().stream()
-
 namespace tensorflow {
 __host__ __device__ inline tensorflow::bfloat16 GpuLdg(
     const tensorflow::bfloat16* address) {

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
+#include "tensorflow/core/util/gpu_cuda_alias.h"
 #include "tensorflow/core/util/gpu_device_functions.h"
 #include "tensorflow/core/util/gpu_launch_config.h"
 
@@ -47,8 +48,13 @@ limitations under the License.
 // Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.
 #define GPU_1D_KERNEL_LOOP(i, n) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
+#define CUDA_1D_KERNEL_LOOP(i, n) \
+  for (int i : ::tensorflow::GpuGridRangeX<int>(n))
+
 // Deprecated, use 'for(int i : GpuGridRange?(n))' instead.
 #define GPU_AXIS_KERNEL_LOOP(i, n, axis) \
+  for (int i : ::tensorflow::GpuGridRange##axis<int>(n))
+#define CUDA_AXIS_KERNEL_LOOP(i, n, axis) \
   for (int i : ::tensorflow::GpuGridRange##axis<int>(n))
 
 #if GOOGLE_CUDA
@@ -73,6 +79,7 @@ __host__ __device__ inline tensorflow::bfloat16 GpuLdg(
   return_value.value = GpuLdg(reinterpret_cast<const uint16_t*>(address));
   return return_value;
 }
+// Already aliased in gpu_device_functions.h
 
 template <typename T>
 __host__ __device__ inline T ldg(const T* ptr) {
@@ -117,12 +124,14 @@ __device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleUpSync(
   return Eigen::half(
       GpuShuffleUpSync(mask, static_cast<uint16>(value), delta, width));
 }
+CREATE_CUDA_HOST_FUNCTION_ALIAS(GpuShuffleUpSync, CudaShuffleUpSync);
 
 __device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleDownSync(
     unsigned mask, Eigen::half value, int delta, int width = warpSize) {
   return Eigen::half(
       GpuShuffleDownSync(mask, static_cast<uint16>(value), delta, width));
 }
+CREATE_CUDA_HOST_FUNCTION_ALIAS(GpuShuffleDownSync, CudaShuffleDownSync);
 
 __device__ EIGEN_ALWAYS_INLINE Eigen::half GpuShuffleXorSync(
     unsigned mask, Eigen::half value, int lane_mask, int width = warpSize) {
@@ -171,8 +180,8 @@ __device__ OutType lower_bound(const T* first, OutType count, T val) {
 
   return first - orig;
 }
-
 }  // namespace gpu_helper
+namespace cuda_helper = gpu_helper;
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -27,11 +27,23 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
-#define FWD(func, alias) \
-template <typename... Args> \
-auto alias(Args&&... args) -> decltype(func(std::forward<Args>(args)...)) { \
-  return alias(std::forward<Args>(args)...); \
-}
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_FUNCTION_ALIAS(func, cuda_alias) \
+  template <typename... Args> \
+  auto cuda_alias(Args&&... args) -> decltype(func(std::forward<Args>(args)...)) { \
+    return cuda_alias(std::forward<Args>(args)...); \
+  }
+#else
+  #define CREATE_CUDA_FUNCTION_ALIAS(func, cuda_alias)
+#endif
+
+#ifndef TENSORFLOW_USE_ROCM
+  #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias) \
+  using cuda_alias = type;
+#else
+  #define CREATE_CUDA_TYPE_ALIAS(type, cuda_alias)
+#endif
+
 // Usage of GetGpuLaunchConfig, GetGpu2DLaunchConfig, and
 // GetGpu3DLaunchConfig:
 //
@@ -122,7 +134,7 @@ struct GpuLaunchConfig {
   // Number of blocks for Gpu kernel launch.
   int block_count = -1;
 };
-using CudaLaunchConfig = GpuLaunchConfig;
+CREATE_CUDA_TYPE_ALIAS(GpuLaunchConfig, CudaLaunchConfig);
 
 // Calculate the Gpu launch config we should use for a kernel launch.
 // This is assuming the kernel is quite simple and will largely be
@@ -192,7 +204,7 @@ inline GpuLaunchConfig GetGpuLaunchConfig(int work_element_count,
   config.block_count = block_count;
   return config;
 }
-FWD(GetGpuLaunchConfig, GetCudaLaunchConfig);
+CREATE_CUDA_FUNCTION_ALIAS(GetGpuLaunchConfig, GetCudaLaunchConfig);
 
 // Calculate the Gpu launch config we should use for a kernel launch. This
 // variant takes the resource limits of func into account to maximize occupancy.
@@ -234,14 +246,14 @@ inline GpuLaunchConfig GetGpuLaunchConfigFixedBlockSize(
   config.block_count = block_count;
   return config;
 }
-FWD(GetGpuLaunchConfigFixedBlockSize, GetCudaLaunchConfigFixedBlockSize);
+CREATE_CUDA_FUNCTION_ALIAS(GetGpuLaunchConfigFixedBlockSize, GetCudaLaunchConfigFixedBlockSize);
 
 struct Gpu2DLaunchConfig {
   dim3 virtual_thread_count = dim3(0, 0, 0);
   dim3 thread_per_block = dim3(0, 0, 0);
   dim3 block_count = dim3(0, 0, 0);
 };
-using Cuda2DLaunchConfig = Gpu2DLaunchConfig;
+CREATE_CUDA_TYPE_ALIAS(Gpu2DLaunchConfig, Cuda2DLaunchConfig);
 
 inline Gpu2DLaunchConfig GetGpu2DLaunchConfig(int xdim, int ydim,
                                                 const Eigen::GpuDevice& d) {
@@ -345,7 +357,7 @@ inline Gpu3DLaunchConfig GetGpu3DLaunchConfig(
   config.block_count = dim3(blocksx, blocksy, blocksz);
   return config;
 }
-FWD(GetGpu3DLaunchConfig, GetCuda3DLaunchConfig);
+CREATE_CUDA_FUNCTION_ALIAS(GetGpu3DLaunchConfig, GetCuda3DLaunchConfig);
 
 template <typename DeviceFunc>
 inline Gpu2DLaunchConfig GetGpu2DLaunchConfig(
@@ -354,7 +366,7 @@ inline Gpu2DLaunchConfig GetGpu2DLaunchConfig(
   return GetGpu3DLaunchConfig(xdim, ydim, 1, d, func,
                                dynamic_shared_memory_size, block_size_limit);
 }
-FWD(GetGpu2DLaunchConfig, GetCuda2DLaunchConfig);
+CREATE_CUDA_FUNCTION_ALIAS(GetGpu2DLaunchConfig, GetCuda2DLaunchConfig);
 
 #if GOOGLE_CUDA
 // Returns a raw reference to the current cuda stream.  Required by a
@@ -368,7 +380,7 @@ inline const cudaStream_t& GetGpuStream(OpKernelContext* context) {
                                                 ->GpuStreamMemberHack()));
   return *ptr;
 }
-FWD(GetGpuStream, GetCudaStream);
+CREATE_CUDA_FUNCTION_ALIAS(GetGpuStream, GetCudaStream);
 #endif // GOOGLE_CUDA
 
 namespace detail {

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -367,6 +367,8 @@ inline const cudaStream_t& GetCudaStream(OpKernelContext* context) {
 }
 #endif // GOOGLE_CUDA
 
+#define GetGpuStream(context) context->eigen_gpu_device().stream()
+
 namespace detail {
 template <typename... Ts, size_t... Is>
 std::array<void*, sizeof...(Ts)> GetArrayOfElementPointersImpl(


### PR DESCRIPTION
After some careful thought, what this PR aims to achieve are:

- Help upstream for its Cuda* related types/functions backward compatibility
  - Should not break upstream ROCm/Cuda builds, either for current or future build. Potentially this means both upstream ROCm/Cuda builds should be able to compile with both set of symbols.
- Help us for our Gpu* related types/functions backward compatibility
  - Should not break our ROCm/Cuda builds
- Has to be able to conveniently taken out step by step as upstream dependencies choose to rename over time

It looks like the only way to achieve all goals is to add alias function/types to existing ones (available to both ROCm and Cuda builds). 

This is the starting point of the PR. The complete scope of the PR means to address all renaming under tensorflow/core/util/gpu_*. I will wait for @whchung @deven-amd opinions until working on other files.

Test performed:
Current code compiles on dev machine in ROCm environment.
Also tested on dev machine in Cuda environment