### PR TITLE
Update install_pip_packages.sh

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -130,8 +130,8 @@ pip2 install --upgrade h5py==2.8.0
 pip3 install --upgrade h5py==2.8.0
 
 # Estimator
-pip2 install tf-estimator-nightly --no-deps
-pip3 install tf-estimator-nightly --no-deps
+pip2 install tf-estimator-nightly==1.14.0.dev2019061801 --no-deps
+pip3 install tf-estimator-nightly==1.14.0.dev2019061801 --no-deps
 
 # Argparse
 pip2 install --upgrade argparse


### PR DESCRIPTION
This PR is to workaround the unit tests failures caused by tensorflow-estimator version movement. 
Passing: 
tf-estimator-nightly-1.14.0.dev2019061801
http://ml-ci.amd.com:21096/job/tensorflow-upstream-rel1.14-nightly/14/consoleFull
Failing:
tf-estimator-nightly-1.14.0.dev2019061901
http://ml-ci.amd.com:21096/job/tensorflow-upstream-rel1.14-nightly/15/consoleFull