### PR TITLE
[DO NOT MERGE] Prototype for MIOpen Immediate Mode integration

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -489,7 +489,7 @@ cc_library(
 
 tf_cuda_library(
     name = "gpu_utils",
-    srcs = if_cuda_is_configured(["gpu_utils.cc"]),
+    srcs = if_cuda_is_configured(["gpu_utils.cc"]) + if_rocm_is_configured(["gpu_utils.cc"]),
     hdrs = ["gpu_utils.h"],
     deps = [
         ":gpu_util_hdrs",

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1360,12 +1360,18 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
     ProfileResult best_result_no_scratch;
     if (cudnn_use_autotune_ && !AutoTuneConv3dBwdData::GetInstance()->Find(
                                    conv_parameters, &algorithm_config)) {
-#if GOOGLE_CUDA
       std::vector<AlgorithmDesc> algorithms;
+#if GOOGLE_CUDA
       CHECK(stream->parent()->GetConvolveBackwardDataAlgorithms(
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
           &algorithms));
+#elif TENSORFLOW_USE_ROCM
+      CHECK(stream->parent()->GetMIOpenConvolveAlgorithms(
+          se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
+          se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
+          output_desc, &algorithms));
+#endif
       for (auto profile_algorithm : algorithms) {
         // TODO(zhengxq): profile each algorithm multiple times to better
         // accuracy.
@@ -1403,22 +1409,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         algorithm_config.set_algorithm_no_scratch(
             best_result_no_scratch.algorithm());
       }
-#elif TENSORFLOW_USE_ROCM
-      LOG(INFO) << "running auto-tune for Backward-Data";
-      DnnScratchAllocator scratch_allocator(
-          ConvolveBackwardDataScratchSize, context);
-      bool miopen_find_status =
-          stream
-              ->ThenConvolveBackwardDataWithAlgorithm(
-                  filter_desc, filter_ptr, output_desc, out_backprop_ptr,
-                  conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
-                  AlgorithmConfig(), &best_result)
-              .ok();
-      OP_REQUIRES(context, miopen_find_status && best_result.is_valid(),
-                  errors::NotFound("Failed to find backward data algorithm!"));
-      algorithm_config.set_algorithm(best_result.algorithm());
-      algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
       AutoTuneConv3dBwdData::GetInstance()->Insert(conv_parameters,
                                                    algorithm_config);
     }
@@ -1784,12 +1774,18 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
     ProfileResult best_result_no_scratch;
     if (cudnn_use_autotune_ && !AutoTuneConv3dBwdFilter::GetInstance()->Find(
                                    conv_parameters, &algorithm_config)) {
-#if GOOGLE_CUDA
       std::vector<AlgorithmDesc> algorithms;
+#if GOOGLE_CUDA
       CHECK(stream->parent()->GetConvolveBackwardFilterAlgorithms(
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
           &algorithms));
+#elif TENSORFLOW_USE_ROCM
+      CHECK(stream->parent()->GetMIOpenConvolveAlgorithms(
+          se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
+          se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
+          output_desc, &algorithms));
+#endif
       for (auto profile_algorithm : algorithms) {
         // TODO(zhengxq): profile each algorithm multiple times to better
         // accuracy.
@@ -1828,22 +1824,6 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
         algorithm_config.set_algorithm_no_scratch(
             best_result_no_scratch.algorithm());
       }
-#elif TENSORFLOW_USE_ROCM
-      LOG(INFO) << "running auto-tune for Backward-Filter";
-      DnnScratchAllocator scratch_allocator(
-          ConvolveBackwardFilterScratchSize, context);
-      bool miopen_find_status =
-          stream
-              ->ThenConvolveBackwardFilterWithAlgorithm(
-                  input_desc, input_ptr, output_desc, out_backprop_ptr,
-                  conv_desc, filter_desc, &filter_backprop_ptr,
-                  &scratch_allocator, AlgorithmConfig(), &best_result)
-              .ok();
-      OP_REQUIRES(context, miopen_find_status && best_result.is_valid(),
-                  errors::NotFound("Failed to find backward filter algorithm!"));
-      algorithm_config.set_algorithm(best_result.algorithm());
-      algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
       AutoTuneConv3dBwdFilter::GetInstance()->Insert(conv_parameters,
                                                      algorithm_config);
     }

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -984,7 +984,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
                            filter_desc, output_desc, conv_desc,
                            stream->parent(), results);
     OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-
     AutoTuneConv::GetInstance()->Insert(conv_parameters, algorithm_config);
   }
 

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -434,8 +434,8 @@ struct LaunchConvOp<GPUDevice, T> {
     AlgorithmConfig algorithm_config;
     if (cudnn_use_autotune && !AutoTuneConv3d::GetInstance()->Find(
                                   conv_parameters, &algorithm_config)) {
-#if GOOGLE_CUDA
       std::vector<AlgorithmDesc> algorithms;
+#if GOOGLE_CUDA
       OP_REQUIRES(ctx,
                   stream->parent()->GetConvolveAlgorithms(
                       conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
@@ -445,6 +445,17 @@ struct LaunchConvOp<GPUDevice, T> {
                       "Failed to get convolution algorithm. This is probably "
                       "because cuDNN failed to initialize, so try looking to "
                       "see if a warning log message was printed above."));
+#elif TENSORFLOW_USE_ROCM
+      OP_REQUIRES(ctx,
+                  stream->parent()->GetMIOpenConvolveAlgorithms(
+                      se::dnn::ConvolutionKind::FORWARD, stream,
+                      se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+                      conv_desc, output_desc, &algorithms),
+                  errors::Unknown(
+                      "Failed to get convolution algorithm. This is probably "
+                      "because MIOpen failed to initialize, so try looking to "
+                      "see if a warning log message was printed above."));
+#endif
 
       std::vector<tensorflow::AutotuneResult> results;
       for (auto profile_algorithm : algorithms) {
@@ -477,22 +488,6 @@ struct LaunchConvOp<GPUDevice, T> {
                              filter_desc, output_desc, conv_desc,
                              stream->parent(), results);
       OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-#elif TENSORFLOW_USE_ROCM
-      ProfileResult best_result;
-      LOG(INFO) << "running auto-tune for convolution";
-      DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
-      bool miopen_find_status =
-          stream
-              ->ThenConvolveWithAlgorithm(
-                  input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
-                  output_desc, &output_ptr, &scratch_allocator,
-                  AlgorithmConfig(), &best_result)
-              .ok();
-      OP_REQUIRES(ctx, miopen_find_status && best_result.is_valid(),
-                  errors::NotFound("Failed to find conv algorithm!"));
-      algorithm_config.set_algorithm(best_result.algorithm());
-      algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
       AutoTuneConv3d::GetInstance()->Insert(conv_parameters, algorithm_config);
     }
 

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/gpu_utils.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include "google/protobuf/any.pb.h"
 #include "tensorflow/core/platform/logger.h"
@@ -148,4 +148,4 @@ Status BestCudnnConvAlgorithm(absl::Span<const AutotuneResult> results,
 
 }  // namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -33,6 +33,16 @@ bool DnnSupport::GetConvolveAlgorithms(
   return false;
 }
 
+bool DnnSupport::GetMIOpenConvolveAlgorithms(
+    dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<AlgorithmDesc>* out_algorithms) {
+  return false;
+}
+
 bool DnnSupport::GetRnnAlgorithms(std::vector<AlgorithmDesc>* out_algorithms) {
   return false;
 }

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1312,6 +1312,14 @@ class DnnSupport {
       bool with_winograd_nonfused, int cc_major, int cc_minor,
       std::vector<AlgorithmDesc>* out_algorithms);
 
+  virtual bool GetMIOpenConvolveAlgorithms(
+      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<AlgorithmDesc>* out_algorithms);
+
   // Returns a list of supported rnn algorithms.
   virtual bool GetRnnAlgorithms(std::vector<AlgorithmDesc>* out_algorithms);
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2686,151 +2686,112 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
 
   absl::optional<dnn::AlgorithmDesc> input_algo_desc =
       algorithm_config.algorithm();
-  size_t scratch_memory_size;
 
-  miopenStatus_t status = miopenStatusSuccess;
+  assert(input_algo_desc.has_value());
 
-  if (!input_algo_desc.has_value()) {
-    // With the default algorithm, use MIOpen's heuristics.
-    assert(scratch_allocator);
+  // An algorithm has been specified.
+  *algorithm_desc = *input_algo_desc;
 
-    assert(kind != dnn::ConvolutionKind::FORWARD);
+  const uint64_t solution_id = algorithm_desc->algo_id();
 
-    DeviceMemory<uint8> scratch_memory_temp;
-    MIOpenAllocatorContext mac(scratch_allocator, stream);
-    wrap::miopenSetAllocator(miopen.handle(), MIOpenAllocatorCallback,
-                             MIOpenDeallocatorCallback, &mac);
-    size_t size_in_bytes;
+  size_t scratch_memory_size = 0;
 
-    switch (kind) {
-      case dnn::ConvolutionKind::BACKWARD_DATA: {
-        status = wrap::miopenConvolutionBackwardDataGetWorkSpaceSize(
-            miopen.handle(), /*diffDesc=*/output_nd.handle(),
-            /*filterDesc=*/filter.handle(), /*convDesc=*/conv.handle(),
-            /*gradDesc=*/input_nd.handle(), /*sizeInBytes=*/&size_in_bytes);
-        break;
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      auto status = wrap::miopenConvolutionForwardGetSolutionWorkspaceSize(
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), solution_id, &scratch_memory_size);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionForwardGetSolutionWorkspaceSize "
+            "failed: ",
+            ToString(status)));
       }
-      case dnn::ConvolutionKind::BACKWARD_FILTER: {
-        status = wrap::miopenConvolutionBackwardWeightsGetWorkSpaceSize(
-            miopen.handle(), /*diffDesc=*/output_nd.handle(),
-            /*srcDesc=*/input_nd.handle(), /*convDesc=*/conv.handle(),
-            /*gradDesc=*/filter.handle(), /*sizeInBytes=*/&size_in_bytes);
-        break;
+
+      // The call to *CompileSolution solution should be in this routine
+      // in order to ensure the running time measured in the DoConvole step
+      // is accurate (in the sense it does not include the time needed to
+      // do the compile step)
+      //
+      // Having this call here also means that the *CompileSolution routine
+      // will get called more than once for same solution_id, but that should
+      // be okay since the all subsequent calls to *CompileSolution for the
+      // same solution_id will return immediately (they are no-ops)
+      status = wrap::miopenConvolutionForwardCompileSolution(
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), solution_id);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionForwardCompileSolution failed: ",
+            ToString(status)));
       }
