### PR TITLE
Avoid hardcoding global address spaces

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -997,7 +997,8 @@ Status IrEmitterUnnested::HandleRng(HloInstruction* rng) {
   // Emit a kernel to increment the global state for Philox RNG algorithm.
   std::unique_ptr<Thunk> increment_seed_thunk =
       BuildKernelThunk(rng, /*implements_whole_instruction=*/false);
-  llvm_ir::IncrementVariableForPhiloxRngState(1, module_, &b_);
+  unsigned int global_address_space = GetGlobalMemoryAddressSpace(module_);
+  llvm_ir::IncrementVariableForPhiloxRngState(1, module_, &b_, global_address_space);
 
   // Build the SequentialThunk for the RNG hlo.
   std::vector<std::unique_ptr<Thunk>> thunks;
@@ -3796,6 +3797,7 @@ Status IrEmitterUnnested::EmitConstantGlobals() {
     //
     // We may have to be more more clever here in the future if we notice that
     // we're keeping around too many globals because of their linkage.
+    unsigned int global_address_space = GetGlobalMemoryAddressSpace(ir_emitter_context_->llvm_module());
     llvm::GlobalVariable* global_for_const = new llvm::GlobalVariable(
         global_type, /*isConstant=*/should_emit_initializer,
         llvm::GlobalValue::ExternalLinkage,
@@ -3803,7 +3805,7 @@ Status IrEmitterUnnested::EmitConstantGlobals() {
         llvm_ir::AsStringRef(
             llvm_ir::ConstantBufferAllocationToGlobalName(allocation)),
         /*TLMode=*/llvm::GlobalValue::NotThreadLocal,
-        /*AddressSpace=*/llvm_ir::kAMDGPUGlobalMemoryAddrSpace,
+        /*AddressSpace=*/global_address_space,
         /*isExternallyInitialized=*/false);
     global_for_const->setAlignment(kConstantBufferAlignBytes);
     ir_emitter_context_->llvm_module()->getGlobalList().push_back(

--- a/tensorflow/compiler/xla/service/gpu/target_util.cc
+++ b/tensorflow/compiler/xla/service/gpu/target_util.cc
@@ -335,6 +335,25 @@ struct TargetInfo GetTargetInfo(TargetFunctionID function_id,
 }
 }  // namespace
 
+unsigned int GetGlobalMemoryAddressSpace(llvm::Module* module) {
+  llvm::Triple target_triple = llvm::Triple(module->getTargetTriple());
+  if (target_triple.getArch() == llvm::Triple::amdgcn){
+    return kAMDGPUGlobalMemoryAddrSpace;
+  }
+  return 0;
+}
+
+unsigned int GetSharedMemoryAddressSpace(llvm::Module* module) {
+  llvm::Triple target_triple = llvm::Triple(module->getTargetTriple());
+  if (target_triple.getArch() == llvm::Triple::nvptx ||
+      target_triple.getArch() == llvm::Triple::nvptx64) {
+    return kNVPTXSharedMemoryAddrSpace;
+  } else if (target_triple.getArch() == llvm::Triple::amdgcn) {
+    return kAMDGPUSharedMemoryAddrSpace;
+  }
+  return 0;
+}
+
 llvm::Value* EmitCallToTargetFunction(
     TargetFunctionID function_id, absl::Span<llvm::Value* const> operands,
     absl::Span<const PrimitiveType> input_types, PrimitiveType output_type,

--- a/tensorflow/compiler/xla/service/gpu/target_util.h
+++ b/tensorflow/compiler/xla/service/gpu/target_util.h
@@ -56,6 +56,12 @@ enum class TargetFunctionID {
   kFmod,
   kRound,
 };
+// AMDGCN target address spaces
+constexpr int kAMDGPUGlobalMemoryAddrSpace = 1;
+constexpr int kAMDGPUSharedMemoryAddrSpace = 3;
+
+// NVPTX target address spaces
+constexpr int kNVPTXSharedMemoryAddrSpace = 3;
 
 // Emits a call to the specified target function  with the given operands.
 // Target function can either be an intrinsic or a device function.
@@ -68,6 +74,10 @@ llvm::Value* EmitCallToTargetFunction(
     absl::Span<const PrimitiveType> input_types, PrimitiveType output_type,
     absl::Span<const llvm::Attribute::AttrKind> attributes,
     absl::Span<llvm::Type* const> overloaded_types, llvm::IRBuilder<>* b);
+
+// Obtain the target specific address space for global variables
+unsigned int GetGlobalMemoryAddressSpace(llvm::Module* module);
+unsigned int GetSharedMemoryAddressSpace(llvm::Module* module);
 
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -135,7 +135,7 @@ tf_cc_test(
 tf_cc_test(
     name = "gpu_kernel_tiling_test",
     srcs = ["gpu_kernel_tiling_test.cc"],
-    tags = tf_cuda_tests_tags() + ["no_rocm"],
+    tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
         "//tensorflow/compiler/xla/service:hlo",

--- a/tensorflow/compiler/xla/service/llvm_ir/kernel_tiling.cc
+++ b/tensorflow/compiler/xla/service/llvm_ir/kernel_tiling.cc
@@ -191,8 +191,11 @@ llvm::GlobalVariable* KernelMappingScheme::GetSharedMemoryBufferForElementType(
   llvm::Type* buffer_type = llvm::ArrayType::get(
       llvm::ArrayType::get(elem_ty, GetTileSizeForDimension(DimX) + 1),
       GetTileSizeForDimension(DimY));
-  return llvm_ir::AllocateSharedMemoryTile(b_->GetInsertBlock()->getModule(),
-                                           buffer_type, buffer_name);
+  llvm::Module* module = b_->GetInsertBlock()->getModule();
+  unsigned shared_memory_address_space = gpu::GetSharedMemoryAddressSpace(module);
+  return llvm_ir::AllocateSharedMemoryTile(module,
+                                           buffer_type, buffer_name,
+                                           shared_memory_address_space);
 }
 
 std::tuple<llvm::Value*, llvm::Value*>

--- a/tensorflow/compiler/xla/service/llvm_ir/llvm_util.cc
+++ b/tensorflow/compiler/xla/service/llvm_ir/llvm_util.cc
@@ -264,15 +264,14 @@ llvm::Constant* ConvertLiteralToIrConstant(const Literal& literal,
       /*AddNull=*/false);
 }
 
-llvm::GlobalVariable* AllocateSharedMemoryTile(llvm::Module* module,
-                                               llvm::Type* tile_type,
-                                               absl::string_view name) {
-  const int kNVPTXSharedMemoryAddrSpace = 3;
+llvm::GlobalVariable* AllocateSharedMemoryTile(
+    llvm::Module* module, llvm::Type* tile_type, absl::string_view name,
+    unsigned int shared_memory_address_space) {
   return new llvm::GlobalVariable(
       *module, tile_type,
       /*isConstant=*/false, llvm::GlobalValue::PrivateLinkage,
       llvm::UndefValue::get(tile_type), AsStringRef(name), nullptr,
-      llvm::GlobalValue::NotThreadLocal, kNVPTXSharedMemoryAddrSpace);
+      llvm::GlobalValue::NotThreadLocal, shared_memory_address_space);
 }
 
 llvm::AllocaInst* EmitAllocaAtFunctionEntry(llvm::Type* type,
@@ -690,7 +689,7 @@ std::pair<llvm::Value*, llvm::Value*> SplitInt64ToInt32s(
 }
 
 llvm::GlobalVariable* GetOrCreateVariableForPhiloxRngState(
-    llvm::Module* module, llvm::IRBuilder<>* b) {
+    llvm::Module* module, llvm::IRBuilder<>* b, unsigned int global_address_space) {
   static const char* kPhiloxRngStateVariableName = "philox_rng_state";
   llvm::GlobalVariable* state_ptr =
       module->getNamedGlobal(kPhiloxRngStateVariableName);
@@ -704,16 +703,17 @@ llvm::GlobalVariable* GetOrCreateVariableForPhiloxRngState(
         /*Name=*/kPhiloxRngStateVariableName,
         /*InsertBefore=*/nullptr,
         /*TLMode=*/llvm::GlobalValue::NotThreadLocal,
-        /*AddressSpace=*/llvm_ir::kAMDGPUGlobalMemoryAddrSpace,
+        /*AddressSpace=*/global_address_space, 
         /*isExternallyInitialized=*/false);
   }
   return state_ptr;
 }
 
 void IncrementVariableForPhiloxRngState(int64 value, llvm::Module* module,
-                                        llvm::IRBuilder<>* builder) {
+                                        llvm::IRBuilder<>* builder, 
+                                         unsigned int global_address_space) {
   llvm::GlobalVariable* state_ptr =
-      GetOrCreateVariableForPhiloxRngState(module, builder);
+      GetOrCreateVariableForPhiloxRngState(module, builder, global_address_space);
   llvm::Value* state_value_old = builder->CreateLoad(state_ptr, "load_state");
   // If the 64-bit value overflows, we use the wraparound value. This should
   // be fine in practice as we only add one to the value each time when a RNG is

--- a/tensorflow/compiler/xla/service/llvm_ir/llvm_util.h
+++ b/tensorflow/compiler/xla/service/llvm_ir/llvm_util.h
@@ -159,9 +159,9 @@ llvm::Constant* ConvertLiteralToIrConstant(const Literal& literal,
                                            llvm::Module* module);
 
 // Allocates a tile of shared memory.
-llvm::GlobalVariable* AllocateSharedMemoryTile(llvm::Module* module,
-                                               llvm::Type* tile_type,
-                                               absl::string_view name);
+llvm::GlobalVariable* AllocateSharedMemoryTile(
+    llvm::Module* module, llvm::Type* tile_type, absl::string_view name,
+    unsigned int shared_memory_address_space);
 
 // Inserts an allocate of the requested type at the entry point of the
 // function that the builder is currently building. The insert point
@@ -308,17 +308,17 @@ std::pair<llvm::Value*, llvm::Value*> SplitInt64ToInt32s(
 // state passed between RNG calls implemented with Philox algorithm. If not,
 // creates such a variable. Returns the global variable.
 llvm::GlobalVariable* GetOrCreateVariableForPhiloxRngState(
-    llvm::Module* module, llvm::IRBuilder<>* b);
+    llvm::Module* module, llvm::IRBuilder<>* b, 
+    unsigned int global_address_space = 0);
 
 // Adds a value to the global state variable each time when a RNG hlo is
 // executed. The value of this global state variable is added to the seed
 // of the Philox RNG algorithm so that calling the same RNG Hlo multiple times
 // should rarely produce the same result.
 void IncrementVariableForPhiloxRngState(int64 value, llvm::Module* module,
-                                        llvm::IRBuilder<>* b);
+                                        llvm::IRBuilder<>* b, 
+                                        unsigned int global_address_space = 0);
 
-constexpr int kAMDGPUGlobalMemoryAddrSpace = 1;
-constexpr int kAMDGPUSharedMemoryAddrSpace = 3;
 }  // namespace llvm_ir
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/llvm_ir/sort_util.cc
+++ b/tensorflow/compiler/xla/service/llvm_ir/sort_util.cc
@@ -331,13 +331,14 @@ Status EmitSortInPlace(
   std::vector<llvm::Value*> param_shmem_buffers(values_arrays.size(), nullptr);
   if (xor_masks.size() > 1) {
     llvm::Module* module = b->GetInsertBlock()->getParent()->getParent();
+    unsigned int shared_memory_address_space = gpu::GetSharedMemoryAddressSpace(module);
     for (int64 i = 0; i < values_arrays.size(); ++i) {
       llvm::Type* tile_type = llvm::ArrayType::get(
           llvm_ir::PrimitiveTypeToIrType(
               values_arrays[i].GetShape().element_type(), module),
           tile_size);
-      param_shmem_buffers[i] = llvm_ir::AllocateSharedMemoryTile(
-          module, tile_type, absl::StrCat(name, "_tile_param_", i));
+      param_shmem_buffers[i] = llvm_ir::AllocateSharedMemoryTile(module, tile_type, absl::StrCat(name, "_tile_param_", i),
+       shared_memory_address_space);
     }
   }
 


### PR DESCRIPTION
Doesnt look like LLVM provides any way to map default address spaces. So provide a target API to do that