### PR TITLE
Implementing gembatched using strided memory

### DIFF
--- a/tensorflow/python/kernel_tests/batch_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/batch_matmul_op_test.py
@@ -293,27 +293,20 @@ if __name__ == "__main__":
               "testBatchMatmulOp_" + name + "_{}".format(use_static_shape_),
               _GetBatchMatmulOpTest(dtype_, adjoint_a_, adjoint_b_,
                                     use_static_shape_))
-          # Broadcasting is supported only in v2.
-          # ROCm: BatchMatmul broadcasting is currently unsupported, refer to PR 387 for details
-          if not test.is_built_with_rocm():
-            setattr(
-                BatchMatmulOpTest, "testBatchMatmulBroadcasting_" + name +
-                ("_%s" % use_static_shape_),
-                _GetBatchMatmulOpBroadcastingTest(dtype_, adjoint_a_, adjoint_b_,
-                                                use_static_shape_))
+          setattr(
+              BatchMatmulOpTest, "testBatchMatmulBroadcasting_" + name +
+              ("_%s" % use_static_shape_),
+              _GetBatchMatmulOpBroadcastingTest(dtype_, adjoint_a_, adjoint_b_,
+                                              use_static_shape_))
         if dtype_ == np.int32:
           continue
 
-        if not test.is_built_with_rocm():
-          # TODO: Fix BatchMatmulGradientTest on ROCm
-          setattr(BatchMatmulGradientTest, "testBatchMatmulGradient_" + name,
-                _GetBatchMatmulGradientTest(dtype_, adjoint_a_, adjoint_b_))
+        setattr(BatchMatmulGradientTest, "testBatchMatmulGradient_" + name,
+              _GetBatchMatmulGradientTest(dtype_, adjoint_a_, adjoint_b_))
 
-          # ROCm: BatchMatmul broadcasting is currently unsupported, refer to PR 387 for details
-          # Broadcasting is supported only in v2.
-          setattr(
-              BatchMatmulGradientTest,
-              "testBatchMatmulGradientWithBroadcasting_" + name,
-              _GetBatchMatmulGradientWithBroadcastingTest(dtype_, adjoint_a_,
-                                                          adjoint_b_))
+        setattr(
+            BatchMatmulGradientTest,
+            "testBatchMatmulGradientWithBroadcasting_" + name,
+            _GetBatchMatmulGradientWithBroadcastingTest(dtype_, adjoint_a_,
+                                                        adjoint_b_))
   test.main()

--- a/tensorflow/python/ops/parallel_for/BUILD
+++ b/tensorflow/python/ops/parallel_for/BUILD
@@ -146,7 +146,7 @@ cuda_py_test(
         "//tensorflow/python:util",
     ],
     shard_count = 5,
-    tags = ["optonly", "no_rocm"],  # Too slow in non-opt mode
+    tags = ["optonly"],  # Too slow in non-opt mode
     xla_enable_strict_auto_jit = True,
 )
 

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -1811,15 +1811,60 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
   return false;
 }
 
-template <typename T>
-struct EigenHalfToRocBlasHalf {
-  using type = T;
-};
-
 template <>
