### PR TITLE
Manually syncing GetGpuStream from upstream

### DIFF
--- a/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
+++ b/tensorflow/contrib/rnn/kernels/lstm_ops_gpu.cu.cc
@@ -231,7 +231,7 @@ void LSTMBlockCellFpropWithCUDA(
     typename TTypes<T>::Matrix co, typename TTypes<T>::Matrix icfo,
     typename TTypes<T>::Matrix h, int batch_size, int cell_size,
     int input_size) {
-  const cudaStream_t& cu_stream = GetCudaStream(ctx);
+  const cudaStream_t& cu_stream = GetGpuStream(ctx);
 
   // Concatenate xh = [x, h].
   //
@@ -370,7 +370,7 @@ void LSTMBlockCellBpropWithCUDA(
     typename TTypes<T>::Vec wci_grad, typename TTypes<T>::Vec wcf_grad,
     typename TTypes<T>::Vec wco_grad, const int batch_size, const int cell_size,
     const bool use_peephole) {
-  const cudaStream_t& cu_stream = GetCudaStream(ctx);
+  const cudaStream_t& cu_stream = GetGpuStream(ctx);
 
   dim3 block_dim_2d(std::min(batch_size, 8), 32);
   dim3 grid_dim_2d(Eigen::divup(batch_size, static_cast<int>(block_dim_2d.x)),

--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -103,8 +103,8 @@ struct BincountFunctor<GPUDevice, T> {
         /* num_samples */ num_samples,
         /* stream */ stream);
     if (err != gpuSuccess) {
-      return errors::Internal("Could not launch HistogramEven: ",
-                              GpuGetErrorString(err), ".");
+      return errors::Internal(
+          "Could not launch HistogramEven: ", GpuGetErrorString(err), ".");
     }
     return Status::OK();
   }

--- a/tensorflow/core/kernels/histogram_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/histogram_op_gpu.cu.cc
@@ -114,8 +114,8 @@ struct HistogramFixedWidthFunctor<GPUDevice, T, Tout> {
         /* num_samples */ num_samples,
         /* stream */ stream);
     if (err != gpuSuccess) {
-      return errors::Internal("Could not launch HistogramRange: ",
-                              GpuGetErrorString(err), ".");
+      return errors::Internal(
+          "Could not launch HistogramRange: ", GpuGetErrorString(err), ".");
     }
 
     return Status::OK();

--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -436,7 +436,7 @@ Status LaunchSortKernel(OpKernelContext* ctx, const T* input, int num_rows,
                         typename TTypes<T, 2>::Tensor values,
                         TTypes<int, 2>::Tensor indices) {
   const GPUDevice& d = ctx->eigen_device<GPUDevice>();
-  const cudaStream_t& cu_stream = GetCudaStream(ctx);
+  const cudaStream_t& cu_stream = GetGpuStream(ctx);
   size_t temp_storage_bytes = -1;
 
   // TODO(ebrevdo): Once cub supports iterators for ValueT replace that tensor
@@ -550,7 +550,7 @@ struct TopKFunctor<GPUDevice, T> {
       return impl::LaunchSortKernel(context, input.data(), num_rows, num_cols,
                                     k, values, indices);
     } else {
-      const cudaStream_t& cu_stream = GetCudaStream(context);
+      const cudaStream_t& cu_stream = GetGpuStream(context);
       auto err = impl::LaunchTopKKernel(cu_stream, /* num_shards */ 0,
                                         input.data(), num_rows, num_cols, k,
                                         sorted, values.data(), indices.data());

--- a/tensorflow/core/kernels/where_op_gpu.cu.h
+++ b/tensorflow/core/kernels/where_op_gpu.cu.h
@@ -187,8 +187,7 @@ struct NumTrue<GPUDevice, T, TIndex> {
       return errors::Internal(
           "WhereOp: Could not launch gpuprim::DeviceReduce::Sum to count "
           "number of true / nonzero indices.  temp_storage_bytes: ",
-          temp_storage_bytes, ", status: ",
-          GpuGetErrorString(second_success));
+          temp_storage_bytes, ", status: ", GpuGetErrorString(second_success));
     }
 
     return Status::OK();

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -635,6 +635,7 @@ __device__ inline double GpuAtomicAdd(double* ptr, double value) {
                                     [value](double a) { return a + value; });
 }
 #endif
+
 // GpuAtomicAdd
 // Specializations of GpuAtomicAdd for complex types, which GpuAtomicAdd does
 // not support. We treat a std::complex<T>* as a T* (the C++ standard section

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -67,7 +67,6 @@ using gpuError_t = hipError_t;
 #endif
 
 namespace tensorflow {
-
 #if GOOGLE_CUDA
 // cudaGetErrorString is available to both host and device
 __host__ __device__ inline const char* GpuGetErrorString(cudaError_t error) {
@@ -79,7 +78,18 @@ inline const char* GpuGetErrorString(hipError_t error) {
 #endif
 }
 
-// Launches a GPU kernel through GpuLaunchKernel in Cuda environment, or
+inline const gpuStream_t& GetGpuStream(OpKernelContext* context) {
+  // Returns a raw reference to the current cuda stream. Required by a
+  // number of kernel calls (for which StreamInterface* does not work),
+  // i.e. CUB and certain cublas primitives.
+  const gpuStream_t* ptr = CHECK_NOTNULL(
+      reinterpret_cast<const gpuStream_t*>(context->op_device_context()
+                                               ->stream()
+                                               ->implementation()
+                                               ->GpuStreamMemberHack()));
+  return *ptr;
+}
+
 // hipLaunchKernel in ROCm environment with the given arguments.
 //
 // The kernel parameters 'Ts' must be constructible from the arguments 'Args'.

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -374,17 +374,6 @@ Gpu2DLaunchConfig GetGpu2DLaunchConfig(int xdim, int ydim,
 CREATE_CUDA_HOST_FUNCTION_ALIAS(GetGpu2DLaunchConfig, GetCuda2DLaunchConfig);
 
 #if GOOGLE_CUDA
-// Returns a raw reference to the current cuda stream.  Required by a
-// number of kernel calls (for which StreamInterface* does not work), i.e.
-// CUB and certain cublas primitives.
-inline const cudaStream_t& GetCudaStream(OpKernelContext* context) {
-  const cudaStream_t* ptr = CHECK_NOTNULL(
-      reinterpret_cast<const cudaStream_t*>(context->op_device_context()
-                                                ->stream()
-                                                ->implementation()
-                                                ->GpuStreamMemberHack()));
-  return *ptr;
-}
 template <typename DeviceFunc>
 Cuda2DLaunchConfig GetCuda2DLaunchConfig(int xdim, int ydim,
                                          const Eigen::GpuDevice& d,
@@ -395,8 +384,6 @@ Cuda2DLaunchConfig GetCuda2DLaunchConfig(int xdim, int ydim,
                               block_size_limit);
 }
 #endif  // GOOGLE_CUDA
-
-#define GetGpuStream(context) context->eigen_gpu_device().stream()
 
 namespace detail {
 template <typename... Ts, size_t... Is>


### PR DESCRIPTION
Manually address conflict from upstream:
#[29181](https://github.com/tensorflow/tensorflow/pull/29181) [ROCm] Renaming GetCudaStream to GetGpuStream
#[29154 ](https://github.com/tensorflow/tensorflow/pull/29154)[ROCm] Adding a macro wrapper for the ROCm/CUDA routine to get the error string

As well as files under tensorflow/core/util/gpu_*

-----
Test performed: 
	//tensorflow/tools/pip_package:build_pip_package compiles
		