### PR TITLE
[ROCm][XLA:GPU] Introduce ReduceRewriter to AMDGPU XLA backend

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -514,6 +514,8 @@ tf_cc_shared_object(
         "//tensorflow/core:lib_internal_impl",
         "//tensorflow/stream_executor:stream_executor_impl",
         "//tensorflow:tf_framework_version_script.lds",
+
+        "//tensorflow/core/kernels:reduce_thunk_op",
     ] + tf_additional_binary_deps(),
 )
 

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -392,7 +392,10 @@ cc_library(
         "cholesky_thunk.cc",
         "nvptx_executable.cc"
        ])
-      +  if_rocm_is_configured(["amdgpu_executable.cc"]),
+      +  if_rocm_is_configured([
+        "amdgpu_executable.cc",
+        "reduce_thunk.cc",
+       ]),
     hdrs = [
         "conditional_thunk.h",
         "convolution_thunk.h",
@@ -416,7 +419,10 @@ cc_library(
          "cholesky_thunk.h",
          "nvptx_executable.h"
      ])
-      + if_rocm_is_configured(["amdgpu_executable.h"]),
+      + if_rocm_is_configured([
+         "amdgpu_executable.h",
+         "reduce_thunk.h",
+     ]),
     deps = [
         ":buffer_allocations",
         ":cudnn_conv_runner",
@@ -966,7 +972,10 @@ cc_library(
             "nvptx_compiler.h",
             "cudnn_batchnorm_rewriter.h",
             ])
-           + if_rocm_is_configured(["amdgpu_compiler.h"]),
+           + if_rocm_is_configured([
+            "amdgpu_compiler.h",
+            "reduce_rewriter.h",
+            ]),
     deps = [
         ":cudnn_conv_pad_for_tensor_cores",
         ":cudnn_conv_padding_legalization",
@@ -1053,8 +1062,22 @@ cc_library(
         "//tensorflow/stream_executor/cuda:ptxas_utils",
     ])
     + if_rocm_is_configured([":miopen_conv_algorithm_picker",
+                             ":reduce_rewriter",
                             "//tensorflow/core:rocm_rocdl_path",]),
     alwayslink = True,  # Contains compiler registration
