### PR TITLE
Fix bfloat16 compilation

### DIFF
--- a/tensorflow/core/lib/bfloat16/bfloat16.h
+++ b/tensorflow/core/lib/bfloat16/bfloat16.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 #include "tensorflow/core/platform/byte_order.h"
 
-#if defined(__CUDACC__) || TENSORFLOW_COMPILER_IS_HIP_CLANG
+#if defined(__CUDACC__) || (defined(__HIPCC__) && defined(__HIP__))
 // All functions callable from CUDA code must be qualified with __device__
 #define B16_DEVICE_FUNC __host__ __device__
 


### PR DESCRIPTION
- Check `__HIPCC__` instead to ensure `__host__`/`__device__` attributes
  are only added when compiled with HIP/Clang.