### PR TITLE
ROCm enable cwise op zeta

### DIFF
--- a/tensorflow/core/kernels/cwise_op_zeta.cc
+++ b/tensorflow/core/kernels/cwise_op_zeta.cc
@@ -19,10 +19,8 @@ namespace tensorflow {
 REGISTER2(BinaryOp, CPU, "Zeta", functor::zeta, float, double);
 REGISTER2(BinaryOp, CPU, "Polygamma", functor::polygamma, float, double);
 
-#if GOOGLE_CUDA
-REGISTER2(BinaryOp, GPU, "Zeta", functor::zeta, float, double);
-#endif
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+REGISTER2(BinaryOp, GPU, "Zeta", functor::zeta, float, double);
 REGISTER2(BinaryOp, GPU, "Polygamma", functor::polygamma, float, double);
 #endif
 }  // namespace tensorflow


### PR DESCRIPTION
#159 disabled the zeta op for the rocm path.  This PR re-enables zeta to see if CI passes all tests.