### PR TITLE
Remove the redundant rocprim from workspace.bzl

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -713,24 +713,15 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
             "https://github.com/NVlabs/cub/archive/1.8.0.zip",
         ],
     )
+
     tf_http_archive(
         name = "rocprim_archive",
-        urls = [ 
-            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rocPRIM/archive/4a33d328f8352df1654271939da66914f2334424.tar.gz",
-            "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/4a33d328f8352df1654271939da66914f2334424.tar.gz",
-        ],      
+        build_file = clean_dep("//third_party:rocprim.BUILD"),
         sha256 = "3c178461ead70ce6adb60c836a35a52564968af31dfa81f4157ab72b5f14d31f",
         strip_prefix = "rocPRIM-4a33d328f8352df1654271939da66914f2334424",
-        build_file = clean_dep("//third_party:rocprim.BUILD"),
-    )
-    tf_http_archive(
-        name = "rocprim_archive",
-        build_file = clean_dep("//third_party:rocprim.BUILD"),
-        sha256 = "12adf5bf3641d73c92915f102b17951f978704551fdcb9ed7f6311ed299b1d80",
-        strip_prefix = "rocPRIM-eff7d0687baf57db2507a31663a3dea72eed9093",
         urls = [
-            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rocPRIM/archive/eff7d0687baf57db2507a31663a3dea72eed9093.tar.gz",
-            "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/eff7d0687baf57db2507a31663a3dea72eed9093.tar.gz",
+            "https://mirror.bazel.build/github.com/ROCmSoftwarePlatform/rocPRIM/archive/4a33d328f8352df1654271939da66914f2334424.tar.gz",
+            "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/4a33d328f8352df1654271939da66914f2334424.tar.gz",
         ],
     )
 


### PR DESCRIPTION
In responding to a linker issue reported by @sumesh13, I take a look at the current workspace.bzl and realized that we have two versions of rocprim. The second rocprim is out-of-date and will cause linker issue when picked. This PR removes the second rocprim.