-      default:
-        return port::InternalError(
-            absl::StrCat("Unexpected convolution kind ", static_cast<int>(kind)));
+
+      break;
     }
 
-    if (status == miopenStatusSuccess && size_in_bytes != 0) {
-      auto allocated = scratch_allocator->AllocateBytes(stream, size_in_bytes);
-      if (allocated.ok()) {
-        scratch_memory_temp = allocated.ValueOrDie();
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      auto status = wrap::miopenConvolutionBackwardDataGetSolutionWorkspaceSize(
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), solution_id, &scratch_memory_size);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionabckwardDataGetSolutionWorkspaceSize "
+            "failed: ",
+            ToString(status)));
       }
+
+      status = wrap::miopenConvolutionBackwardDataCompileSolution(
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), solution_id);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionBackwardDataCompileSolution failed: ",
+            ToString(status)));
+      }
+
+      break;
     }
 
-    miopenConvAlgoPerf_t preference;
-    int returnedAlgoCount;
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      auto status =
+          wrap::miopenConvolutionBackwardWeightsGetSolutionWorkspaceSize(
+              miopen.handle(), output_nd.handle(), input_nd.handle(),
+              conv.handle(), filter.handle(), solution_id,
+              &scratch_memory_size);
 
-    switch (kind) {
-      case dnn::ConvolutionKind::BACKWARD_DATA: {
-        auto status = wrap::miopenFindConvolutionBackwardDataAlgorithm(
-            miopen.handle(),
-            /*diffDesc=*/output_nd.handle(), output_data.opaque(),
-            /*filterDesc=*/filter.handle(), filter_data.opaque(),
-            /*convDesc=*/conv.handle(),
-            /*gradDesc=*/input_nd.handle(), input_data.opaque(),
-            /*requestCount=*/1, /*returnedAlgoCount=*/&returnedAlgoCount,
-            /*preference=*/&preference,
-            /*WorkSpace=*/scratch_memory_temp.opaque(),
-            /*WorkSpaceSize=*/scratch_memory_temp.size(),
-            /*exhaustiveSearch=*/false);
-        CHECK_EQ(status, miopenStatusSuccess) << "Unable to find a suitable "
-                                                 "algorithm for doing backward "
-                                                 "data convolution";
-        *algorithm_desc = dnn::AlgorithmDesc(preference.bwd_data_algo, false);
-        break;
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionabckwardWeightsGetSolutionWorkspaceSize "
+            "failed: ",
+            ToString(status)));
       }
