### PR TITLE
[XLA] add cudnn batchnorm rewriter to AMDGPU path

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -970,12 +970,10 @@ cc_library(
     name = "gpu_compiler",
     srcs = if_cuda_is_configured(["nvptx_compiler.cc"])
            + if_rocm_is_configured(["amdgpu_compiler.cc"]),
-    hdrs = if_cuda_is_configured([
-            "nvptx_compiler.h",
-            "cudnn_batchnorm_rewriter.h",
-            ])
+    hdrs = if_cuda_is_configured(["nvptx_compiler.h"])
            + if_rocm_is_configured(["amdgpu_compiler.h"]),
     deps = [
+        ":cudnn_batchnorm_rewriter",
         ":cudnn_conv_pad_for_tensor_cores",
         ":cudnn_conv_padding_legalization",
         ":cudnn_conv_rewriter",
@@ -1053,7 +1051,6 @@ cc_library(
         "@llvm//:core",
     ]+
     if_cuda_is_configured([
-         "cudnn_batchnorm_rewriter",
         ":cusolver_rewriter",
         ":cudnn_conv_algorithm_picker",
         "//tensorflow/core:cuda_libdevice_path",

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -41,6 +41,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/dynamic_index_splitter.h"
 #include "tensorflow/compiler/xla/service/flatten_call_graph.h"
 #include "tensorflow/compiler/xla/service/gpu/amdgpu_executable.h"
+#include "tensorflow/compiler/xla/service/gpu/cudnn_batchnorm_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/cudnn_conv_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/cudnn_conv_padding_legalization.h"
@@ -181,6 +182,13 @@ Status OptimizeHloModule(HloModule* hlo_module, se::StreamExecutor* stream_exec,
       pass.AddInvariantChecker<HloVerifier>(/*layout_sensitive=*/false,
                                             /*allow_mixed_precision=*/false);
 
+      // If MIOpen batchnorms are enabled, rewrite batchnorm HLOs to MIOpen
+      // calls where possible.  Not every batchnorm op can be implemented as a
+      // call to MIOpen, so decompose any remaining batchnorm ops into a soup of
+      // HLOs.
+      if (hlo_module->config().debug_options().xla_gpu_use_cudnn_batchnorm()) {
+        pass.AddPass<CudnnBatchNormRewriter>();
+      }
       pass.AddPass<BatchNormExpander>(
           /*rewrite_training_op=*/true,
           /*rewrite_inference_op=*/true,


### PR DESCRIPTION
The pass works out of the box on MIOpen + ROCm + AMDGPU. Add it into
amdgpu_compiler in this commit.

Empirical test results show XLA BatchNorm kernels outperform MIOpen BatchNorm
kernels so this rewriter should remain disabled by default.

@sunway513 FYI.
