### PR TITLE
Adding post_push hook to auto-build

### DIFF
--- a/tensorflow/tools/ci_build/hooks/post_push
+++ b/tensorflow/tools/ci_build/hooks/post_push
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "current image name: "$IMAGE_NAME
+
+NEW_IMAGE_NAME=$DOCKER_REPO":"`date +"%y%m%d"`
+echo "new image name: "$NEW_IMAGE_NAME
+
+docker tag $IMAGE_NAME $NEW_IMAGE_NAME
+docker push $NEW_IMAGE_NAME


### PR DESCRIPTION
This script will be triggered when an auto-build finishes. Please refer to [here ](https://docs.docker.com/docker-hub/builds/advanced/)for definition of auto-builds.

Environmental variables used in the script:

- `DOCKER_REPO`: the name of the Docker repository being built.
- `DOCKER_TAG`: the Docker repository tag being built.
- `IMAGE_NAME`: the name and tag of the Docker repository being built. (This variable is a combination of DOCKER_REPO:DOCKER_TAG.)

Say that the auto-build creates a image called `rocm/tensorflow-autobuilds:latest`, this script will tag the image to a different name `rocm/tensorflow-autobuilds:"YYMMDD"`, eg: `rocm/tensorflow-autobuilds:190522`

Test done:
Everything are already tested in my personal fork of [tensorflow-upstream](https://github.com/jerryyin/tensorflow-upstream/tree/develop-upstream/tensorflow/tools/ci_build/hooks).

-----------

Immediately after this PR I will create another hook called `pre_build`, such that it will only build when there are code changes to `ci_build` folder