### PR TITLE
Fix build failure for hip-clang

### DIFF
--- a/tensorflow/core/lib/bfloat16/bfloat16.h
+++ b/tensorflow/core/lib/bfloat16/bfloat16.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 #include "tensorflow/core/platform/byte_order.h"
 
-#if defined(__CUDACC__) || TENSORFLOW_COMPILER_IS_HIP_CLANG
+#if defined(__CUDACC__) || (TENSORFLOW_COMPILER_IS_HIP_CLANG && __HIP__)
 // All functions callable from CUDA code must be qualified with __device__
 #define B16_DEVICE_FUNC __host__ __device__
 

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -145,7 +145,7 @@ def InvokeHipcc(argv, log=False):
   undefines = GetOptionValue(argv, 'U')
   undefines = ''.join([' -U' + define for define in undefines])
   std_options = GetOptionValue(argv, 'std')
-  hipcc_allowed_std_options = ["c++11"]
+  hipcc_allowed_std_options = ["c++14"]
   std_options = ''.join([' -std=' + define
       for define in std_options if define in hipcc_allowed_std_options])
 
@@ -270,6 +270,7 @@ def main():
 
     # XXX: SE codes need to be built with gcc, but need this macro defined
     cpu_compiler_flags.append("-D__HIP_PLATFORM_HCC__")
+    cpu_compiler_flags.append("-std=c++14")
     if VERBOSE: print(' '.join([CPU_COMPILER] + cpu_compiler_flags))
     return subprocess.call([CPU_COMPILER] + cpu_compiler_flags)
 


### PR DESCRIPTION
TENSORFLOW_COMPILER_IS_HIP_CLANG=1 when rocm workspace is configured to use hip-clang.
It is defined when gcc is used to compile non-HIP source. It is not sufficient to
indicate HIP compilation. __HIP__ is needed to differentiate between gcc and hip-clang.