### PR TITLE
Update doc for ROCm2.4 release

### DIFF
--- a/README.ROCm.md
+++ b/README.ROCm.md
@@ -8,7 +8,7 @@ This repository hosts the port of [Tensorflow](https://github.com/tensorflow/ten
 
 For further background information on ROCm, refer [here](https://github.com/RadeonOpenCompute/ROCm/blob/master/README.md).
 
-The project is derived from TensorFlow 1.13.1 and has been verified to work with the latest ROCm2.3 release.
+The project is derived from TensorFlow 1.13.1 and has been verified to work with the latest ROCm2.4 release.
 
 For details on installation and usage, see these links:
 * [Basic installation](rocm_docs/tensorflow-install-basic.md)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ subscribing to
 [announce@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/announce).
 
 **Tensorflow ROCm port**
-This project is based on TensorFlow 1.13.1. It has been verified to work with the latest ROCm2.3 release.
+This project is based on TensorFlow 1.13.1. It has been verified to work with the latest ROCm2.4 release.
 Please follow the instructions [here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md) to set up your ROCm stack.
 A docker container: **rocm/tensorflow:latest(https://hub.docker.com/r/rocm/tensorflow/)** is readily available to be used:
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,9 @@
+# Release 1.13.3
+
+## Bug Fixes and Other Changes
+* The 1.13.3 whl package is built the ROCm2.4 user-bit environment
+
+
 # Release 1.12.2
 
 ## Bug Fixes and Other Changes


### PR DESCRIPTION
This PR updates the doc for ROCm2.4. 
The PyPI package tensorflow-rocm version 1.13.3 would be compatible to ROCm2.4 user-bit packages. 