### PR TITLE
Adding pre_build hook to auto-build

### DIFF
--- a/tensorflow/tools/ci_build/hooks/pre_build
+++ b/tensorflow/tools/ci_build/hooks/pre_build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if git diff --name-only HEAD^ HEAD | grep -q "ci_build"
+then
+  echo "Start a new build"
+else
+  echo "No dependency changes, abort build"
+  exit 1
+fi


### PR DESCRIPTION
This is a follow-up to PR #469. It needs to be merged after #469.

This pre-build script serves as a filter to auto-builds. If the previous commit does not include changes in the `ci_build` folder, it will abort and give up auto-builds. Otherwise, it exits without an error code and let the build continues. 

Test done:
Everything are already tested in my personal fork of [tensorflow-upstream](https://github.com/jerryyin/tensorflow-upstream/tree/develop-upstream/tensorflow/tools/ci_build/hooks).