### PR TITLE
Update 3d convolution to run in large workspace size

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2758,6 +2758,10 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     wrap::miopenSetAllocator(miopen.handle(), nullptr, nullptr, nullptr);
 
     scratch_memory_size = preference.memory;
+
+    // Reuse the scratch_memory_temp in actual convolution
+    *scratch_memory = scratch_memory_temp;
+    return port::Status::OK();
   } else {
     // An algorithm has been specified.
     *algorithm_desc = *algo_desc;


### PR DESCRIPTION
This PR makes an MIOpen convolution algorithm that requires 5GB of workspace to be able to finish the first round of auto-tune. Since `miopenConvolutionForwardGetWorkSpaceSize()` returns a size of 5GB, we have to be extremely careful in not making one additional memory allocation to blow it up.

Since the use case is rare, I don't feel strong about this PR. Depending on CI result, I'm open to keep only the rocm_dnn.cc update.