-      case dnn::ConvolutionKind::BACKWARD_FILTER: {
-        auto status = wrap::miopenFindConvolutionBackwardWeightsAlgorithm(
-            miopen.handle(),
-            /*diffDesc=*/output_nd.handle(), output_data.opaque(),
-            /*srcDesc=*/input_nd.handle(), input_data.opaque(),
-            /*convDesc=*/conv.handle(),
-            /*gradDesc=*/filter.handle(), filter_data.opaque(),
-            /*requestAlgoCount=*/1, /*returnedAlgoCount=*/&returnedAlgoCount,
-            /*preference=*/&preference,
-            /*WorkSpace=*/scratch_memory_temp.opaque(),
-            /*WorkSpaceSize=*/scratch_memory_temp.size(),
-            /*exhaustiveSearch=*/false);
-        CHECK_EQ(status, miopenStatusSuccess) << "Unable to find a suitable "
-                                                  "algorithm for doing backward "
-                                                  "filter convolution";
-        *algorithm_desc = dnn::AlgorithmDesc(preference.bwd_weights_algo, false);
-        break;
+
+      status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), solution_id);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionBackwardWeightsCompileSolution failed: ",
+            ToString(status)));
       }
-      default:
-        return port::InternalError(
-            absl::StrCat("Unexpected convolution kind ", static_cast<int>(kind)));
+      break;
     }
 
