### PR TITLE
Updating tag name by post_push hook

### DIFF
--- a/tensorflow/tools/ci_build/hooks/post_push
+++ b/tensorflow/tools/ci_build/hooks/post_push
@@ -2,7 +2,8 @@
 
 echo "current image name: "$IMAGE_NAME
 
-NEW_IMAGE_NAME=$DOCKER_REPO":"`date +"%y%m%d"`
+GIT_COMMIT_HASH=`git rev-parse --short HEAD`
+NEW_IMAGE_NAME=$DOCKER_REPO":dev-"$GIT_COMMIT_HASH
 echo "new image name: "$NEW_IMAGE_NAME
 
 docker tag $IMAGE_NAME $NEW_IMAGE_NAME


### PR DESCRIPTION
Update the tag name according to offline discussion. The updated naming conversion will be:
rocm/tensorflow-autobuilds:dev-$HASH
o	Eg, rocm/tensorflow-autobuilds:dev-fe8c5fa
o	And, rocm/tensorflow-autobuilds:dev-latest