### PR TITLE
[XLA] temporarily disable L2Loss op on XLA

### DIFF
--- a/tensorflow/compiler/tests/unary_ops_test.py
+++ b/tensorflow/compiler/tests/unary_ops_test.py
@@ -230,14 +230,16 @@ class UnaryOpsTest(xla_test.XLATestCase):
               [[np.NINF, -2, -1, 0, 0.5, 1, 2, np.inf, np.nan]], dtype=dtype),
           expected=np.array([[0, 1, 1, 1, 1, 1, 1, 0, 0]], dtype=np.bool))
 
+      # ROCM TODO: Disable test l2_loss for now. Re-enable it after properly
+      # optimize perf for HLO reduction on ROCm
       # Tests for tf.nn ops.
-      self._assertOpOutputMatchesExpected(
-          nn_ops.l2_loss, np.array([[[]]], dtype=dtype), expected=dtype(0))
+      #self._assertOpOutputMatchesExpected(
+      #    nn_ops.l2_loss, np.array([[[]]], dtype=dtype), expected=dtype(0))
 
-      self._assertOpOutputMatchesExpected(nn_ops.l2_loss, dtype(4), dtype(8))
+      #self._assertOpOutputMatchesExpected(nn_ops.l2_loss, dtype(4), dtype(8))
 
-      self._assertOpOutputMatchesExpected(
-          nn_ops.l2_loss, np.array([[-2, 4]], dtype=dtype), expected=dtype(10))
+      #self._assertOpOutputMatchesExpected(
+      #    nn_ops.l2_loss, np.array([[-2, 4]], dtype=dtype), expected=dtype(10))
 
       self._assertOpOutputMatchesExpected(
           math_ops.reciprocal,

--- a/tensorflow/compiler/tf2xla/kernels/l2loss_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/l2loss_op.cc
@@ -46,7 +46,8 @@ class L2LossOp : public XlaOpKernel {
   }
 };
 
-REGISTER_XLA_OP(Name("L2Loss"), L2LossOp);
+// ROCM TODO: improve perf for IR emitted for L2Loss
+//REGISTER_XLA_OP(Name("L2Loss"), L2LossOp);
 
 }  // namespace
 }  // namespace tensorflow


### PR DESCRIPTION
Empirical tests shows IR emitted to L2Loss slowers overall performance. Before
the long-term fix can be devised, disable L2Loss op on XLA for now.

@sunway513 please cherry-pick this to r1.14-rocm release branch once merged.