-struct EigenHalfToRocBlasHalf<Eigen::half> {
+struct ROCMBlas::EigenHalfToRocBlasHalf<Eigen::half> {
   using type = rocblas_half;
 };
+
+template <typename T>
+port::Status ROCMBlas::AllocateStridedBuffer(
+    const std::vector<typename EigenHalfToRocBlasHalf<T>::type *>& raw_ptrs, int batch_count, 
+    uint64_t batch_stride, ScratchAllocator* scratch_allocator, Stream * stream, 
+    std::unique_ptr<TemporaryDeviceMemory<typename EigenHalfToRocBlasHalf<T>::type>>& temp_memory,
+    DeviceMemory<typename EigenHalfToRocBlasHalf<T>::type>& device_memory) {
+  using MAPPED_T = typename EigenHalfToRocBlasHalf<T>::type;
+
+  bool needs_allocate_strided = false;
+  for (int i = 1; i < batch_count; ++i) {
+    uint64_t tmp_batch_stride = raw_ptrs[i] - raw_ptrs[i - 1];
+    if (tmp_batch_stride != batch_stride) {
+      needs_allocate_strided = true;
+      break;
+    }
+  }
+
+  size_t matrix_byte_size = batch_stride * sizeof(MAPPED_T);
+  size_t matrix_batch_byte_size = matrix_byte_size * batch_count;
+
+  // No need to do re-allocation, take the short cut and return
+  if (!needs_allocate_strided) {
+    device_memory = DeviceMemory<MAPPED_T>(DeviceMemoryBase(raw_ptrs[0], matrix_batch_byte_size));
+    return port::Status::OK();
+  }
+
+  if (scratch_allocator != nullptr){
+    SE_ASSIGN_OR_RETURN(DeviceMemory<uint8> batch_matrix_bytes,
+                        scratch_allocator->AllocateBytes(stream, matrix_batch_byte_size));
+    device_memory = DeviceMemory<MAPPED_T>(batch_matrix_bytes);
+  } else {
+    SE_ASSIGN_OR_RETURN(temp_memory,
+                        stream->AllocateTemporaryArray<MAPPED_T>(matrix_batch_byte_size));
+    device_memory = DeviceMemory<MAPPED_T>(*temp_memory->mutable_device_memory());
+  }
+
+  for (int i = 0; i < batch_count; ++i) {
+    char * device_memory_ptr = static_cast<char *>(device_memory.opaque());
+    DeviceMemoryBase src_mem = DeviceMemoryBase(raw_ptrs[i], matrix_byte_size); 
+    DeviceMemoryBase target_mem = DeviceMemoryBase(device_memory_ptr + i * matrix_byte_size, matrix_byte_size);
+    bool a_status = stream->ThenMemcpy(&target_mem, src_mem, matrix_byte_size).ok();
+    //parent_->Deallocate(&src_mem);
+    if (!a_status){
+      return port::Status(port::error::INTERNAL,
+                          "failed to copy device memory in ROCMBlas::DoBlasGemmBatched");
+    }
+  }
+  return port::Status::OK();
+}
 
 template <typename T, typename FuncT>
 port::Status ROCMBlas::DoBlasGemmBatchedInternal(
@@ -1829,15 +1874,40 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
     const port::ArraySlice<DeviceMemory<T>*>& b_ptrs_to_wrappers, int ldb,
     T beta, const port::ArraySlice<DeviceMemory<T>*>& c_ptrs_to_wrappers,
     int ldc, int batch_count, ScratchAllocator* scratch_allocator) {
+
   // MAPPED_T will be same as T for all types except Eigen::Half
   // for T = Eigen::half, MAPPED_T = rocblas_half
   using MAPPED_T = typename EigenHalfToRocBlasHalf<T>::type;
+
+  // Sanity checks before making any further progress
+  uint64_t batch_stride_a = 0;
+  uint64_t batch_stride_b = 0;
+  uint64_t batch_stride_c = 0;
+
+  assert(ldc >= m);
+  batch_stride_c = ldc * n;
+
+  if (ROCMBlasTranspose(transa) == rocblas_operation_none) {
+      assert(lda >= m);
+      batch_stride_a = lda * k;
+  } else {
+      assert(lda >= k);
+      batch_stride_a = lda * m;
+  }
+
+  if (ROCMBlasTranspose(transb) == rocblas_operation_none) {
+      assert(ldb >= k);
+      batch_stride_b = ldb * n;
+  } else {
+      assert(ldb >= n);
+      batch_stride_b = ldb * k;
+  }
 
   // Alocate local vectors to hold device pointers to matrices
   std::vector<MAPPED_T *> a_raw_ptrs, b_raw_ptrs, c_raw_ptrs;
   for (int i = 0; i < batch_count; ++i) {
     // static_cast does work when converting Eigen::half* to rocblas_half*,
-    // hence the use od reinterpret_cast
+    // hence the use of reinterpret_cast
     a_raw_ptrs.push_back(
         reinterpret_cast<MAPPED_T*>(a_ptrs_to_wrappers[i]->opaque()));
     b_raw_ptrs.push_back(
@@ -1846,79 +1916,47 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
         reinterpret_cast<MAPPED_T*>(c_ptrs_to_wrappers[i]->opaque()));
   }
 
-  //  batch_count <= 1 is base case, no definable matrix stride, set it same as
-  //  ld*
-  long long bsa = lda;
-  long long bsb = ldb;
-  long long bsc = ldc;
-  bool bsa_is_constant = true;
-  bool bsb_is_constant = true;
-  bool bsc_is_constant = true;
-
-  if (batch_count > 1) {
-    // Remember first stride; if any other stride is different that this one,
-    // KABLAM
-    bsa = a_raw_ptrs[1] - a_raw_ptrs[0];
-    bsb = b_raw_ptrs[1] - b_raw_ptrs[0];
-    bsc = c_raw_ptrs[1] - c_raw_ptrs[0];
-
-    //  Loop to verify that batched strides are constant
-    //  All the test cases from batch_matmul_op_test.py seem to satisfy this
-    //  requirement of a constant stride.  If this can be proven globally, then
-    //  this loop check can be safely removed
-    for (int i = 1; i < batch_count - 1; ++i) {
-      long long iterative_bsa = a_raw_ptrs[i + 1] - a_raw_ptrs[i];
-      if (iterative_bsa != bsa) {
-        bsa_is_constant = false;
-        break;
-      }
-
-      long long iterative_bsb = b_raw_ptrs[i + 1] - b_raw_ptrs[i];
-      if (iterative_bsb != bsb) {
-        bsb_is_constant = false;
-        break;
-      }
-
-      long long iterative_bsc = c_raw_ptrs[i + 1] - c_raw_ptrs[i];
-      if (iterative_bsc != bsc) {
-        bsc_is_constant = false;
-        break;
-      }
-    }
+  DeviceMemory<MAPPED_T> a;
+  // Make sure the temporary memory are in-scope before the function returns
+  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> a_temp;
+  port::Status a_allocation_status = AllocateStridedBuffer<T>(
+      a_raw_ptrs, batch_count, batch_stride_a, scratch_allocator, stream, a_temp, a);
+  if(a_allocation_status != port::Status::OK()){
+      return a_allocation_status;
   }
 
-  if (bsa_is_constant && bsb_is_constant && bsc_is_constant) {
-    assert(!(ldc < m || bsc < ldc * n));
+  DeviceMemory<MAPPED_T> b;
+  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> b_temp;
+  port::Status b_allocation_status = AllocateStridedBuffer<T>(
+      b_raw_ptrs, batch_count, batch_stride_b, scratch_allocator, stream, b_temp, b);
+  if(b_allocation_status != port::Status::OK()){
+      return b_allocation_status;
+  }
 
-    if (ROCMBlasTranspose(transa) == rocblas_operation_none)
-      assert(!(lda < m || bsa < lda * k));
-    else
-      assert(!(lda < k || bsa < lda * m));
+  DeviceMemory<MAPPED_T> c;
+  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> c_temp;
+  port::Status c_allocation_status = AllocateStridedBuffer<T>(
+      c_raw_ptrs, batch_count, batch_stride_c, scratch_allocator, stream, c_temp, c);
+  if(c_allocation_status != port::Status::OK()){
+      return c_allocation_status;
+  }
 
-    if (ROCMBlasTranspose(transb) == rocblas_operation_none)
-      assert(!(ldb < k || bsb < ldb * n));
-    else
-      assert(!(ldb < n || bsb < ldb * k));
+  MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
+  MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
 
-    MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
-    MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
+  bool ok = DoBlasInternal(
+      rocblas_func, stream, true /* = pointer_mode_host */,
+      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
+      GpuComplex(alpha_ptr), GpuMemory(a), lda, batch_stride_a, 
+      GpuMemory(b), ldb, batch_stride_b,
+      GpuComplex(beta_ptr), GpuMemoryMutable(&c), ldc, batch_stride_c, batch_count);
 
-    bool ok = DoBlasInternal(
-        rocblas_func, stream, true /* = pointer_mode_host */,
-        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-        GpuComplex(alpha_ptr), a_raw_ptrs[0], lda, bsa, b_raw_ptrs[0], ldb, bsb,
-        GpuComplex(beta_ptr), c_raw_ptrs[0], ldc, bsc, batch_count);
-
-    if (ok) {
-      return port::Status::OK();
-    }
+  if (ok) {
+    return port::Status::OK();
   } else {
-    LOG(ERROR) << "rocBLAS does not currently support broadcasting for GEMMBatched operation.";
-    assert(false);
+    return port::Status(port::error::INTERNAL,
+                    "failed BLAS call, see log for details");
   }
-
-  return port::Status(port::error::INTERNAL,
-                      "failed BLAS call, see log for details");
 }
 
 bool ROCMBlas::DoBlasGemmBatched(

--- a/tensorflow/stream_executor/rocm/rocm_blas.h
+++ b/tensorflow/stream_executor/rocm/rocm_blas.h
@@ -104,24 +104,42 @@ class ROCMBlas : public blas::BlasSupport {
     using type = T;
   };
   
-  // A helper allocation funciton to convert raw pointers memory layout to strided flavor 
+  // A helper allocation funciton to convert raw pointers memory layout to
+  // strided flavor
   template <typename T>
   port::Status AllocateStridedBuffer(
-      const std::vector<typename EigenHalfToRocBlasHalf<T>::type *>& raw_ptrs, int batch_count, 
-      uint64_t batch_stride, ScratchAllocator* scrach_allocator, Stream * stream, 
-      std::unique_ptr<TemporaryDeviceMemory<typename EigenHalfToRocBlasHalf<T>::type>>& temp_memory,
-      DeviceMemory<typename EigenHalfToRocBlasHalf<T>::type>& device_memory);
+      const std::vector<typename EigenHalfToRocBlasHalf<T>::type *> &raw_ptrs,
+      int batch_count, uint64_t batch_stride, ScratchAllocator *scratch_allocator,
+      Stream *stream,
+      std::unique_ptr<
+          TemporaryDeviceMemory<typename EigenHalfToRocBlasHalf<T>::type>>
+          *temp_memory,
+      DeviceMemory<typename EigenHalfToRocBlasHalf<T>::type> *device_memory);
 
   // A helper function to implement DoBlasGemmBatched interfaces for generic
   // types.
+  //
+  // Note: This function is implemented using gemm_strided_batched interface,
+  // NOT gemm_batched interface, because rocblas do not support it. As a
+  // result, if the passed in batch matrix are not allocated in strided batched
+  // format, it might end up in non-trivial amount of memory allocation and
+  // copy. To avoid this, always prioritize to use DoBlasGemmStridedBatched
+  // interface.
+  //
+  // In most use cases, batch matrix do get allocated in strided manner, making
+  // calling this interface equivalent with DoBlasGemmStridedBatched. The only
+  // use case we see so far that violates this observation is when batch
+  // matrix is created by broadcasting from a smaller matrix. When it happens,
+  // It will take advantage of the AllocateStridedBuffer subroutine to
+  // reallocate the memory layout to be strided batched.
   template <typename T, typename FuncT>
   port::Status DoBlasGemmBatchedInternal(
       FuncT rocblas_func, Stream *stream, blas::Transpose transa,
       blas::Transpose transb, uint64 m, uint64 n, uint64 k, T alpha,
-      const port::ArraySlice<DeviceMemory<T> *> &a_array, int lda,
-      const port::ArraySlice<DeviceMemory<T> *> &b_array, int ldb, T beta,
-      const port::ArraySlice<DeviceMemory<T> *> &c_array, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
+      const port::ArraySlice<DeviceMemory<T> *> &a_ptrs_to_wrappers, int lda,
+      const port::ArraySlice<DeviceMemory<T> *> &b_ptrs_to_wrappers, int ldb,
+      T beta, const port::ArraySlice<DeviceMemory<T> *> &c_ptrs_to_wrappers,
+      int ldc, int batch_count, ScratchAllocator *scratch_allocator);
 
   // Helper function for implementing DoBlasGemmWithAlgorithm.
   //


### PR DESCRIPTION
Adding a new subroutine AllocateStridedBuffer() to do memory allocation properly. The subroutine will take the shortcut when buffer is already allocated in a strided manner. And re-allocate when gemm batched buffer isn't properly strided. 

Tests performed:

- tensorflow/python/ops/parallel_for/math_test
- tensorflow/python/kernel_tests/batch_matmul_op_test

Adding @sunway513 as a FYI that math_test get re-enabled, after weekly merge PR #427.
Adding @deven-amd @sumesh13 as a FYI of the follow-up of our discussion.