### PR TITLE
Adding an explicit #define to indicate hip-clang mode

### DIFF
--- a/tensorflow/core/kernels/conv_2d_gpu.h
+++ b/tensorflow/core/kernels/conv_2d_gpu.h
@@ -232,7 +232,7 @@ __global__ void SwapDimension1And2InTensor3UsingTiles(
   constexpr int ReadRowPerPass = NumThreads / TileSizeJ;
   constexpr int WriteRowPerPass = NumThreads / TileSizeI;
   // One extra line in the inner dimension to avoid share memory bank conflict.
-#if GOOGLE_CUDA || __HIP__
+#if GOOGLE_CUDA || TENSORFLOW_COMPILER_IS_HIP_CLANG
   // This is to mimic the following, but no constructor of T can be invoked.
   //     __shared__ T shared_memory_tile[TileSizeI][TileSizeJ + 1];
   __shared__ __align__(

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -287,7 +287,7 @@ __global__ void ColumnReduceMax16ColumnsKernel(
   // TODO(nluehr) revert to 2D array when compiler is ready.
   // This is to mimic the following, but without any constructors:
   //   __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1)];
-#if GOOGLE_CUDA || __HIP__
+#if GOOGLE_CUDA || TENSORFLOW_COMPILER_IS_HIP_CLANG
   __shared__ __align__(
       alignof(value_type)) char partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1) * sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);
@@ -344,7 +344,7 @@ __global__ void ColumnReduceKernel(
   // TODO(nluehr) revert to 2D array when compiler is ready.
   // This is to mimic the following, but without constructors:
   //     __shared__ storage_type<value_type> partial_sums[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1)];
-#if GOOGLE_CUDA || __HIP__
+#if GOOGLE_CUDA || TENSORFLOW_COMPILER_IS_HIP_CLANG
   __shared__ __align__(
       alignof(value_type)) char partial_sums_raw[TF_RED_WARPSIZE * (TF_RED_WARPSIZE+1) * sizeof(value_type)];
   value_type* partial_sums = reinterpret_cast<value_type*>(partial_sums_raw);

--- a/tensorflow/core/lib/bfloat16/bfloat16.h
+++ b/tensorflow/core/lib/bfloat16/bfloat16.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 #include "tensorflow/core/platform/byte_order.h"
 
-#if defined(__CUDACC__) || __HIP__
+#if defined(__CUDACC__) || TENSORFLOW_COMPILER_IS_HIP_CLANG
 // All functions callable from CUDA code must be qualified with __device__
 #define B16_DEVICE_FUNC __host__ __device__
 


### PR DESCRIPTION
This PR  adding a TENSORFLOW_COMPILER_IS_HIP_CLANG macro that will be defined when compiling ROCM with hip-clang based hipcc.

I will file a PR to upstream this change once this PR is merged into develop-upstream

@whchung , please review.