### PR TITLE
 Fix for the fp16 related XLA unit test failures. 

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -846,7 +846,6 @@ tf_xla_py_test(
         "//tensorflow/python:math_ops_gen",
         "//tensorflow/python:platform_test",
     ],
-    tags = ["no_rocm"],
 )
 
 tf_xla_py_test(
@@ -1069,7 +1068,7 @@ tf_xla_py_test(
     name = "scatter_nd_op_test",
     size = "medium",
     srcs = ["scatter_nd_op_test.py"],
-    tags = ["optonly", "no_rocm"],
+    tags = ["optonly"],
     deps = [
         ":xla_test",
         "//tensorflow/python:array_ops",
@@ -1308,5 +1307,4 @@ tf_xla_py_test(
         "//tensorflow/python:platform_test",
         "@absl_py//absl/testing:parameterized",
     ],
-    tags = ["no_rocm"],
 )

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -380,8 +380,11 @@ Status IrEmitter::EmitAtomicOperationUsingCAS(const HloComputation& computation,
   } else {
     atomic_memory_address =
         PointerBitCastOrAddrSpaceCast(output_address, atomic_address_type);
-    binop_output_address = PointerBitCastOrAddrSpaceCast(cas_new_output_address,
-                                                         element_address_type);
+    binop_output_address = PointerBitCastOrAddrSpaceCast(
+        cas_new_output_address,
+        llvm::PointerType::get(
+            element_type,
+            cas_new_output_address->getType()->getPointerAddressSpace()));
   }
 
   // Use the value from the memory that atomicCAS operates on to initialize


### PR DESCRIPTION
This commit builds upon the work that Sumesh has done in PR 447, to fix the incorrect code generation for the atomic CAS loop, in the case where the element type is < 32bits.

The main change in this commit over what was already tried out in PR 447 is to use the correct address space, when the casting the value for "cas_new_output_address" from i64 to half*.

@sumesh13 @whchung , please review