-    // Restore default allocator, note mac is stack temp
-    wrap::miopenSetAllocator(miopen.handle(), nullptr, nullptr, nullptr);
-
-    scratch_memory_size = preference.memory;
-  } else {
-    // An algorithm has been specified.
-    *algorithm_desc = *input_algo_desc;
-
-    switch (kind) {
-      case dnn::ConvolutionKind::FORWARD: {
-        const uint64_t solution_id = algorithm_desc->algo_id();
-
-        status = wrap::miopenConvolutionForwardGetSolutionWorkspaceSize(
-            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-            output_nd.handle(), solution_id, &scratch_memory_size);
-
-        if (status != miopenStatusSuccess) {
-          return port::InternalError(absl::StrCat(
-              "call to miopenConvolutionForwardGetSolutionWorkspaceSize "
-              "failed: ",
-              ToString(status)));
-        }
-
-        // The call to *CompileSolution solution should be in this routine
-        // in order to ensure the running time measured in the DoConvole step
-        // is accurate (in the sense it does not include the time needed to
-        // do the compile step)
-        //
-        // Having this call here also means that the *CompileSolution routine
-        // will get called more than once for same solution_id, but that should
-        // be okay since the all subsequent calls to *CompileSolution for the
-        // same solution_id will return immediately (they are no-ops)
-        status = wrap::miopenConvolutionForwardCompileSolution(
-            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-            output_nd.handle(), solution_id);
-
-        if (status != miopenStatusSuccess) {
-          return port::InternalError(absl::StrCat(
-              "call to miopenConvolutionForwardCompileSolution failed: ",
-              ToString(status)));
-        }
-
-        break;
-      }
-      case dnn::ConvolutionKind::BACKWARD_DATA: {
-        scratch_memory_size = *(algorithm_config.scratch_size());
-        break;
-      }
-      case dnn::ConvolutionKind::BACKWARD_FILTER: {
-        scratch_memory_size = *(algorithm_config.scratch_size());
-        break;
-      }
-      default:
-        return port::InternalError(absl::StrCat("Unexpected convolution kind ",
-                                                static_cast<int>(kind)));
+    default: {
+      return port::InternalError(
+          absl::StrCat("Unexpected convolution kind ", static_cast<int>(kind)));
+      break;
     }
   }
+
+  VLOG(kImmediateModeVlogLevel)
+      << "miopen...GetSolutionWorkspaceSize returned " << scratch_memory_size
+      << " for solution_id " << solution_id;
 
   // allocate scratch memory
   if (scratch_memory_size != 0) {
@@ -2941,10 +2902,11 @@ port::Status MIOpenSupport::DoConvolve(
     }
   }
 
+  const uint64_t solution_id = algorithm_desc.algo_id();
+
   miopenStatus_t status = miopenStatusSuccess;
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
-      const uint64_t solution_id = algorithm_desc.algo_id();
 
       status = wrap::miopenConvolutionForwardImmediate(
           miopen.handle(), filter.handle(), filter_data.opaque(),
@@ -2964,21 +2926,11 @@ port::Status MIOpenSupport::DoConvolve(
                                          &output_back_descriptor, output_data,
                                          &transform_scratch);
 
-      status = wrap::miopenConvolutionBackwardData(
-          miopen.handle(),
-          /*alpha=*/&alpha,
-          /*diffDesc=*/output_nd.handle(),
-          /*diffData=*/output_data.opaque(),
-          /*filterDesc=*/filter.handle(),
-          /*filterData=*/filter_data.opaque(),
-          /*convDesc=*/conv.handle(),
-          /*algo=*/
-          static_cast<miopenConvBwdDataAlgorithm_t>(algorithm_desc.algo_id()),
-          /*beta=*/&beta,
-          /*gradDesc=*/input_nd.handle(),
-          /*gradData=*/input_data.opaque(),
-          /*workSpace=*/scratch_memory.opaque(),
-          /*workSpaceSizeInBytes=*/scratch_memory.size());
+      status = wrap::miopenConvolutionBackwardDataImmediate(
+          miopen.handle(), output_nd.handle(), output_data.opaque(),
+          filter.handle(), filter_data.opaque(), conv.handle(),
+          input_nd.handle(), input_data.opaque(), scratch_memory.opaque(),
+          scratch_memory.size(), solution_id);
       break;
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
@@ -2991,22 +2943,11 @@ port::Status MIOpenSupport::DoConvolve(
                                          &output_back_descriptor, output_data,
                                          &transform_scratch);
 
-      status = wrap::miopenConvolutionBackwardWeights(
-          miopen.handle(),
-          /*alpha=*/&alpha,
-          /*diffDesc=*/output_nd.handle(),
-          /*diffData=*/output_data.opaque(),
-          /*srcDesc=*/input_nd.handle(),
-          /*srcData=*/input_data.opaque(),
-          /*convDesc=*/conv.handle(),
-          /*algo=*/
-          static_cast<miopenConvBwdWeightsAlgorithm_t>(
-              algorithm_desc.algo_id()),
-          /*beta=*/&beta,
-          /*gradDesc=*/filter.handle(),
-          /*gradData=*/filter_data.opaque(),
-          /*workSpace=*/scratch_memory.opaque(),
-          /*workSpaceSizeInBytes=*/scratch_memory.size());
+      status = wrap::miopenConvolutionBackwardWeightsImmediate(
+          miopen.handle(), output_nd.handle(), output_data.opaque(),
+          input_nd.handle(), input_data.opaque(), conv.handle(),
+          filter.handle(), filter_data.opaque(), scratch_memory.opaque(),
+          scratch_memory.size(), solution_id);
       break;
     }
     default:
@@ -3061,10 +3002,10 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   auto miopen = miopen_->GetHandle(parent_, stream);
 
-  ScopedTensorDescriptor input{input_descriptor,
-                               ToMIOpenDataType(element_type)};
-  ScopedTensorDescriptor output{output_descriptor,
-                                ToMIOpenDataType(element_type)};
+  ScopedTensorDescriptor input_nd{input_descriptor,
+                                  ToMIOpenDataType(element_type)};
+  ScopedTensorDescriptor output_nd{output_descriptor,
+                                   ToMIOpenDataType(element_type)};
   ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
                                 ToMIOpenDataType(element_type)};
   ScopedConvolutionDescriptor conv{convolution_descriptor,
@@ -3076,8 +3017,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenConvolutionForwardGetSolutionCount(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), &maxSolutionCount);
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), &maxSolutionCount);
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionForwardGetSolutionCount failed: "
@@ -3088,8 +3029,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_DATA: {
       auto status = wrap::miopenConvolutionBackwardDataGetSolutionCount(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), &maxSolutionCount);
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), &maxSolutionCount);
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardDataGetSolutionCount failed: "
@@ -3100,8 +3041,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
       auto status = wrap::miopenConvolutionBackwardWeightsGetSolutionCount(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), &maxSolutionCount);
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), &maxSolutionCount);
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardWeightsGetSolutionCount "
@@ -3128,8 +3069,9 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenConvolutionForwardGetSolution(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), maxSolutionCount, &solutionCount,
+          solutions.get());
       if (status != miopenStatusSuccess) {
         LOG(FATAL) << "call to miopenConvolutionForwardGetSolution failed: "
                    << ToString(status);
@@ -3139,8 +3081,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_DATA: {
       auto status = wrap::miopenConvolutionBackwardDataGetSolution(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), maxSolutionCount, &solutionCount, solutions.get());
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardDataGetSolution failed: "
@@ -3151,8 +3093,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
       auto status = wrap::miopenConvolutionBackwardWeightsGetSolution(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), maxSolutionCount, &solutionCount, solutions.get());
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardWeightsGetSolution failed: "

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -194,6 +194,14 @@ class MIOpenSupport : public dnn::DnnSupport {
       bool with_winograd_nonfused, int cc_major, int cc_minor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
+  bool GetMIOpenConvolveAlgorithms(
+      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
+
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -290,6 +290,22 @@ bool StreamExecutor::GetConvolveAlgorithms(
                                             cc_minor, out_algorithms);
 }
 
+bool StreamExecutor::GetMIOpenConvolveAlgorithms(
+    dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<dnn::AlgorithmDesc>* out_algorithms) {
+  dnn::DnnSupport* dnn_support = AsDnn();
+  if (!dnn_support) {
+    return false;
+  }
+  return dnn_support->GetMIOpenConvolveAlgorithms(
+      kind, stream, element_type, input_descriptor, filter_descriptor,
+      convolution_descriptor, output_descriptor, out_algorithms);
+}
+
 bool StreamExecutor::GetRnnAlgorithms(
     std::vector<dnn::AlgorithmDesc> *out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -374,6 +374,16 @@ class StreamExecutor {
   bool GetConvolveAlgorithms(bool with_winograd_nonfused,
                              std::vector<dnn::AlgorithmDesc> *out_algorithms);
 
+  // Returns the list of supported algorithms for the forward convolution
+  // operation.
+  bool GetMIOpenConvolveAlgorithms(
+      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms);
+
   // Returns the list of supported algorithms for rnn operation.
   bool GetRnnAlgorithms(std::vector<dnn::AlgorithmDesc> *out_algorithms);
 


### PR DESCRIPTION
This prototype only addresses the non-XLA conv2d-forward scenario. 
All other cases (conv2d-backward, conv3d-forward, conv3d-backward, XLA versions of all the cases) will follow a similar pattern.

The two main files to review are 
1. conv_ops.cc
2. rocm_dnn,.cc

Things to note:
1. in conv_ops.cc, the CUDA and ROCm implementation will now differ only in the part that caal the Get*Algorithms routine.
2. Having a MIOpen specific routine (GetMIOpenConvolveAlgorithms) in the SE layer is ok, as timshen has indicated preference for this approach in the feedback he has provided (in another PR)
3. We call the `*GetSolution` and  `*CompileSolution` routines during the "Prepare" phase, and only the "*Immediate" routine in the "DoConvolve" phase. This ensures that profiler measurements done during the "DoConvolve" phase are accurate. They need to be accurate, because those times will be used by the TF layer to determine the "best" algorithm. The downside of this is that "*CompileSolution" routine will be called everytime. I have confirmed with the MIOpen team, that doing so is okay functionally and performance-wise.
4. When we do performance testing on this, we should check whether the fastest solution reported by the `*GetSolution` call, also ends being the fastest solution as determined empirically by the TF layer.
5. This code does not pass the conv unit tests yet, as we need (at least) one more piece on the MIOpen side. Currently the MIOpen API will error out, if we try to invoke Immediate mode for a config for which no solution exists in the DB. MIOpen team is working on a "fall back" solution for this case, and that should be available sometime early next week. We can do begin functional testing this part, once the MIOpen change is made

---------------------------------------------

@whchung @jerryyin 


----------------------------------------------

update : added support for conv2d backward-data and conv2d backward-weights