+)
+
+cc_library(
+    name = "reduce_rewriter",
+    srcs = ["reduce_rewriter.cc"],
+    hdrs = ["reduce_rewriter.h"],
+    deps = [
+        ":ir_emission_utils",
+        "//tensorflow/compiler/xla:literal",
+        "//tensorflow/compiler/xla:literal_util",
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_pass",
+    ],
 )
 
 cc_library(

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -59,6 +59,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h"
 #include "tensorflow/compiler/xla/service/gpu/multi_output_fusion.h"
 #include "tensorflow/compiler/xla/service/gpu/partition_assignment.h"
+#include "tensorflow/compiler/xla/service/gpu/reduce_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/stream_assignment.h"
 #include "tensorflow/compiler/xla/service/gpu/stream_executor_util.h"
 #include "tensorflow/compiler/xla/service/gpu/thunk_schedule.h"
@@ -185,6 +186,10 @@ Status OptimizeHloModule(HloModule* hlo_module, se::StreamExecutor* stream_exec,
           /*rewrite_training_op=*/true,
           /*rewrite_inference_op=*/true,
           /*rewrite_grad_op=*/true);
+
+      // Use rocPRIM for scalar reductions to avoid slow atomic CAS loops
+      // employed by XLA LLVM IR emitter
+      pipeline.AddPass<ReduceRewriter>();
 
       pipeline.AddPass<HloGetDimensionSizeRewriter>();
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -191,9 +191,20 @@ bool IsCustomCallToCusolver(const HloInstruction& hlo) {
   return target == kCusolverCholeskyCallTarget;
 }
 
+const char* const kReduceCallTarget = "__rocm$reduce";
+
+bool IsCustomCallToROCmLibs(const HloInstruction& hlo) {
+  if (hlo.opcode() != HloOpcode::kCustomCall) {
+    return false;
+  }
+  const auto& target = hlo.custom_call_target();
+  return target == kReduceCallTarget;
+}
+
 bool ImplementedAsLibraryCall(const HloInstruction& hlo) {
   return ImplementedAsGemm(hlo) || IsCustomCallToDnnBatchNorm(hlo) ||
-         IsCustomCallToDnnConvolution(hlo);
+         IsCustomCallToDnnConvolution(hlo) ||
+         IsCustomCallToROCmLibs(hlo);
 }
 
 bool IsReductionFromOrToContiguousDimensions(const HloInstruction& reduce) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -144,6 +144,10 @@ bool IsCustomCallToCusolver(const HloInstruction& hlo);
 // is a success/failure code per batch element.
 extern const char* const kCusolverCholeskyCallTarget;
 
+bool IsCustomCallToROCmLibs(const HloInstruction& hlo);
+
+extern const char* const kReduceCallTarget;
+
 // Returns true if `hlo` will be implemented as a library call, e.g. cuBLAS gemm
 // or cuDNN convolution.
 bool ImplementedAsLibraryCall(const HloInstruction& hlo);

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -63,6 +63,9 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/outfeed_thunk.h"
 #include "tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.h"
 #include "tensorflow/compiler/xla/service/gpu/partition_assignment.h"
+#if TENSORFLOW_USE_ROCM
+  #include "tensorflow/compiler/xla/service/gpu/reduce_thunk.h"
+#endif
 #include "tensorflow/compiler/xla/service/gpu/sequential_thunk.h"
 #include "tensorflow/compiler/xla/service/gpu/target_util.h"
 #include "tensorflow/compiler/xla/service/gpu/thunk.h"
@@ -511,6 +514,31 @@ Status IrEmitterUnnested::HandleCustomCall(HloInstruction* custom_call) {
     return Status::OK();
   }
 #endif
+
+  if (custom_call->custom_call_target() == kReduceCallTarget) {
+    // understand the information of reduce HLO
+    const HloReduceInstruction* reduce = Cast<HloReduceInstruction>(custom_call->operand(0));
+    const HloConstantInstruction* init_value = Cast<HloConstantInstruction>(reduce->operand(1));
+    VLOG(3) << "Reduce HLO:";
+    VLOG(3) << "Shape/Layout: " << reduce->shape().ToString(true);
+    VLOG(3) << "Input: " << reduce->operand(0)->shape().ToString(true);
+    VLOG(3) << "Initial value: " << init_value->literal().Get<float>({0});
+    VLOG(3) << "Dimension to reduce: " << reduce->dimensions(0);
+    VLOG(3) << "Reduce computation: ";
+    for (auto& computation : reduce->called_computations()) {
+      VLOG(3) << computation->ToString();
+    }
+
+    AddThunkToThunkSequence(absl::make_unique<ReduceThunk>(
+        GetAllocationSlice(*reduce), // tensor from reduce output
+        GetAllocationSlice(*custom_call), // tensor for custom-call output
+        custom_call, // custom-call HLO
+        custom_call->operand(0), // reduce HLO
+        GetAllocationSlice(*reduce->operand(0)), // tensor for reduce
+        reduce->dimensions(0), // dimension to reduce
+        init_value->literal().Get<float>({0}))); // initial value
+    return Status::OK();
+  }
 
   if (void* call_target = CustomCallTargetRegistry::Global()->Lookup(
           custom_call->custom_call_target(),

--- a/tensorflow/compiler/xla/service/gpu/reduce_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/reduce_rewriter.cc
@@ -1,0 +1,92 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/gpu/reduce_rewriter.h"
+
+#include "tensorflow/compiler/xla/literal.h"
+#include "tensorflow/compiler/xla/literal_util.h"
+#include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class Visitor : public DfsHloVisitorWithDefault {
+ public:
+  explicit Visitor(HloComputation* computation) : computation_(computation) {}
+
+  static bool Run(HloComputation* computation) {
+    Visitor visitor(computation);
+    TF_CHECK_OK(computation->Accept(&visitor));
+    return visitor.changed_;
+  }
+
+  Status DefaultAction(HloInstruction* /*hlo_instruction*/) override {
+    return Status::OK();
+  }
+
+  Status HandleReduce(HloInstruction* reduce) override;
+
+ private:
+  bool changed_ = false;
+  HloComputation* computation_;
+};
+
+Status Visitor::HandleReduce(HloInstruction* reduce) {
+  const HloReduceInstruction* reduce_instr = Cast<HloReduceInstruction>(reduce);
+  if (reduce_instr) {
+    // only rewrite when the reduction results a scalar f32 value
+    if (reduce_instr->shape().dimensions_size() == 0 &&
+        reduce_instr->shape().element_type() == F32) {
+      LOG(INFO) << "[ReduceRewriter] Rewrite: " << reduce_instr->ToString();
+      std::vector<HloInstruction*> operands;
+      operands.push_back(reduce);
+      HloInstruction* new_instr =
+          computation_->AddInstruction(HloInstruction::CreateCustomCall(
+              reduce->shape(), operands, kReduceCallTarget));
+      LOG(INFO) << "[ReduceRewriter] New instruction: "
+                << new_instr->ToString();
+      if (computation_->root_instruction() == reduce) {
+        computation_->set_root_instruction(new_instr);
+      }
+      changed_ = true;
+    } else {
+      VLOG(3) << "[ReduceRewriter] Skip: " << reduce_instr->ToString();
+    }
+  }
+  return Status::OK();
+}
+
+}  // anonymous namespace
+
+StatusOr<bool> ReduceRewriter::Run(HloModule* module) {
+  VLOG(2) << "ReduceRewriter::Run(), before:";
+  XLA_VLOG_LINES(2, module->ToString());
+
+  bool changed = false;
+  for (auto* comp : module->MakeNonfusionComputations()) {
+    if (Visitor::Run(comp)) {
+      changed = true;
+    }
+  }
+
+  VLOG(2) << "ReduceRewriter::Run(), after:";
+  XLA_VLOG_LINES(2, module->ToString());
+  return changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/reduce_rewriter.h
+++ b/tensorflow/compiler/xla/service/gpu/reduce_rewriter.h
@@ -1,0 +1,35 @@
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_REDUCE_REWRITER_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_REDUCE_REWRITER_H_
+
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/hlo_module.h"
+#include "tensorflow/compiler/xla/service/hlo_pass_interface.h"
+
+namespace xla {
+namespace gpu {
+
+// Rewrites Reduce HLOs into calls into ReduceThunk.
+class ReduceRewriter : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "reduce_rewriter"; }
+  StatusOr<bool> Run(HloModule* module) override;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_REDUCE_REWRITER_H_

--- a/tensorflow/compiler/xla/service/gpu/reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/reduce_thunk.cc
@@ -1,0 +1,59 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/gpu/reduce_thunk.h"
+
+#include "tensorflow/compiler/xla/service/gpu/hlo_execution_profiler.h"
+#include "tensorflow/core/lib/core/errors.h"
+
+namespace xla {
+namespace gpu {
+
+ReduceThunk::ReduceThunk(const BufferAllocation::Slice& reduce_output_tensor,
+                         const BufferAllocation::Slice& output,
+                         const HloInstruction* custom_call_hlo,
+                         const HloInstruction* hlo,
+                         const BufferAllocation::Slice& reduce_input_tensor,
+                         int64 reduce_dimension, float init_value)
+    : Thunk(Kind::kReduce, custom_call_hlo),
+      reduce_input_(reduce_input_tensor),
+      reduce_output_(reduce_output_tensor),
+      output_(output),
+      hlo_(hlo),
+      reduce_dimension_(reduce_dimension),
+      init_value_(init_value) {}
+
+Status ReduceThunk::Initialize(const GpuExecutable& executable,
+                               se::StreamExecutor* executor) {
+  return Status::OK();
+}
+
+Status ReduceThunk::ExecuteOnStream(const BufferAllocations& buffer_allocations,
+                                    se::Stream* stream,
+                                    HloExecutionProfiler* profiler) {
+  se::DeviceMemoryBase input_data =
+      buffer_allocations.GetDeviceAddress(reduce_input_);
+  se::DeviceMemoryBase reference_output_data =
+      buffer_allocations.GetDeviceAddress(reduce_output_);
+  se::DeviceMemoryBase output_data =
+      buffer_allocations.GetDeviceAddress(output_);
+  auto op_profiler = profiler->MakeScopedInstructionProfiler(hlo_instruction());
+  VLOG(3) << "[ReduceThunk] Launch reduction for HLO: " << hlo_->ToString();
+  stream->ThenReduce(input_data, &output_data, init_value_, reduce_dimension_);
+  return Status::OK();
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/reduce_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/reduce_thunk.h
@@ -1,0 +1,56 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_REDUCE_THUNK_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_REDUCE_THUNK_H_
+
+#include "tensorflow/compiler/xla/service/gpu/buffer_allocations.h"
+#include "tensorflow/compiler/xla/service/gpu/hlo_execution_profiler.h"
+#include "tensorflow/compiler/xla/service/gpu/thunk.h"
+#include "tensorflow/compiler/xla/service/hlo_instruction.h"
+#include "tensorflow/core/platform/stream_executor_no_cuda.h"
+
+namespace xla {
+namespace gpu {
+
+class ReduceThunk : public Thunk {
+ public:
+  ReduceThunk(const BufferAllocation::Slice& reduce_output_tensor,
+              const BufferAllocation::Slice& output,
+              const HloInstruction* custom_call_hlo, const HloInstruction* hlo,
+              const BufferAllocation::Slice& reduce_input_tensor,
+              int64 reduce_dimension, float init_value);
+  ReduceThunk(const ReduceThunk&) = delete;
+  ReduceThunk& operator=(const ReduceThunk&) = delete;
+
+  Status Initialize(const GpuExecutable& executable,
+                    se::StreamExecutor* executor) override;
+  Status ExecuteOnStream(const BufferAllocations& buffer_allocations,
+                         se::Stream* stream,
+                         HloExecutionProfiler* profiler) override;
+
+ private:
+  const BufferAllocation::Slice reduce_input_;
+  const BufferAllocation::Slice reduce_output_;
+  const BufferAllocation::Slice output_;
+  const HloInstruction* hlo_;
+  int64 reduce_dimension_;
+  float init_value_;
+};
+
+}  // namespace gpu
+}  // namespace xla
+
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_REDUCE_THUNK_H_

--- a/tensorflow/compiler/xla/service/gpu/thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/thunk.cc
@@ -52,6 +52,8 @@ absl::string_view ThunkKindToString(Thunk::Kind kind) {
       return "kMemzero";
     case Thunk::kOutfeed:
       return "kOutfeed";
+    case Thunk::kReduce:
+      return "kReduce";
     case Thunk::kSequential:
       return "kSequential";
     case Thunk::kTriangularSolve:

--- a/tensorflow/compiler/xla/service/gpu/thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/thunk.h
@@ -58,6 +58,7 @@ class Thunk {
     kMemzero,
     kNcclAllReduce,
     kOutfeed,
+    kReduce,
     kSequential,
     kTriangularSolve,
     kTuple,

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4674,6 +4674,7 @@ cc_library(
     name = "required",
     deps = [
         ":no_op",
+        ":reduce_thunk_op",
         ":sendrecv_ops",
     ],
 )
@@ -4687,6 +4688,33 @@ tf_kernel_library(
     name = "no_op",
     prefix = "no_op",
     deps = REQUIRED_DEPS,
+)
+
+tf_kernel_library(
+    name = "reduce_thunk_op",
+    srcs = [
+        "reduce_thunk_op.cc",
+    ],
+    hdrs = [
+        "reduce_thunk_op.h",
+    ],
+    gpu_srcs = [
+        "reduce_thunk_op.h",
+        "reduce_thunk_op_gpu.cu.cc",
+    ],
+    deps = REQUIRED_DEPS + if_rocm_is_configured([
+        "@rocprim_archive//:rocprim",
+    ]),
+)
+
+cc_library(
+    name = "reduce_thunk_op_headers",
+    srcs = [
+        "reduce_thunk_op.h",
+    ],
+    deps = REQUIRED_DEPS + if_rocm_is_configured([
+        "@rocprim_archive//:rocprim",
+    ]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/reduce_thunk_op.cc
+++ b/tensorflow/core/kernels/reduce_thunk_op.cc
@@ -1,0 +1,20 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/reduce_thunk_op.h"
+
+namespace tensorflow {
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/reduce_thunk_op.h
+++ b/tensorflow/core/kernels/reduce_thunk_op.h
@@ -1,0 +1,32 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_REDUCE_THUNK_OP_H_
+#define TENSORFLOW_CORE_KERNELS_REDUCE_THUNK_OP_H_
+
+#include "rocm/include/hip/hip_runtime.h"
+#include "tensorflow/stream_executor/stream_executor.h"
+
+namespace tensorflow {
+
+typedef hipStream_t gpuStream_t;
+void ReduceKernelLaunch(gpuStream_t gpu_stream,
+                        const se::DeviceMemoryBase& input,
+                        se::DeviceMemoryBase* output, float init_value,
+                        int64 reduction_dimension);
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_REDUCE_THUNK_OP_H_

--- a/tensorflow/core/kernels/reduce_thunk_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/reduce_thunk_op_gpu.cu.cc
@@ -1,0 +1,70 @@
+#if TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include "external/rocprim_archive/hipcub/include/hipcub/hipcub.hpp"
+#include "tensorflow/core/kernels/reduce_thunk_op.h"
+#include "tensorflow/core/lib/core/bits.h"
+#include "tensorflow/core/util/gpu_device_functions.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+namespace gpuprim = ::hipcub;
+
+namespace tensorflow {
+
+// each block does a grid strided loop and reduces its values locally
+// the case of one block is used for low latency small reductions to scalars
+__global__ void BlockReduceKernel(const float* in, float* out, int num_elems,
+                                  float initVal) {
+  const int bid = blockIdx.x;
+  const int tid = threadIdx.x;
+
+  const int gid = bid * blockDim.x + tid;
+  const int stride = blockDim.x * gridDim.x;
+
+  float sum = initVal;
+  if (gid < num_elems) {
+    sum = in[gid];
+    for (int pos = gid + stride; pos < num_elems; pos += stride) {
+      sum = sum + in[pos];
+    }
+  }
+
+  typedef gpuprim::BlockReduce<float, 256> BlockReduce;
+
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+
+  // only include input values in the reduction
+  //
+  // elements: -----------------
+  // grid:     |====|====|====|====|====|
+  const int num_elements_to_reduce = max(min(256 - bid * blockDim.x, 256), 0);
+
+  sum = BlockReduce(temp_storage)
+            .Reduce(sum, gpuprim::Sum(), num_elements_to_reduce);
+
+  if (tid == 0) out[bid] = sum;
+}
+
+void ReduceKernelLaunch(gpuStream_t gpu_stream,
+                        const se::DeviceMemoryBase& input,
+                        se::DeviceMemoryBase* output, float init_value,
+                        int64 reduction_dimension) {
+  VLOG(3) << "ReduceKernelLaunch()";
+  VLOG(3) << "input device memory size: " << input.size();
+  VLOG(3) << "output device memory size: " << output->size();
+  VLOG(3) << "init value: " << init_value;
+  VLOG(3) << "reudction dimension: " << reduction_dimension;
+
+  const int num_blocks = 1;
+  const int num_threads = 256;
+  TF_CHECK_OK(GpuLaunchKernel(BlockReduceKernel, dim3(num_blocks),
+                              dim3(num_threads), 0, gpu_stream,
+                              reinterpret_cast<const float*>(input.opaque()),
+                              reinterpret_cast<float*>(output->opaque()),
+                              input.size() / sizeof(float), init_value));
+}
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -2575,6 +2575,13 @@ class DnnSupport {
       dnn::ProfileResult* output_profile_result) {
     return false;
   }
+
+  virtual bool DoReduce(Stream* stream, const DeviceMemoryBase& input,
+                        DeviceMemoryBase* output, float init_value,
+                        int64 reduction_dimension) {
+    return false;
+  }
+
  protected:
   // Returns whether status is 'ok', and potentially logs the error.
   static bool IsStatusOk(const port::Status& status, bool report_error);

--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -213,6 +213,9 @@ cc_library(
         "//tensorflow/stream_executor/lib",
         "//tensorflow/stream_executor/platform",
         "//tensorflow/stream_executor/platform:dso_loader",
+
+        "//tensorflow/core:framework",
+        "//tensorflow/core/kernels:reduce_thunk_op_headers",
     ] + if_static(["@local_config_rocm//rocm:miopen"])),
     alwayslink = True,
 )

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -40,6 +40,8 @@ limitations under the License.
 #include "rocm/include/miopen/miopen.h"
 // clang-format on
 
+#include "tensorflow/core/kernels/reduce_thunk_op.h"
+
 
 namespace {
 
@@ -4503,6 +4505,15 @@ bool MIOpenSupport::DoFusedBatchNormActivationBackward(
       scale_offset_mean_variance_descriptor, scale_data, offset_data,
       saved_mean_data, saved_var_data, x_bn_backprop_data, scale_backprop_data,
       offset_backprop_data, output_profile_result);
+}
+
+bool MIOpenSupport::DoReduce(Stream* stream, const DeviceMemoryBase& input,
+                             DeviceMemoryBase* output, float init_value,
+                             int64 reduction_dimension) {
+  hipStream_t hip_stream = stream ? AsGpuStreamValue(stream) : nullptr;
+  tensorflow::ReduceKernelLaunch(hip_stream, input, output, init_value,
+                                 reduction_dimension);
+  return true;
 }
 
 }  // namespace gpu

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -771,6 +771,10 @@ class MIOpenSupport : public dnn::DnnSupport {
       ScratchAllocator* scratch_allocator, dnn::AlgorithmDesc* algorithm_desc,
       DeviceMemory<uint8>* scratch_memory) override;
 
+  bool DoReduce(Stream* stream, const DeviceMemoryBase& input,
+                DeviceMemoryBase* output, float init_value,
+                int64 reduction_dimension) override;
+
   SE_DISALLOW_COPY_AND_ASSIGN(MIOpenSupport);
 };
 

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -5489,6 +5489,22 @@ Stream& Stream::ThenFusedBatchNormActivationBackward(
   return *this;
 }
 
+Stream& Stream::ThenReduce(const DeviceMemoryBase& input,
+                           DeviceMemoryBase* output, float init_value,
+                           int64 reduction_dimension) {
+  if (ok()) {
+    // TODO: review is is better to extract DoReduce into a separate module
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(
+          dnn->DoReduce(this, input, output, init_value, reduction_dimension));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
 port::Status Stream::BlockHostUntilDone() {
   VLOG_CALL();
 

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -2040,6 +2040,11 @@ class Stream {
   // negative effects on performance.
   Stream &ThenDoHostCallbackWithStatus(std::function<port::Status()> callback);
 
+  // Execute reduction. Currently only scalar reduction (output be a 0-rank
+  // tensor) is supported.
+  Stream& ThenReduce(const DeviceMemoryBase& input, DeviceMemoryBase* output,
+                     float init_value, int64 reduction_dimension);
+
   // Returns the StreamExecutor (parent object) associated with this stream.
   StreamExecutor *parent() const {
     CHECK(parent_ != nullptr);


### PR DESCRIPTION
Changed the following places in TensorFlow:

- Introduce ReduceRewriter, ReduceThunk in XLA
- Revise LLVM IR emitter to cope with kReduce in custom-call HLO
- Adopted ReduceWriter in AMDGPU XLA compiler backend
- Add ThenReduce() interface in StreamExecutor
- Hook ThenReduce() to DoReduce() in rocm_dnn module
- Hook DoReduce() to reduce_thunk_op custom TF op to launch rocPRIM kernels
- Relevant bazel script changes