### PR TITLE
[DO NOT MERGE] MIOpen immediate mode integration

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.cc
@@ -82,15 +82,7 @@ Status RunCudnnConvImpl(const CudnnConvParams& params,
   auto output_buf = se::DeviceMemory<T>(params.output_buf);
   AlgorithmConfig algorithm = params.algorithm;
 
-  if (options.first_call_from_algorithm_picker) {
-    // in ROCm mode, the first call to run the convolution needs to trigger the
-    // code that calls miopenFind* API. That triggger is implicit, it is based
-    // on whether or not the AlgorithmConfig::algorithm is empty! So for the
-    // first call we need to ensure that the AlgorithmConfig::algorithm is
-    // empty. For all subsequent calls, we should use the value retrieved from
-    // the backend_config
-    algorithm = AlgorithmConfig();
-  } else if (options.algo_override) {
+  if (options.algo_override) {
     algorithm = AlgorithmConfig(*options.algo_override);
   }
 
@@ -189,8 +181,7 @@ StatusOr<CudnnConvParams> GetCudnnConvParams(
   const Shape* output_shape;
 
   params.algorithm = se::dnn::AlgorithmConfig(se::dnn::AlgorithmDesc(
-      backend_config.algorithm(), backend_config.tensor_ops_enabled()),
-      backend_config.scratch_size());
+      backend_config.algorithm(), backend_config.tensor_ops_enabled()));
   params.conv_result_scale = backend_config.conv_result_scale();
 
   switch (params.kind) {

--- a/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.h
@@ -35,9 +35,6 @@ struct RunConvOptions {
 
   // Use this algorithm, instead of the one from the instruction.
   absl::optional<se::dnn::AlgorithmDesc> algo_override;
-
-  // This is the first call to conv runner from the algorithm picker
-  bool first_call_from_algorithm_picker;
 };
 
 // Implementation struct exposed for debugging and log analysis.

--- a/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
@@ -33,7 +33,7 @@ namespace {
 using absl::optional;
 using se::DeviceMemoryBase;
 using se::dnn::AlgorithmDesc;
-  
+
 class ScratchAllocator : public se::ScratchAllocator {
  public:
   ScratchAllocator(int device_ordinal, se::DeviceMemoryAllocator* memory_allocator)
@@ -201,8 +201,8 @@ StatusOr<ConvCacheKey> AutotuneCacheKeyfromInstruction(
 }
 
 tensorflow::mutex autotune_cache_lock(tensorflow::LINKER_INITIALIZED);
-auto& autotune_cache GUARDED_BY(autotune_cache_lock) =
-    *new absl::flat_hash_map<ConvCacheKey, MiopenConvAlgorithmPicker::AutotuneResult>();
+auto& autotune_cache GUARDED_BY(autotune_cache_lock) = *new absl::flat_hash_map<
+    ConvCacheKey, MiopenConvAlgorithmPicker::AutotuneResult>();
 auto& autotune_cache_stats GUARDED_BY(autotune_cache_lock) =
     *new ConvCacheStats();
 }  // anonymous namespace
@@ -237,7 +237,8 @@ MiopenConvAlgorithmPicker::PickBestAlgorithm(
     autotune_cache_stats.cache_misses++;
   }
 
-  StatusOr<MiopenConvAlgorithmPicker::AutotuneResult> result_or = PickBestAlgorithmNoCache(instr);
+  StatusOr<MiopenConvAlgorithmPicker::AutotuneResult> result_or =
+      PickBestAlgorithmNoCache(instr);
   if (result_or.ok()) {
     tensorflow::mutex_lock lock(autotune_cache_lock);
     CHECK(autotune_cache.insert({key, result_or.ValueOrDie()}).second);
@@ -276,8 +277,7 @@ MiopenConvAlgorithmPicker::PickBestAlgorithmNoCache(
     allocator = &*se_allocator;
   }
 
-  const auto initialize_buffer = [&stream](
-                                     DeviceMemoryBase buffer) {
+  const auto initialize_buffer = [&stream](DeviceMemoryBase buffer) {
     // Although we don't have evidence this matters, zero out the buffers
     // before autotuning.  It's conceivable that using uninitialized memory as
     // the inputs might affect performance if e.g. the inputs contain
@@ -348,7 +348,8 @@ MiopenConvAlgorithmPicker::PickBestAlgorithmNoCache(
 
   const auto& best_result = absl::c_min_element(
       profile_results,
-      [&](const MiopenConvAlgorithmPicker::AutotuneResult& lhs, const MiopenConvAlgorithmPicker::AutotuneResult& rhs) {
+      [&](const MiopenConvAlgorithmPicker::AutotuneResult& lhs,
+          const MiopenConvAlgorithmPicker::AutotuneResult& rhs) {
         return lhs.runtime < rhs.runtime;
       });
 

--- a/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
@@ -32,9 +32,8 @@ namespace {
 
 using absl::optional;
 using se::DeviceMemoryBase;
-using se::dnn::AlgorithmConfig;
 using se::dnn::AlgorithmDesc;
-
+  
 class ScratchAllocator : public se::ScratchAllocator {
  public:
   ScratchAllocator(int device_ordinal, se::DeviceMemoryAllocator* memory_allocator)
@@ -77,6 +76,65 @@ StatusOr<se::DeviceMemory<uint8>> ScratchAllocator::AllocateBytes(
   return se::DeviceMemory<uint8>(buffer_addr);
 }
 
+StatusOr<se::dnn::ConvolutionKind> GetDnnConvolutionKind(
+    const HloCustomCallInstruction* conv) {
+  TF_ASSIGN_OR_RETURN(CudnnConvKind kind, GetCudnnConvKind(conv));
+
+  switch (kind) {
+    case CudnnConvKind::kBackwardFilter:
+      return se::dnn::ConvolutionKind::BACKWARD_FILTER;
+    case CudnnConvKind::kBackwardInput:
+      return se::dnn::ConvolutionKind::BACKWARD_DATA;
+    case CudnnConvKind::kForward:
+      return se::dnn::ConvolutionKind::FORWARD;
+    default:
+      break;
+  }
+  return InternalError("Unsupported convolution type : %s", conv->ToString());
+}
+
+StatusOr<se::dnn::DataType> GetDnnDataType(
+    const HloCustomCallInstruction* conv) {
+  PrimitiveType output_primitive_type =
+      conv->shape().tuple_shapes(0).element_type();
+
+  switch (output_primitive_type) {
+    case F16:
+      return se::dnn::ToDataType<Eigen::half>::value;
+    case F32:
+      return se::dnn::ToDataType<float>::value;
+    case F64:
+      return se::dnn::ToDataType<double>::value;
+    default:
+      break;
+  }
+
+  return InternalError("Unsupported convolution datatype : %s",
+                       conv->ToString());
+}
+
+StatusOr<std::vector<AlgorithmDesc>> GetAlgorithms(
+    const HloCustomCallInstruction* conv,
+    absl::Span<se::DeviceMemoryBase> operand_buffers,
+    se::DeviceMemoryBase result_buffer, se::StreamExecutor* stream_exec,
+    se::Stream* stream) {
+  std::vector<AlgorithmDesc> algorithms;
+
+  TF_ASSIGN_OR_RETURN(se::dnn::ConvolutionKind kind,
+                      GetDnnConvolutionKind(conv));
+
+  TF_ASSIGN_OR_RETURN(se::dnn::DataType dtype, GetDnnDataType(conv));
+
+  TF_ASSIGN_OR_RETURN(CudnnConvParams params,
+                      GetCudnnConvParams(conv, operand_buffers, result_buffer));
+
+  bool succ = stream_exec->GetMIOpenConvolveAlgorithms(
+      kind, stream, dtype, params.input_descriptor, params.filter_descriptor,
+      params.conv_desc, params.output_descriptor, &algorithms);
+  DCHECK(succ);
+
+  return algorithms;
+}
 
 string AlgorithmToString(const AlgorithmDesc& algo) {
   if (algo.tensor_ops_enabled()) {
@@ -112,44 +170,89 @@ tensorflow::mutex_lock LockGpu(const se::StreamExecutor* stream_exec) {
   return tensorflow::mutex_lock{it->second};
 }
 
+using ConvCacheKey =
+    std::tuple<se::StreamExecutor*, std::string, std::string, Shape,
+               std::vector<Shape>, std::string, std::string, int64>;
+
+struct ConvCacheStats {
+  int64 cache_hits = 0;
+  int64 cache_misses = 0;
+
+  void LogStats() {
+    VLOG(2) << "Cache hits: " << cache_hits;
+    VLOG(2) << "Cache misses: " << cache_misses;
+  }
+};
+
+StatusOr<ConvCacheKey> AutotuneCacheKeyfromInstruction(
+    const HloCustomCallInstruction* conv, se::StreamExecutor* se) {
+  TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
+                      conv->backend_config<CudnnConvBackendConfig>());
+  std::vector<Shape> operand_shapes;
+  absl::c_transform(conv->operands(), std::back_inserter(operand_shapes),
+                    [&](const HloInstruction* op) { return op->shape(); });
+
+  return std::make_tuple(
+      se, backend_config.SerializeAsString(), conv->custom_call_target(),
+      conv->shape(), std::move(operand_shapes),
+      conv->window().SerializeAsString(),
+      conv->convolution_dimension_numbers().SerializeAsString(),
+      conv->feature_group_count());
+}
+
+tensorflow::mutex autotune_cache_lock(tensorflow::LINKER_INITIALIZED);
+auto& autotune_cache GUARDED_BY(autotune_cache_lock) =
+    *new absl::flat_hash_map<ConvCacheKey, MiopenConvAlgorithmPicker::AutotuneResult>();
+auto& autotune_cache_stats GUARDED_BY(autotune_cache_lock) =
+    *new ConvCacheStats();
 }  // anonymous namespace
 
-// We could have caching here so that we don't redo this work for two identical
-// convolutions.  Unfortunately our cache key would have to be a tuple
-// containing the protos passed to this function, and we have no utility for
-// hashing protos.  We could write our own hash functions, but they'd silently
-// break if we ever added a field to one of the protos.  Perhaps we could hack
-// using the binary-encoded proto as the hash key, on the assumption that two
-// protos being binary-equal is a sufficient, if not necessary, condition for
-// proper equality.  But that would still leave us open to having unnecessary
-// cache misses and doing extra work.  Overall, caching doesn't seem worth the
-// trouble, but we may want to revisit this if we ever find a model where
-// caching would speed up compilation a lot.
 StatusOr<MiopenConvAlgorithmPicker::AutotuneResult>
 MiopenConvAlgorithmPicker::PickBestAlgorithm(
     const HloCustomCallInstruction* instr) {
-  // TODO(timshen): for now only check fp16. It can be expanded to other types,
-  // with some work on the HLO routines.
-
-  // FIXME(rocm): disable cross_check temporarily
-  // The cross_check functionality for the Eigen::half datatype, will call
-  // "ThenMemset32" with a value that > 255. This results in a failed check in
-  // the code rocm_driver.cpp, which then leads to test failure.
-  //
-  // This is an known bug which is being in the process of being fixed
-  // disabling this check until then
-
-  // const bool cross_check_enabled =
-  //     instr->shape().tuple_shapes(0).element_type() == xla::F16;
-
-  const bool cross_check_enabled = false;
-
   // Don't run this function concurrently on the same GPU.
   //
   // This is a bit of a hack and doesn't protect us against arbitrary concurrent
   // use of a GPU, but it's sufficient to let us compile two HLO modules
   // concurrently and then run them sequentially.
+  //
+  // Putting the lock in here rather than in PickBestAlgorithmNoCache lets us
+  // avoid ever doing duplicate work.  If we have a cache miss, only one thread
+  // will run PickBestAlgorithmImpl for a particular device.
   tensorflow::mutex_lock lock = LockGpu(stream_exec_);
+
+  // We cache the autotuning results to avoid doing the duplicate work,
+  // which can greatly improve both stability (deterministic numeric results
+  // within a process for a given input) and performance (2x speedup on some
+  // models).
+  TF_ASSIGN_OR_RETURN(ConvCacheKey key,
+                      AutotuneCacheKeyfromInstruction(instr, stream_exec_));
+  {
+    tensorflow::mutex_lock lock(autotune_cache_lock);
+    auto it = autotune_cache.find(key);
+    if (it != autotune_cache.end()) {
+      autotune_cache_stats.cache_hits++;
+      return it->second;
+    }
+    autotune_cache_stats.cache_misses++;
+  }
+
+  StatusOr<MiopenConvAlgorithmPicker::AutotuneResult> result_or = PickBestAlgorithmNoCache(instr);
+  if (result_or.ok()) {
+    tensorflow::mutex_lock lock(autotune_cache_lock);
+    CHECK(autotune_cache.insert({key, result_or.ValueOrDie()}).second);
+  }
+  return result_or;
+}
+
+StatusOr<MiopenConvAlgorithmPicker::AutotuneResult>
+MiopenConvAlgorithmPicker::PickBestAlgorithmNoCache(
+    const HloCustomCallInstruction* instr) {
+  XLA_SCOPED_LOGGING_TIMER(
+      absl::StrCat("CudnnConvAlgorithmPicker::PickBestAlgorithmImpl for ",
+                   instr->ToString()));
+
+  const Shape& result_shape = instr->shape().tuple_shapes(0);
 
   // Make sure any previous activity on this executor is done. We don't want to
   // interfere with programs that are still running on the GPU.
@@ -169,41 +272,17 @@ MiopenConvAlgorithmPicker::PickBestAlgorithm(
   if (allocator_ != nullptr) {
     allocator = allocator_;
   } else {
-    se_allocator.emplace(stream_exec_->platform(),
-                         absl::Span<se::StreamExecutor* const>({stream_exec_}));
+    se_allocator.emplace(stream_exec_);
     allocator = &*se_allocator;
   }
 
-  const auto initialize_buffer = [&stream, cross_check_enabled](
+  const auto initialize_buffer = [&stream](
                                      DeviceMemoryBase buffer) {
-    if (cross_check_enabled) {
-      // Broadcast a constant to the buffer, instead of zeroing the buffer. A
-      // non-zero constant is useful for the cross checking, because zero-inputs
-      // may not always reveal the bugs.
-      CHECK_EQ(0, (uintptr_t)buffer.opaque() % 4);
-      size_t left_over_bytes = buffer.size() % 4;
-      CHECK_EQ(0, left_over_bytes % 2);
-
-      constexpr float kBroadcastedConstant = 0.1f;
-      static const Eigen::half halfs[2] = {Eigen::half(kBroadcastedConstant),
-                                           Eigen::half(kBroadcastedConstant)};
-      uint32 bits;
-      static_assert(sizeof(bits) == sizeof(halfs), "");
-      memcpy(&bits, halfs, sizeof(bits));
-
-      size_t aligned_size = buffer.size() / 4 * 4;
-      stream.ThenMemset32(&buffer, bits, aligned_size);
-
-      DeviceMemoryBase left_over(
-          static_cast<char*>(buffer.opaque()) + aligned_size, left_over_bytes);
-      stream.ThenMemcpy(&left_over, halfs, left_over_bytes);
-    } else {
-      // Although we don't have evidence this matters, zero out the buffers
-      // before autotuning.  It's conceivable that using uninitialized memory as
-      // the inputs might affect performance if e.g. the inputs contain
-      // denormals, and this is easy enough.
-      stream.ThenMemZero(&buffer, buffer.size());
-    }
+    // Although we don't have evidence this matters, zero out the buffers
+    // before autotuning.  It's conceivable that using uninitialized memory as
+    // the inputs might affect performance if e.g. the inputs contain
+    // denormals, and this is easy enough.
+    stream.ThenMemZero(&buffer, buffer.size());
   };
 
   // Allocate space for the input, filter, and output of the convolution.  We
@@ -224,45 +303,57 @@ MiopenConvAlgorithmPicker::PickBestAlgorithm(
           &stream, ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(0))));
   initialize_buffer(result_buffer);
 
-  se::dnn::ProfileResult best_result;
-  int64 best_result_bytes_used = 0;
-  TF_ASSIGN_OR_RETURN(auto backend_config,
-                      instr->backend_config<CudnnConvBackendConfig>());
+  TF_ASSIGN_OR_RETURN(std::vector<AlgorithmDesc> algorithms,
+                      GetAlgorithms(instr, absl::MakeSpan(operand_buffers),
+                                    result_buffer, stream_exec_, &stream));
 
-  ScratchAllocator scratch_allocator(device_ordinal, allocator);
-  se::dnn::ProfileResult profile_result;
-  VLOG(3) << "Auto-tuning for " << instr->ToString();
-  RunConvOptions options;
-  options.profile_result = &profile_result;
-  options.first_call_from_algorithm_picker = true;
-  bool launch_ok =
+  std::vector<MiopenConvAlgorithmPicker::AutotuneResult> profile_results;
+
+  for (const AlgorithmDesc& alg : algorithms) {
+    XLA_SCOPED_LOGGING_TIMER_LEVEL(
+        absl::StrCat("CudnnConvAlgorithmPicker::PickBestAlgorithm algo ",
+                     AlgorithmToString(alg)),
+        2);
+
+    ScratchAllocator scratch_allocator(device_ordinal, allocator);
+    se::dnn::ProfileResult profile_result;
+    VLOG(3) << "Trying algorithm " << AlgorithmToString(alg) << " for "
+            << instr->ToString();
+
+    // Use assignment instead of brace-list to make GCC 4.9 happy.
+    RunConvOptions options;
+    options.profile_result = &profile_result;
+    options.algo_override = alg;
+    Status launch_status =
         RunCudnnConv(instr, absl::MakeSpan(operand_buffers), result_buffer,
-                     &scratch_allocator, &stream, options)
-            .ok();
+                     &scratch_allocator, &stream, options);
 
-  if (launch_ok && profile_result.is_valid()) {
+    if (!launch_status.ok()) {
+      continue;
+    }
+
+    if (!profile_result.is_valid()) {
+      continue;
+    }
+
+    profile_results.emplace_back();
+    MiopenConvAlgorithmPicker::AutotuneResult& result = profile_results.back();
+    result.algorithm = alg.algo_id();
+    result.tensor_ops_enabled = alg.tensor_ops_enabled();
+
     int64 scratch_bytes_used = scratch_allocator.TotalAllocatedBytes();
-    VLOG(3) << "Auto-tuning succeeded, taking "
-            << profile_result.elapsed_time_in_ms() << "ms and using "
-            << NumBytesToString(scratch_bytes_used)
-            << " of scratch (Best result: " << best_result.elapsed_time_in_ms()
-            << "ms, " << NumBytesToString(best_result_bytes_used)
-            << " of scratch)";
-    best_result = profile_result;
-    best_result_bytes_used = scratch_bytes_used;
-  } else {
-    VLOG(3) << "Auto-tuning failed.";
+    result.scratch_bytes = scratch_bytes_used;
+    result.runtime = absl::Milliseconds(profile_result.elapsed_time_in_ms());
   }
 
-  if (best_result.is_valid()) {
-    VLOG(2) << "Best algorithm for " << instr->ToString() << ": "
-            << AlgorithmToString(best_result.algorithm()) << ", takes "
-            << best_result.elapsed_time_in_ms() << "ms, and uses "
-            << best_result_bytes_used << "B of scratch memory.";
-    return AutotuneResult{best_result.algorithm().algo_id(),
-                          best_result.algorithm().tensor_ops_enabled(),
-                          best_result_bytes_used,
-                          absl::Milliseconds(best_result.elapsed_time_in_ms())};
+  const auto& best_result = absl::c_min_element(
+      profile_results,
+      [&](const MiopenConvAlgorithmPicker::AutotuneResult& lhs, const MiopenConvAlgorithmPicker::AutotuneResult& rhs) {
+        return lhs.runtime < rhs.runtime;
+      });
+
+  if (best_result != profile_results.end()) {
+    return *best_result;
   }
 
   return InternalError(
@@ -275,7 +366,7 @@ StatusOr<bool> MiopenConvAlgorithmPicker::RunOnInstruction(
     HloInstruction* instr) {
   CHECK(IsCustomCallToDnnConvolution(*instr));
 
-  StatusOr<AutotuneResult> best_algo_or =
+  StatusOr<MiopenConvAlgorithmPicker::AutotuneResult> best_algo_or =
       PickBestAlgorithm(Cast<HloCustomCallInstruction>(instr));
   if (!best_algo_or.ok()) {
     LOG(ERROR) << best_algo_or.status();
@@ -299,7 +390,6 @@ StatusOr<bool> MiopenConvAlgorithmPicker::RunOnInstruction(
                       instr->backend_config<CudnnConvBackendConfig>());
   backend_config.set_algorithm(best_algo.algorithm);
   backend_config.set_tensor_ops_enabled(best_algo.tensor_ops_enabled);
-  backend_config.set_scratch_size(best_algo.scratch_bytes);
 
   HloInstruction* new_call = computation->AddInstruction(
       instr->CloneWithNewOperands(new_call_shape, instr->operands()));
@@ -340,11 +430,25 @@ StatusOr<bool> MiopenConvAlgorithmPicker::RunOnComputation(
 }
 
 StatusOr<bool> MiopenConvAlgorithmPicker::Run(HloModule* module) {
+  XLA_SCOPED_LOGGING_TIMER("CudnnConvAlgorithmPicker");
+
+  if (module->config().debug_options().xla_gpu_disable_autotune()) {
+    VLOG(2) << "Convolution auto-tuning disabled, CudnnConvAlgorithmPicker "
+               "returning early.";
+    return false;
+  }
+
   bool changed = false;
   for (HloComputation* computation : module->MakeNonfusionComputations()) {
     TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
     changed |= result;
   }
+
+  {
+    tensorflow::mutex_lock lock(autotune_cache_lock);
+    autotune_cache_stats.LogStats();
+  }
+
   return changed;
 }
 

--- a/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h
+++ b/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h
@@ -47,7 +47,6 @@ class MiopenConvAlgorithmPicker : public HloModulePass {
 
   StatusOr<bool> Run(HloModule* module) override;
 
- private:
   struct AutotuneResult {
     int64 algorithm;
     bool tensor_ops_enabled;
@@ -55,13 +54,16 @@ class MiopenConvAlgorithmPicker : public HloModulePass {
     absl::Duration runtime;
   };
 
+ private:
   StatusOr<bool> RunOnComputation(HloComputation* computation);
   StatusOr<bool> RunOnInstruction(HloInstruction* instr);
   StatusOr<AutotuneResult> PickBestAlgorithm(
       const HloCustomCallInstruction* instr);
+  StatusOr<AutotuneResult> PickBestAlgorithmNoCache(
+      const HloCustomCallInstruction* instr);
 
   se::StreamExecutor* stream_exec_;                   // never null
-  se::DeviceMemoryAllocator* allocator_;                  // may be null
+  se::DeviceMemoryAllocator* allocator_;              // may be null
   Compiler* compiler_;
 };
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -492,7 +492,7 @@ cc_library(
 
 tf_cuda_library(
     name = "gpu_utils",
-    srcs = if_cuda_is_configured(["gpu_utils.cc"]),
+    srcs = if_cuda_is_configured(["gpu_utils.cc"]) + if_rocm_is_configured(["gpu_utils.cc"]),
     hdrs = ["gpu_utils.h"],
     deps = [
         ":gpu_util_hdrs",

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -871,11 +871,17 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   AlgorithmConfig algorithm_config;
   if (cudnn_use_autotune && !AutoTuneConvBwdFilter::GetInstance()->Find(
                                 conv_parameters, &algorithm_config)) {
-#if GOOGLE_CUDA
     std::vector<AlgorithmDesc> algorithms;
+#if GOOGLE_CUDA
     CHECK(stream->parent()->GetConvolveBackwardFilterAlgorithms(
         conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(stream->parent()),
         &algorithms));
+#elif TENSORFLOW_USE_ROCM
+    CHECK(stream->parent()->GetMIOpenConvolveAlgorithms(
+        se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
+        se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
+        output_desc, &algorithms));
+#endif
     std::vector<tensorflow::AutotuneResult> results;
     for (auto profile_algorithm : algorithms) {
       // TODO(zhengxq): profile each algorithm multiple times to better
@@ -908,22 +914,6 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                            filter_desc, output_desc, conv_desc,
                            stream->parent(), results);
     OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-#elif TENSORFLOW_USE_ROCM
-    ProfileResult best_result;
-    DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
-                                          ctx);
-    bool miopen_find_status =
-        stream
-            ->ThenConvolveBackwardFilterWithAlgorithm(
-                input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
-                filter_desc, &filter_backprop_ptr, &scratch_allocator,
-                AlgorithmConfig(), &best_result)
-            .ok();
-    OP_REQUIRES(ctx, miopen_find_status && best_result.is_valid(),
-                errors::NotFound("Failed to find backward filter algorithm!"));
-    algorithm_config.set_algorithm(best_result.algorithm());
-    algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
     AutoTuneConvBwdFilter::GetInstance()->Insert(conv_parameters,
                                                  algorithm_config);
   }

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1096,11 +1096,17 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   AlgorithmConfig algorithm_config;
   if (cudnn_use_autotune && !AutoTuneConvBwdData::GetInstance()->Find(
                                 conv_parameters, &algorithm_config)) {
-#if GOOGLE_CUDA
     std::vector<AlgorithmDesc> algorithms;
+#if GOOGLE_CUDA
     CHECK(stream->parent()->GetConvolveBackwardDataAlgorithms(
         conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(stream->parent()),
         &algorithms));
+#elif TENSORFLOW_USE_ROCM
+    CHECK(stream->parent()->GetMIOpenConvolveAlgorithms(
+        se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
+        se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
+        output_desc, &algorithms));
+#endif
     std::vector<tensorflow::AutotuneResult> results;
     for (auto profile_algorithm : algorithms) {
       // TODO(zhengxq): profile each algorithm multiple times to better
@@ -1131,24 +1137,6 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
         in_backprop_ptr, filter_ptr, out_backprop_ptr, input_desc, filter_desc,
         output_desc, conv_desc, stream->parent(), results);
     OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-#elif TENSORFLOW_USE_ROCM
-    // MIOpen has its own Find and autotuner so use it here, passing
-    // default AlgorithmConfig to force a search
-    DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize, ctx);
-    ProfileResult best_result;
-    bool miopen_find_status =
-        stream
-            ->ThenConvolveBackwardDataWithAlgorithm(
-                filter_desc, filter_ptr, output_desc, out_backprop_ptr,
-                conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
-                AlgorithmConfig(), &best_result)
-            .ok();
-    OP_REQUIRES(ctx, miopen_find_status && best_result.is_valid(),
-                errors::NotFound("Failed to find backwards-data algorithm!"));
-
-    algorithm_config.set_algorithm(best_result.algorithm());
-    algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
     AutoTuneConvBwdData::GetInstance()->Insert(conv_parameters,
                                                algorithm_config);
   }

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1116,7 +1116,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
                            output_tensor, input_desc, filter_desc, output_desc,
                            conv_desc, stream->parent(), results);
     OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-
     AutoTuneConv::GetInstance()->Insert(conv_parameters, algorithm_config);
   }
 

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1069,28 +1069,54 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
         CheckRedzones(rz_allocator, stream, &result);
       }
     }
+
+#elif TENSORFLOW_USE_ROCM
+    std::vector<AlgorithmDesc> algorithms;
+    OP_REQUIRES(ctx,
+                stream->parent()->GetMIOpenConvolveAlgorithms(
+                    se::dnn::ConvolutionKind::FORWARD, stream,
+                    se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+                    conv_desc, output_desc, &algorithms),
+                errors::Unknown(
+                    "Failed to get convolution algorithm. This is probably "
+                    "because MIOpen failed to initialize, so try looking to "
+                    "see if a warning log message was printed above."));
+
+    se::DeviceMemory<T> output_tensor = output_ptr;
+
+    std::vector<tensorflow::AutotuneResult> results;
+    for (auto profile_algorithm : algorithms) {
+      // TODO(zhengxq): profile each algorithm multiple times to better
+      // accuracy.
+      DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
+      ProfileResult profile_result;
+      bool miopen_launch_status =
+          stream
+              ->ThenConvolveWithAlgorithm(
+                  input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
+                  output_desc, &output_tensor, &scratch_allocator,
+                  AlgorithmConfig(profile_algorithm), &profile_result)
+              .ok();
+      if (miopen_launch_status && profile_result.is_valid()) {
+        results.emplace_back();
+        auto& result = results.back();
+        result.mutable_conv()->set_algorithm(profile_algorithm.algo_id());
+        result.mutable_conv()->set_tensor_ops_enabled(
+            profile_algorithm.tensor_ops_enabled());
+
+        result.set_scratch_bytes(scratch_allocator.TotalByteSize());
+        *result.mutable_run_time() = proto_utils::ToDurationProto(
+            absl::Milliseconds(profile_result.elapsed_time_in_ms()));
+      }
+    }
+
+#endif
     LogConvAutotuneResults(se::dnn::ConvolutionKind::FORWARD,
                            se::dnn::ToDataType<T>::value, input_ptr, filter_ptr,
                            output_tensor, input_desc, filter_desc, output_desc,
                            conv_desc, stream->parent(), results);
     OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-#elif TENSORFLOW_USE_ROCM
-    DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
-    ProfileResult best_result;
-    bool miopen_find_status =
-        stream
-            ->ThenConvolveWithAlgorithm(input_desc, input_ptr, filter_desc,
-                                        filter_ptr, conv_desc, output_desc,
-                                        &output_ptr, &scratch_allocator,
-                                        AlgorithmConfig(), &best_result)
-            .ok();
 
-    OP_REQUIRES(ctx, miopen_find_status && best_result.is_valid(),
-                errors::NotFound("Failed to find conv algorithm!"));
-
-    algorithm_config.set_algorithm(best_result.algorithm());
-    algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
     AutoTuneConv::GetInstance()->Insert(conv_parameters, algorithm_config);
   }
 

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -435,8 +435,8 @@ struct LaunchConvOp<GPUDevice, T> {
 
     if (cudnn_use_autotune && !AutoTuneConv3d::GetInstance()->Find(
                                   conv_parameters, &algorithm_config)) {
-#if GOOGLE_CUDA
       std::vector<AlgorithmDesc> algorithms;
+#if GOOGLE_CUDA
       OP_REQUIRES(ctx,
                   stream->parent()->GetConvolveAlgorithms(
                       conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
@@ -446,6 +446,17 @@ struct LaunchConvOp<GPUDevice, T> {
                       "Failed to get convolution algorithm. This is probably "
                       "because cuDNN failed to initialize, so try looking to "
                       "see if a warning log message was printed above."));
+#elif TENSORFLOW_USE_ROCM
+      OP_REQUIRES(ctx,
+                  stream->parent()->GetMIOpenConvolveAlgorithms(
+                      se::dnn::ConvolutionKind::FORWARD, stream,
+                      se::dnn::ToDataType<T>::value, input_desc, filter_desc,
+                      conv_desc, output_desc, &algorithms),
+                  errors::Unknown(
+                      "Failed to get convolution algorithm. This is probably "
+                      "because MIOpen failed to initialize, so try looking to "
+                      "see if a warning log message was printed above."));
+#endif
 
       std::vector<tensorflow::AutotuneResult> results;
       for (auto profile_algorithm : algorithms) {
@@ -478,21 +489,6 @@ struct LaunchConvOp<GPUDevice, T> {
                              filter_ptr, output_ptr, input_desc, filter_desc,
                              output_desc, conv_desc, stream->parent(), results);
       OP_REQUIRES_OK(ctx, BestCudnnConvAlgorithm(results, &algorithm_config));
-#elif TENSORFLOW_USE_ROCM
-      ProfileResult best_result;
-      DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
-      bool miopen_find_status =
-          stream
-              ->ThenConvolveWithAlgorithm(input_desc, input_ptr, filter_desc,
-                                          filter_ptr, conv_desc, output_desc,
-                                          &output_ptr, &scratch_allocator,
-                                          AlgorithmConfig(), &best_result)
-              .ok();
-      OP_REQUIRES(ctx, miopen_find_status && best_result.is_valid(),
-                  errors::NotFound("Failed to find conv algorithm!"));
-      algorithm_config.set_algorithm(best_result.algorithm());
-      algorithm_config.set_scratch_size(best_result.scratch_size());
-#endif
       AutoTuneConv3d::GetInstance()->Insert(conv_parameters, algorithm_config);
     }
 

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/gpu_utils.h"
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include <iterator>
 
@@ -168,4 +168,4 @@ Status BestCudnnConvAlgorithm(absl::Span<const AutotuneResult> results,
 
 }  // namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -33,6 +33,16 @@ bool DnnSupport::GetConvolveAlgorithms(
   return false;
 }
 
+bool DnnSupport::GetMIOpenConvolveAlgorithms(
+    dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<AlgorithmDesc>* out_algorithms) {
+  return false;
+}
+
 bool DnnSupport::GetRnnAlgorithms(std::vector<AlgorithmDesc>* out_algorithms) {
   return false;
 }

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -836,8 +836,6 @@ class AlgorithmConfig {
  public:
   AlgorithmConfig() {}
   explicit AlgorithmConfig(AlgorithmDesc algorithm) : algorithm_(algorithm) {}
-  AlgorithmConfig(AlgorithmDesc algorithm, size_t scratch_size)
-      : algorithm_(algorithm), scratch_size_(scratch_size) {}
   AlgorithmConfig(AlgorithmDesc algorithm, AlgorithmDesc algorithm_no_scratch)
       : algorithm_(algorithm), algorithm_no_scratch_(algorithm_no_scratch) {}
   absl::optional<AlgorithmDesc> algorithm() const { return algorithm_; }
@@ -848,12 +846,9 @@ class AlgorithmConfig {
   void set_algorithm_no_scratch(AlgorithmDesc val) {
     algorithm_no_scratch_ = val;
   }
-  absl::optional<size_t> scratch_size() const { return scratch_size_; }
-  void set_scratch_size(size_t val) { scratch_size_ = val; }
   bool operator==(const AlgorithmConfig& other) const {
     return this->algorithm_ == other.algorithm_ &&
-           this->algorithm_no_scratch_ == other.algorithm_no_scratch_ &&
-           this->scratch_size_ == other.scratch_size_;
+           this->algorithm_no_scratch_ == other.algorithm_no_scratch_;
   }
   bool operator!=(const AlgorithmConfig& other) const {
     return !(*this == other);
@@ -863,7 +858,6 @@ class AlgorithmConfig {
  private:
   absl::optional<AlgorithmDesc> algorithm_;
   absl::optional<AlgorithmDesc> algorithm_no_scratch_;
-  absl::optional<size_t> scratch_size_;
 };
 
 // Describes a local response normalization (LRN). LRN is used e.g. in

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1328,6 +1328,14 @@ class DnnSupport {
       bool with_winograd_nonfused, int cc_major, int cc_minor,
       std::vector<AlgorithmDesc>* out_algorithms);
 
+  virtual bool GetMIOpenConvolveAlgorithms(
+      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<AlgorithmDesc>* out_algorithms);
+
   // Returns a list of supported rnn algorithms.
   virtual bool GetRnnAlgorithms(std::vector<AlgorithmDesc>* out_algorithms);
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -53,6 +53,8 @@ NarrowT CheckedNarrowing(const WideT& wide) {
   return narrow;
 }
 
+const int kImmediateModeVlogLevel = -1;
+
 }  // namespace
 
 namespace stream_executor {
@@ -91,6 +93,24 @@ string ToString(miopenStatus_t status) {
   }
 }
 
+string ToString(miopenConvAlgorithm_t algorithm) {
+  string s;
+  switch (algorithm) {
+    case miopenConvolutionAlgoGEMM:
+      s = "GEMM";
+      break;
+    case miopenConvolutionAlgoDirect:
+      s = "Direct";
+      break;
+    case miopenConvolutionAlgoFFT:
+      s = "FFT";
+      break;
+    case miopenConvolutionAlgoWinograd:
+      s = "Winograd";
+      break;
+  }
+  return s;
+}
 // RAII wrapper for all calls to MIOpen with a MIOpen handle argument.
 //
 // See MIOpenAccess::GetHandle() for details.
@@ -244,7 +264,22 @@ namespace wrap {
   __macro(miopenSetOpArgsBatchNormBackward)                \
   __macro(miopenExecuteFusionPlan)                         \
   __macro(miopenDestroyOperatorArgs)                       \
-  __macro(miopenDestroyFusionPlan)
+  __macro(miopenDestroyFusionPlan)			   \
+  __macro(miopenConvolutionForwardGetSolutionCount)			\
+  __macro(miopenConvolutionForwardGetSolution)				\
+  __macro(miopenConvolutionForwardGetSolutionWorkspaceSize)		\
+  __macro(miopenConvolutionForwardCompileSolution)			\
+  __macro(miopenConvolutionForwardImmediate)				\
+  __macro(miopenConvolutionBackwardDataGetSolutionCount)		\
+  __macro(miopenConvolutionBackwardDataGetSolution)			\
+  __macro(miopenConvolutionBackwardDataGetSolutionWorkspaceSize)	\
+  __macro(miopenConvolutionBackwardDataCompileSolution)			\
+  __macro(miopenConvolutionBackwardDataImmediate)			\
+  __macro(miopenConvolutionBackwardWeightsGetSolutionCount)		\
+  __macro(miopenConvolutionBackwardWeightsGetSolution)			\
+  __macro(miopenConvolutionBackwardWeightsGetSolutionWorkspaceSize)	\
+  __macro(miopenConvolutionBackwardWeightsCompileSolution)		\
+  __macro(miopenConvolutionBackwardWeightsImmediate)
 
 // clang-format on
 
@@ -2617,28 +2652,25 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
 
   auto miopen = miopen_->GetHandle(parent_, stream);
 
-  absl::optional<dnn::AlgorithmDesc> algo_desc = algorithm_config.algorithm();
+  absl::optional<dnn::AlgorithmDesc> input_algo_desc =
+      algorithm_config.algorithm();
   size_t scratch_memory_size;
 
-  if (!algo_desc.has_value()) {
+  miopenStatus_t status = miopenStatusSuccess;
+
+  if (!input_algo_desc.has_value()) {
     // With the default algorithm, use MIOpen's heuristics.
     assert(scratch_allocator);
+
+    assert(kind != dnn::ConvolutionKind::FORWARD);
 
     DeviceMemory<uint8> scratch_memory_temp;
     MIOpenAllocatorContext mac(scratch_allocator, stream);
     wrap::miopenSetAllocator(miopen.handle(), MIOpenAllocatorCallback,
                              MIOpenDeallocatorCallback, &mac);
     size_t size_in_bytes;
-    miopenStatus_t status = miopenStatusSuccess;
 
     switch (kind) {
-      case dnn::ConvolutionKind::FORWARD: {
-        status = wrap::miopenConvolutionForwardGetWorkSpaceSize(
-            miopen.handle(), /*filterDesc=*/filter.handle(),
-            /*srcDesc=*/input_nd.handle(), /*convDesc=*/conv.handle(),
-            /*destDesc=*/output_nd.handle(), /*sizeInBytes=*/&size_in_bytes);
-        break;
-      }
       case dnn::ConvolutionKind::BACKWARD_DATA: {
         status = wrap::miopenConvolutionBackwardDataGetWorkSpaceSize(
             miopen.handle(), /*diffDesc=*/output_nd.handle(),
@@ -2669,22 +2701,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     int returnedAlgoCount;
 
     switch (kind) {
-      case dnn::ConvolutionKind::FORWARD: {
-        auto status = wrap::miopenFindConvolutionForwardAlgorithm(
-            miopen.handle(), input_nd.handle(), input_data.opaque(),
-            filter.handle(), filter_data.opaque(), conv.handle(),
-            output_nd.handle(), output_data.opaque(),
-            /*requestAlgoCount=*/1, &returnedAlgoCount,
-            /*preference=*/&preference,
-            /*workspace*/ scratch_memory_temp.opaque(),
-            /*WorkSpaceSize*/ scratch_memory_temp.size(),
-            /*exhaustiveSearch*/ false);
-        CHECK_EQ(status, miopenStatusSuccess) << "Unable to find a suitable "
-                                                 "algorithm for doing forward "
-                                                 "convolution";
-        *algorithm_desc = dnn::AlgorithmDesc(preference.fwd_algo, false);
-        break;
-      }
       case dnn::ConvolutionKind::BACKWARD_DATA: {
         auto status = wrap::miopenFindConvolutionBackwardDataAlgorithm(
             miopen.handle(),
@@ -2733,8 +2749,56 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     scratch_memory_size = preference.memory;
   } else {
     // An algorithm has been specified.
-    *algorithm_desc = *algo_desc;
-    scratch_memory_size = *(algorithm_config.scratch_size());
+    *algorithm_desc = *input_algo_desc;
+
+    switch (kind) {
+      case dnn::ConvolutionKind::FORWARD: {
+        const uint64_t solution_id = algorithm_desc->algo_id();
+
+        status = wrap::miopenConvolutionForwardGetSolutionWorkspaceSize(
+            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+            output_nd.handle(), solution_id, &scratch_memory_size);
+
+        if (status != miopenStatusSuccess) {
+          return port::InternalError(absl::StrCat(
+              "call to miopenConvolutionForwardGetSolutionWorkspaceSize "
+              "failed: ",
+              ToString(status)));
+        }
+
+        // The call to *CompileSolution solution should be in this routine
+        // in order to ensure the running time measured in the DoConvole step
+        // is accurate (in the sense it does not include the time needed to
+        // do the compile step)
+        //
+        // Having this call here also means that the *CompileSolution routine
+        // will get called more than once for same solution_id, but that should
+        // be okay since the all subsequent calls to *CompileSolution for the
+        // same solution_id will return immediately (they are no-ops)
+        status = wrap::miopenConvolutionForwardCompileSolution(
+            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+            output_nd.handle(), solution_id);
+
+        if (status != miopenStatusSuccess) {
+          return port::InternalError(absl::StrCat(
+              "call to miopenConvolutionForwardCompileSolution failed: ",
+              ToString(status)));
+        }
+
+        break;
+      }
+      case dnn::ConvolutionKind::BACKWARD_DATA: {
+        scratch_memory_size = *(algorithm_config.scratch_size());
+        break;
+      }
+      case dnn::ConvolutionKind::BACKWARD_FILTER: {
+        scratch_memory_size = *(algorithm_config.scratch_size());
+        break;
+      }
+      default:
+        return port::InternalError(absl::StrCat("Unexpected convolution kind ",
+                                                static_cast<int>(kind)));
+    }
   }
 
   // allocate scratch memory
@@ -2849,17 +2913,14 @@ port::Status MIOpenSupport::DoConvolve(
   miopenStatus_t status = miopenStatusSuccess;
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
-      status = wrap::miopenConvolutionForward(
-          miopen.handle(),
-          /*alpha=*/&alpha, /*srcDesc=*/input_nd.handle(),
-          /*srcData=*/input_data.opaque(), /*filterDesc=*/filter.handle(),
-          /*filterData=*/filter_data.opaque(), /*convDesc=*/conv.handle(),
-          /*algo=*/
-          static_cast<miopenConvFwdAlgorithm_t>(algorithm_desc.algo_id()),
-          /*beta=*/&beta, /*destDesc=*/output_nd.handle(),
-          /*destData=*/output_data.opaque(),
-          /*workSpace=*/scratch_memory.opaque(),
-          /*workSpaceSizeInBytes=*/scratch_memory.size());
+      const uint64_t solution_id = algorithm_desc.algo_id();
+
+      status = wrap::miopenConvolutionForwardImmediate(
+          miopen.handle(), filter.handle(), filter_data.opaque(),
+          input_nd.handle(), input_data.opaque(), conv.handle(),
+          output_nd.handle(), output_data.opaque(), scratch_memory.opaque(),
+          scratch_memory.size(), solution_id);
+
       break;
     }
     case dnn::ConvolutionKind::BACKWARD_DATA: {
@@ -2955,6 +3016,136 @@ bool MIOpenSupport::GetConvolveAlgorithms(
       dnn::AlgorithmDesc(miopenConvolutionFwdAlgoWinograd, false),
       // clang-format on
   });
+  return true;
+}
+
+bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
+    dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<dnn::AlgorithmDesc>* out_algorithms) {
+  auto miopen = miopen_->GetHandle(parent_, stream);
+
+  ScopedTensorDescriptor input{input_descriptor,
+                               ToMIOpenDataType(element_type)};
+  ScopedTensorDescriptor output{output_descriptor,
+                                ToMIOpenDataType(element_type)};
+  ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
+                                ToMIOpenDataType(element_type)};
+  ScopedConvolutionDescriptor conv{convolution_descriptor,
+                                   ToMIOpenDataType(element_type)};
+
+  // First determine the number of algorityhms available
+  size_t maxSolutionCount = 0;
+
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      auto status = wrap::miopenConvolutionForwardGetSolutionCount(
+          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
+          output.handle(), &maxSolutionCount);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionForwardGetSolutionCount failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      auto status = wrap::miopenConvolutionBackwardDataGetSolutionCount(
+          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
+          output.handle(), &maxSolutionCount);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionBackwardDataGetSolutionCount failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      auto status = wrap::miopenConvolutionBackwardWeightsGetSolutionCount(
+          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
+          output.handle(), &maxSolutionCount);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionBackwardWeightsGetSolutionCount "
+               "failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Unexpected convolution kind " << static_cast<int>(kind);
+      return false;
+      break;
+    }
+  }
+
+  VLOG(kImmediateModeVlogLevel)
+      << "Number of conv solutions max: " << maxSolutionCount;
+
+  size_t solutionCount = 0;
+  std::unique_ptr<miopenConvSolution_t[]> solutions(
+      new miopenConvSolution_t[maxSolutionCount]);
+
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      auto status = wrap::miopenConvolutionForwardGetSolution(
+          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
+          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL) << "call to miopenConvolutionForwardGetSolution failed: "
+                   << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      auto status = wrap::miopenConvolutionBackwardDataGetSolution(
+          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
+          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionBackwardDataGetSolution failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      auto status = wrap::miopenConvolutionBackwardWeightsGetSolution(
+          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
+          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL)
+            << "call to miopenConvolutionBackwardWeightsGetSolution failed: "
+            << ToString(status);
+        return false;
+      }
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Unexpected convolution kind " << static_cast<int>(kind);
+      return false;
+      break;
+    }
+  }
+
+  VLOG(kImmediateModeVlogLevel)
+      << "Number of conv solutions actual: " << solutionCount;
+  for (int i = 0; i < solutionCount; i++) {
+    miopenConvSolution_t solution = solutions[i];
+    VLOG(kImmediateModeVlogLevel)
+        << "solution " << i << " (time, mem, id, algo) =  " << solution.time
+        << ", " << solution.workspace_size << ", " << solution.solution_id
+        << ", " << ToString(solution.algorithm);
+    out_algorithms->emplace_back(solution.solution_id, false);
+  }
+
   return true;
 }
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2654,152 +2654,112 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
 
   absl::optional<dnn::AlgorithmDesc> input_algo_desc =
       algorithm_config.algorithm();
-  size_t scratch_memory_size;
 
-  miopenStatus_t status = miopenStatusSuccess;
+  assert(input_algo_desc.has_value());
 
-  if (!input_algo_desc.has_value()) {
-    // With the default algorithm, use MIOpen's heuristics.
-    assert(scratch_allocator);
+  // An algorithm has been specified.
+  *algorithm_desc = *input_algo_desc;
 
-    assert(kind != dnn::ConvolutionKind::FORWARD);
+  const uint64_t solution_id = algorithm_desc->algo_id();
 
-    DeviceMemory<uint8> scratch_memory_temp;
-    MIOpenAllocatorContext mac(scratch_allocator, stream);
-    wrap::miopenSetAllocator(miopen.handle(), MIOpenAllocatorCallback,
-                             MIOpenDeallocatorCallback, &mac);
-    size_t size_in_bytes;
+  size_t scratch_memory_size = 0;
 
-    switch (kind) {
-      case dnn::ConvolutionKind::BACKWARD_DATA: {
-        status = wrap::miopenConvolutionBackwardDataGetWorkSpaceSize(
-            miopen.handle(), /*diffDesc=*/output_nd.handle(),
-            /*filterDesc=*/filter.handle(), /*convDesc=*/conv.handle(),
-            /*gradDesc=*/input_nd.handle(), /*sizeInBytes=*/&size_in_bytes);
-        break;
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      auto status = wrap::miopenConvolutionForwardGetSolutionWorkspaceSize(
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), solution_id, &scratch_memory_size);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionForwardGetSolutionWorkspaceSize "
+            "failed: ",
+            ToString(status)));
       }
-      case dnn::ConvolutionKind::BACKWARD_FILTER: {
-        status = wrap::miopenConvolutionBackwardWeightsGetWorkSpaceSize(
-            miopen.handle(), /*diffDesc=*/output_nd.handle(),
-            /*srcDesc=*/input_nd.handle(), /*convDesc=*/conv.handle(),
-            /*gradDesc=*/filter.handle(), /*sizeInBytes=*/&size_in_bytes);
-        break;
+
+      // The call to *CompileSolution solution should be in this routine
+      // in order to ensure the running time measured in the DoConvole step
+      // is accurate (in the sense it does not include the time needed to
+      // do the compile step)
+      //
+      // Having this call here also means that the *CompileSolution routine
+      // will get called more than once for same solution_id, but that should
+      // be okay since the all subsequent calls to *CompileSolution for the
+      // same solution_id will return immediately (they are no-ops)
+      status = wrap::miopenConvolutionForwardCompileSolution(
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), solution_id);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionForwardCompileSolution failed: ",
+            ToString(status)));
       }
-      default:
-        return port::InternalError(absl::StrCat("Unexpected convolution kind ",
-                                                static_cast<int>(kind)));
+
+      break;
     }
 
-    if (status == miopenStatusSuccess && size_in_bytes != 0) {
-      auto allocated = scratch_allocator->AllocateBytes(stream, size_in_bytes);
-      if (allocated.ok()) {
-        scratch_memory_temp = allocated.ValueOrDie();
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      auto status = wrap::miopenConvolutionBackwardDataGetSolutionWorkspaceSize(
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), solution_id, &scratch_memory_size);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionabckwardDataGetSolutionWorkspaceSize "
+            "failed: ",
+            ToString(status)));
       }
+
+      status = wrap::miopenConvolutionBackwardDataCompileSolution(
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), solution_id);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionBackwardDataCompileSolution failed: ",
+            ToString(status)));
+      }
+
+      break;
     }
 
-    miopenConvAlgoPerf_t preference;
-    int returnedAlgoCount;
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      auto status =
+          wrap::miopenConvolutionBackwardWeightsGetSolutionWorkspaceSize(
+              miopen.handle(), output_nd.handle(), input_nd.handle(),
+              conv.handle(), filter.handle(), solution_id,
+              &scratch_memory_size);
 
-    switch (kind) {
-      case dnn::ConvolutionKind::BACKWARD_DATA: {
-        auto status = wrap::miopenFindConvolutionBackwardDataAlgorithm(
-            miopen.handle(),
-            /*diffDesc=*/output_nd.handle(), output_data.opaque(),
-            /*filterDesc=*/filter.handle(), filter_data.opaque(),
-            /*convDesc=*/conv.handle(),
-            /*gradDesc=*/input_nd.handle(), input_data.opaque(),
-            /*requestCount=*/1, /*returnedAlgoCount=*/&returnedAlgoCount,
-            /*preference=*/&preference,
-            /*WorkSpace=*/scratch_memory_temp.opaque(),
-            /*WorkSpaceSize=*/scratch_memory_temp.size(),
-            /*exhaustiveSearch=*/false);
-        CHECK_EQ(status, miopenStatusSuccess) << "Unable to find a suitable "
-                                                 "algorithm for doing backward "
-                                                 "data convolution";
-        *algorithm_desc = dnn::AlgorithmDesc(preference.bwd_data_algo, false);
-        break;
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionabckwardWeightsGetSolutionWorkspaceSize "
+            "failed: ",
+            ToString(status)));
       }
-      case dnn::ConvolutionKind::BACKWARD_FILTER: {
-        auto status = wrap::miopenFindConvolutionBackwardWeightsAlgorithm(
-            miopen.handle(),
-            /*diffDesc=*/output_nd.handle(), output_data.opaque(),
-            /*srcDesc=*/input_nd.handle(), input_data.opaque(),
-            /*convDesc=*/conv.handle(),
-            /*gradDesc=*/filter.handle(), filter_data.opaque(),
-            /*requestAlgoCount=*/1, /*returnedAlgoCount=*/&returnedAlgoCount,
-            /*preference=*/&preference,
-            /*WorkSpace=*/scratch_memory_temp.opaque(),
-            /*WorkSpaceSize=*/scratch_memory_temp.size(),
-            /*exhaustiveSearch=*/false);
-        CHECK_EQ(status, miopenStatusSuccess) << "Unable to find a suitable "
-                                                 "algorithm for doing backward "
-                                                 "filter convolution";
-        *algorithm_desc =
-            dnn::AlgorithmDesc(preference.bwd_weights_algo, false);
-        break;
+
+      status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), solution_id);
+
+      if (status != miopenStatusSuccess) {
+        return port::InternalError(absl::StrCat(
+            "call to miopenConvolutionBackwardWeightsCompileSolution failed: ",
+            ToString(status)));
       }
-      default:
-        return port::InternalError(absl::StrCat("Unexpected convolution kind ",
-                                                static_cast<int>(kind)));
+      break;
     }
 
-    // Restore default allocator, note mac is stack temp
-    wrap::miopenSetAllocator(miopen.handle(), nullptr, nullptr, nullptr);
-
-    scratch_memory_size = preference.memory;
-  } else {
-    // An algorithm has been specified.
-    *algorithm_desc = *input_algo_desc;
-
-    switch (kind) {
-      case dnn::ConvolutionKind::FORWARD: {
-        const uint64_t solution_id = algorithm_desc->algo_id();
-
-        status = wrap::miopenConvolutionForwardGetSolutionWorkspaceSize(
-            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-            output_nd.handle(), solution_id, &scratch_memory_size);
-
-        if (status != miopenStatusSuccess) {
-          return port::InternalError(absl::StrCat(
-              "call to miopenConvolutionForwardGetSolutionWorkspaceSize "
-              "failed: ",
-              ToString(status)));
-        }
-
-        // The call to *CompileSolution solution should be in this routine
-        // in order to ensure the running time measured in the DoConvole step
-        // is accurate (in the sense it does not include the time needed to
-        // do the compile step)
-        //
-        // Having this call here also means that the *CompileSolution routine
-        // will get called more than once for same solution_id, but that should
-        // be okay since the all subsequent calls to *CompileSolution for the
-        // same solution_id will return immediately (they are no-ops)
-        status = wrap::miopenConvolutionForwardCompileSolution(
-            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-            output_nd.handle(), solution_id);
-
-        if (status != miopenStatusSuccess) {
-          return port::InternalError(absl::StrCat(
-              "call to miopenConvolutionForwardCompileSolution failed: ",
-              ToString(status)));
-        }
-
-        break;
-      }
-      case dnn::ConvolutionKind::BACKWARD_DATA: {
-        scratch_memory_size = *(algorithm_config.scratch_size());
-        break;
-      }
-      case dnn::ConvolutionKind::BACKWARD_FILTER: {
-        scratch_memory_size = *(algorithm_config.scratch_size());
-        break;
-      }
-      default:
-        return port::InternalError(absl::StrCat("Unexpected convolution kind ",
-                                                static_cast<int>(kind)));
+    default: {
+      return port::InternalError(
+          absl::StrCat("Unexpected convolution kind ", static_cast<int>(kind)));
+      break;
     }
   }
+
+  VLOG(kImmediateModeVlogLevel)
+      << "miopen...GetSolutionWorkspaceSize returned " << scratch_memory_size
+      << " for solution_id " << solution_id;
 
   // allocate scratch memory
   if (scratch_memory_size != 0) {
@@ -2910,10 +2870,11 @@ port::Status MIOpenSupport::DoConvolve(
     }
   }
 
+  const uint64_t solution_id = algorithm_desc.algo_id();
+
   miopenStatus_t status = miopenStatusSuccess;
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
-      const uint64_t solution_id = algorithm_desc.algo_id();
 
       status = wrap::miopenConvolutionForwardImmediate(
           miopen.handle(), filter.handle(), filter_data.opaque(),
@@ -2932,21 +2893,11 @@ port::Status MIOpenSupport::DoConvolve(
           stream, miopen.handle(), ToMIOpenDataType(element_type),
           &output_back_descriptor, output_data, &transform_scratch);
 
-      status = wrap::miopenConvolutionBackwardData(
-          miopen.handle(),
-          /*alpha=*/&alpha,
-          /*diffDesc=*/output_nd.handle(),
-          /*diffData=*/output_data.opaque(),
-          /*filterDesc=*/filter.handle(),
-          /*filterData=*/filter_data.opaque(),
-          /*convDesc=*/conv.handle(),
-          /*algo=*/
-          static_cast<miopenConvBwdDataAlgorithm_t>(algorithm_desc.algo_id()),
-          /*beta=*/&beta,
-          /*gradDesc=*/input_nd.handle(),
-          /*gradData=*/input_data.opaque(),
-          /*workSpace=*/scratch_memory.opaque(),
-          /*workSpaceSizeInBytes=*/scratch_memory.size());
+      status = wrap::miopenConvolutionBackwardDataImmediate(
+          miopen.handle(), output_nd.handle(), output_data.opaque(),
+          filter.handle(), filter_data.opaque(), conv.handle(),
+          input_nd.handle(), input_data.opaque(), scratch_memory.opaque(),
+          scratch_memory.size(), solution_id);
       break;
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
@@ -2958,22 +2909,11 @@ port::Status MIOpenSupport::DoConvolve(
           stream, miopen.handle(), ToMIOpenDataType(element_type),
           &output_back_descriptor, output_data, &transform_scratch);
 
-      status = wrap::miopenConvolutionBackwardWeights(
-          miopen.handle(),
-          /*alpha=*/&alpha,
-          /*diffDesc=*/output_nd.handle(),
-          /*diffData=*/output_data.opaque(),
-          /*srcDesc=*/input_nd.handle(),
-          /*srcData=*/input_data.opaque(),
-          /*convDesc=*/conv.handle(),
-          /*algo=*/
-          static_cast<miopenConvBwdWeightsAlgorithm_t>(
-              algorithm_desc.algo_id()),
-          /*beta=*/&beta,
-          /*gradDesc=*/filter.handle(),
-          /*gradData=*/filter_data.opaque(),
-          /*workSpace=*/scratch_memory.opaque(),
-          /*workSpaceSizeInBytes=*/scratch_memory.size());
+      status = wrap::miopenConvolutionBackwardWeightsImmediate(
+          miopen.handle(), output_nd.handle(), output_data.opaque(),
+          input_nd.handle(), input_data.opaque(), conv.handle(),
+          filter.handle(), filter_data.opaque(), scratch_memory.opaque(),
+          scratch_memory.size(), solution_id);
       break;
     }
     default:
@@ -3028,10 +2968,10 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
   auto miopen = miopen_->GetHandle(parent_, stream);
 
-  ScopedTensorDescriptor input{input_descriptor,
-                               ToMIOpenDataType(element_type)};
-  ScopedTensorDescriptor output{output_descriptor,
-                                ToMIOpenDataType(element_type)};
+  ScopedTensorDescriptor input_nd{input_descriptor,
+                                  ToMIOpenDataType(element_type)};
+  ScopedTensorDescriptor output_nd{output_descriptor,
+                                   ToMIOpenDataType(element_type)};
   ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
                                 ToMIOpenDataType(element_type)};
   ScopedConvolutionDescriptor conv{convolution_descriptor,
@@ -3043,8 +2983,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenConvolutionForwardGetSolutionCount(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), &maxSolutionCount);
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), &maxSolutionCount);
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionForwardGetSolutionCount failed: "
@@ -3055,8 +2995,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_DATA: {
       auto status = wrap::miopenConvolutionBackwardDataGetSolutionCount(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), &maxSolutionCount);
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), &maxSolutionCount);
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardDataGetSolutionCount failed: "
@@ -3067,8 +3007,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
       auto status = wrap::miopenConvolutionBackwardWeightsGetSolutionCount(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), &maxSolutionCount);
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), &maxSolutionCount);
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardWeightsGetSolutionCount "
@@ -3095,8 +3035,9 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
       auto status = wrap::miopenConvolutionForwardGetSolution(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+          output_nd.handle(), maxSolutionCount, &solutionCount,
+          solutions.get());
       if (status != miopenStatusSuccess) {
         LOG(FATAL) << "call to miopenConvolutionForwardGetSolution failed: "
                    << ToString(status);
@@ -3106,8 +3047,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_DATA: {
       auto status = wrap::miopenConvolutionBackwardDataGetSolution(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+          input_nd.handle(), maxSolutionCount, &solutionCount, solutions.get());
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardDataGetSolution failed: "
@@ -3118,8 +3059,8 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
       auto status = wrap::miopenConvolutionBackwardWeightsGetSolution(
-          miopen.handle(), filter.handle(), input.handle(), conv.handle(),
-          output.handle(), maxSolutionCount, &solutionCount, solutions.get());
+          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
+          filter.handle(), maxSolutionCount, &solutionCount, solutions.get());
       if (status != miopenStatusSuccess) {
         LOG(FATAL)
             << "call to miopenConvolutionBackwardWeightsGetSolution failed: "

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2717,9 +2717,8 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     }
   }
 
-  VLOG(2)
-      << "miopen...GetSolutionWorkspaceSize returned " << scratch_memory_size
-      << " for solution_id " << solution_id;
+  VLOG(2) << "miopen...GetSolutionWorkspaceSize returned "
+          << scratch_memory_size << " for solution_id " << solution_id;
 
   // allocate scratch memory
   if (scratch_memory_size != 0) {
@@ -2835,7 +2834,6 @@ port::Status MIOpenSupport::DoConvolve(
   miopenStatus_t status = miopenStatusSuccess;
   switch (kind) {
     case dnn::ConvolutionKind::FORWARD: {
-
       status = wrap::miopenConvolutionForwardImmediate(
           miopen.handle(), filter.handle(), filter_data.opaque(),
           input_nd.handle(), input_data.opaque(), conv.handle(),

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2676,26 +2676,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
             "failed: ",
             ToString(status)));
       }
-
-      // The call to *CompileSolution solution should be in this routine
-      // in order to ensure the running time measured in the DoConvole step
-      // is accurate (in the sense it does not include the time needed to
-      // do the compile step)
-      //
-      // Having this call here also means that the *CompileSolution routine
-      // will get called more than once for same solution_id, but that should
-      // be okay since the all subsequent calls to *CompileSolution for the
-      // same solution_id will return immediately (they are no-ops)
-      status = wrap::miopenConvolutionForwardCompileSolution(
-          miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-          output_nd.handle(), solution_id);
-
-      if (status != miopenStatusSuccess) {
-        return port::InternalError(absl::StrCat(
-            "call to miopenConvolutionForwardCompileSolution failed: ",
-            ToString(status)));
-      }
-
       break;
     }
 
@@ -2710,17 +2690,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
             "failed: ",
             ToString(status)));
       }
-
-      status = wrap::miopenConvolutionBackwardDataCompileSolution(
-          miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
-          input_nd.handle(), solution_id);
-
-      if (status != miopenStatusSuccess) {
-        return port::InternalError(absl::StrCat(
-            "call to miopenConvolutionBackwardDataCompileSolution failed: ",
-            ToString(status)));
-      }
-
       break;
     }
 
@@ -2737,16 +2706,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
             "failed: ",
             ToString(status)));
       }
-
-      status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
-          miopen.handle(), output_nd.handle(), input_nd.handle(), conv.handle(),
-          filter.handle(), solution_id);
-
-      if (status != miopenStatusSuccess) {
-        return port::InternalError(absl::StrCat(
-            "call to miopenConvolutionBackwardWeightsCompileSolution failed: ",
-            ToString(status)));
-      }
       break;
     }
 
@@ -2757,7 +2716,7 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
     }
   }
 
-  VLOG(kImmediateModeVlogLevel)
+  VLOG(2)
       << "miopen...GetSolutionWorkspaceSize returned " << scratch_memory_size
       << " for solution_id " << solution_id;
 
@@ -3038,13 +2997,30 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
           miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
           output_nd.handle(), maxSolutionCount, &solutionCount,
           solutions.get());
+
       if (status != miopenStatusSuccess) {
         LOG(FATAL) << "call to miopenConvolutionForwardGetSolution failed: "
                    << ToString(status);
         return false;
       }
+
+      for (int i = 0; i < solutionCount; i++) {
+        miopenConvSolution_t solution = solutions[i];
+
+        status = wrap::miopenConvolutionForwardCompileSolution(
+            miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
+            output_nd.handle(), solution.solution_id);
+
+        if (status != miopenStatusSuccess) {
+          LOG(FATAL)
+              << "call to miopenConvolutionForwardCompileSolution failed: "
+              << ToString(status);
+          return false;
+        }
+      }
       break;
     }
+
     case dnn::ConvolutionKind::BACKWARD_DATA: {
       auto status = wrap::miopenConvolutionBackwardDataGetSolution(
           miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
@@ -3054,6 +3030,21 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
             << "call to miopenConvolutionBackwardDataGetSolution failed: "
             << ToString(status);
         return false;
+      }
+
+      for (int i = 0; i < solutionCount; i++) {
+        miopenConvSolution_t solution = solutions[i];
+
+        status = wrap::miopenConvolutionBackwardDataCompileSolution(
+            miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
+            input_nd.handle(), solution.solution_id);
+
+        if (status != miopenStatusSuccess) {
+          LOG(FATAL) << " call to miopenConvolutionBackwardDataCompileSolution "
+                        "failed: "
+                     << ToString(status);
+          return false;
+        }
       }
       break;
     }
@@ -3066,6 +3057,22 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
             << "call to miopenConvolutionBackwardWeightsGetSolution failed: "
             << ToString(status);
         return false;
+      }
+
+      for (int i = 0; i < solutionCount; i++) {
+        miopenConvSolution_t solution = solutions[i];
+
+        status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
+            miopen.handle(), output_nd.handle(), input_nd.handle(),
+            conv.handle(), filter.handle(), solution.solution_id);
+
+        if (status != miopenStatusSuccess) {
+          LOG(FATAL)
+              << "call to miopenConvolutionBackwardWeightsCompileSolution "
+                 "failed: "
+              << ToString(status);
+          return false;
+        }
       }
       break;
     }

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -19,9 +19,9 @@ limitations under the License.
 #include <memory>
 
 #include "absl/strings/str_cat.h"
-#include "third_party/eigen3/Eigen/Core"
 #include "rocm/include/miopen/miopen.h"
 #include "tensorflow/core/lib/hash/hash.h"
+#include "tensorflow/core/util/env_var.h"
 #include "tensorflow/stream_executor/dnn.h"
 #include "tensorflow/stream_executor/gpu/gpu_activation.h"
 #include "tensorflow/stream_executor/gpu/gpu_driver.h"
@@ -40,6 +40,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/scratch_allocator.h"
 #include "tensorflow/stream_executor/stream.h"
 #include "tensorflow/stream_executor/stream_executor_pimpl.h"
+#include "third_party/eigen3/Eigen/Core"
 
 namespace {
 
@@ -2987,6 +2988,16 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
   VLOG(kImmediateModeVlogLevel)
       << "Number of conv solutions max: " << maxSolutionCount;
 
+  // if the env var TF_ROCM_MIMIC_FIND_MODE is set, determine the best solution
+  // as per the "runtime" information for each solution (returned by the prior
+  // call to the *GetSolution api), and then return only the best solution
+  // The idea here is to mimic the old "find" mode, in which we relied upon
+  // the miopen api to determine the best solution, and use that solution
+  // without doing any further measurement in the TF layer
+  bool mimic_find_mode = false;
+  tensorflow::ReadBoolFromEnvVar("TF_ROCM_MIMIC_FIND_MODE", false,
+                                 &mimic_find_mode);
+
   size_t solutionCount = 0;
   std::unique_ptr<miopenConvSolution_t[]> solutions(
       new miopenConvSolution_t[maxSolutionCount]);
@@ -3004,18 +3015,58 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         return false;
       }
 
-      for (int i = 0; i < solutionCount; i++) {
-        miopenConvSolution_t solution = solutions[i];
+      VLOG(kImmediateModeVlogLevel)
+          << "Number of conv solutions actual: " << solutionCount;
+
+      if (mimic_find_mode) {
+        miopenConvSolution_t best_solution = solutions[0];
+
+        for (int i = 1; i < solutionCount; i++) {
+          miopenConvSolution_t solution = solutions[i];
+          if (solution.time < best_solution.time) {
+            best_solution = solution;
+          }
+        }
+
+        VLOG(kImmediateModeVlogLevel)
+            << "Best Solution (id, algo) = " << best_solution.solution_id
+            << ", " << ToString(best_solution.algorithm);
 
         status = wrap::miopenConvolutionForwardCompileSolution(
             miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-            output_nd.handle(), solution.solution_id);
+            output_nd.handle(), best_solution.solution_id);
 
         if (status != miopenStatusSuccess) {
-          LOG(FATAL)
-              << "call to miopenConvolutionForwardCompileSolution failed: "
-              << ToString(status);
+          LOG(FATAL) << "call to miopenConvolutionForwardCompileSolution "
+                        "failed: "
+                     << ToString(status);
           return false;
+        }
+
+        out_algorithms->emplace_back(best_solution.solution_id, false);
+
+      } else {
+        for (int i = 0; i < solutionCount; i++) {
+          miopenConvSolution_t solution = solutions[i];
+
+          VLOG(kImmediateModeVlogLevel)
+              << "solution " << i
+              << " (time, mem, id, algo) =  " << solution.time << ", "
+              << solution.workspace_size << ", " << solution.solution_id << ", "
+              << ToString(solution.algorithm);
+
+          status = wrap::miopenConvolutionForwardCompileSolution(
+              miopen.handle(), filter.handle(), input_nd.handle(),
+              conv.handle(), output_nd.handle(), solution.solution_id);
+
+          if (status != miopenStatusSuccess) {
+            LOG(FATAL)
+                << "call to miopenConvolutionForwardCompileSolution failed: "
+                << ToString(status);
+            return false;
+          }
+
+          out_algorithms->emplace_back(solution.solution_id, false);
         }
       }
       break;
@@ -3032,18 +3083,59 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         return false;
       }
 
-      for (int i = 0; i < solutionCount; i++) {
-        miopenConvSolution_t solution = solutions[i];
+      VLOG(kImmediateModeVlogLevel)
+          << "Number of conv solutions actual: " << solutionCount;
+
+      if (mimic_find_mode) {
+        miopenConvSolution_t best_solution = solutions[0];
+
+        for (int i = 1; i < solutionCount; i++) {
+          miopenConvSolution_t solution = solutions[i];
+          if (solution.time < best_solution.time) {
+            best_solution = solution;
+          }
+        }
+
+        VLOG(kImmediateModeVlogLevel)
+            << "Best Solution (id, algo) = " << best_solution.solution_id
+            << ", " << ToString(best_solution.algorithm);
 
         status = wrap::miopenConvolutionBackwardDataCompileSolution(
             miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
-            input_nd.handle(), solution.solution_id);
+            input_nd.handle(), best_solution.solution_id);
 
         if (status != miopenStatusSuccess) {
-          LOG(FATAL) << " call to miopenConvolutionBackwardDataCompileSolution "
+          LOG(FATAL) << "call to miopenConvolutionBackwardDataCompileSolution "
                         "failed: "
                      << ToString(status);
           return false;
+        }
+
+        out_algorithms->emplace_back(best_solution.solution_id, false);
+
+      } else {
+        for (int i = 0; i < solutionCount; i++) {
+          miopenConvSolution_t solution = solutions[i];
+
+          VLOG(kImmediateModeVlogLevel)
+              << "solution " << i
+              << " (time, mem, id, algo) =  " << solution.time << ", "
+              << solution.workspace_size << ", " << solution.solution_id << ", "
+              << ToString(solution.algorithm);
+
+          status = wrap::miopenConvolutionBackwardDataCompileSolution(
+              miopen.handle(), output_nd.handle(), filter.handle(),
+              conv.handle(), input_nd.handle(), solution.solution_id);
+
+          if (status != miopenStatusSuccess) {
+            LOG(FATAL)
+                << " call to miopenConvolutionBackwardDataCompileSolution "
+                   "failed: "
+                << ToString(status);
+            return false;
+          }
+
+          out_algorithms->emplace_back(solution.solution_id, false);
         }
       }
       break;
@@ -3059,12 +3151,26 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         return false;
       }
 
-      for (int i = 0; i < solutionCount; i++) {
-        miopenConvSolution_t solution = solutions[i];
+      VLOG(kImmediateModeVlogLevel)
+          << "Number of conv solutions actual: " << solutionCount;
+
+      if (mimic_find_mode) {
+        miopenConvSolution_t best_solution = solutions[0];
+
+        for (int i = 1; i < solutionCount; i++) {
+          miopenConvSolution_t solution = solutions[i];
+          if (solution.time < best_solution.time) {
+            best_solution = solution;
+          }
+        }
+
+        VLOG(kImmediateModeVlogLevel)
+            << "Best Solution (id, algo) = " << best_solution.solution_id
+            << ", " << ToString(best_solution.algorithm);
 
         status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
             miopen.handle(), output_nd.handle(), input_nd.handle(),
-            conv.handle(), filter.handle(), solution.solution_id);
+            conv.handle(), filter.handle(), best_solution.solution_id);
 
         if (status != miopenStatusSuccess) {
           LOG(FATAL)
@@ -3072,6 +3178,33 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
                  "failed: "
               << ToString(status);
           return false;
+        }
+
+        out_algorithms->emplace_back(best_solution.solution_id, false);
+
+      } else {
+        for (int i = 0; i < solutionCount; i++) {
+          miopenConvSolution_t solution = solutions[i];
+
+          VLOG(kImmediateModeVlogLevel)
+              << "solution " << i
+              << " (time, mem, id, algo) =  " << solution.time << ", "
+              << solution.workspace_size << ", " << solution.solution_id << ", "
+              << ToString(solution.algorithm);
+
+          status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
+              miopen.handle(), output_nd.handle(), input_nd.handle(),
+              conv.handle(), filter.handle(), solution.solution_id);
+
+          if (status != miopenStatusSuccess) {
+            LOG(FATAL)
+                << "call to miopenConvolutionBackwardWeightsCompileSolution "
+                   "failed: "
+                << ToString(status);
+            return false;
+          }
+
+          out_algorithms->emplace_back(solution.solution_id, false);
         }
       }
       break;
@@ -3081,17 +3214,6 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
       return false;
       break;
     }
-  }
-
-  VLOG(kImmediateModeVlogLevel)
-      << "Number of conv solutions actual: " << solutionCount;
-  for (int i = 0; i < solutionCount; i++) {
-    miopenConvSolution_t solution = solutions[i];
-    VLOG(kImmediateModeVlogLevel)
-        << "solution " << i << " (time, mem, id, algo) =  " << solution.time
-        << ", " << solution.workspace_size << ", " << solution.solution_id
-        << ", " << ToString(solution.algorithm);
-    out_algorithms->emplace_back(solution.solution_id, false);
   }
 
   return true;

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -194,6 +194,14 @@ class MIOpenSupport : public dnn::DnnSupport {
       bool with_winograd_nonfused, int cc_major, int cc_minor,
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
+  bool GetMIOpenConvolveAlgorithms(
+      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
+
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -290,6 +290,22 @@ bool StreamExecutor::GetConvolveAlgorithms(
                                             cc_minor, out_algorithms);
 }
 
+bool StreamExecutor::GetMIOpenConvolveAlgorithms(
+    dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+    const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    std::vector<dnn::AlgorithmDesc>* out_algorithms) {
+  dnn::DnnSupport* dnn_support = AsDnn();
+  if (!dnn_support) {
+    return false;
+  }
+  return dnn_support->GetMIOpenConvolveAlgorithms(
+      kind, stream, element_type, input_descriptor, filter_descriptor,
+      convolution_descriptor, output_descriptor, out_algorithms);
+}
+
 bool StreamExecutor::GetRnnAlgorithms(
     std::vector<dnn::AlgorithmDesc> *out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -374,6 +374,16 @@ class StreamExecutor {
   bool GetConvolveAlgorithms(bool with_winograd_nonfused,
                              std::vector<dnn::AlgorithmDesc> *out_algorithms);
 
+  // Returns the list of supported algorithms for the forward convolution
+  // operation.
+  bool GetMIOpenConvolveAlgorithms(
+      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      std::vector<dnn::AlgorithmDesc>* out_algorithms);
+
   // Returns the list of supported algorithms for rnn operation.
   bool GetRnnAlgorithms(std::vector<dnn::AlgorithmDesc> *out_algorithms);
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -105,6 +105,12 @@ RUN bash -c 'echo -e "gfx803\ngfx900\ngfx906" >> /opt/rocm/bin/target.lst'
 #    CXX=/opt/rocm/hcc/bin/hcc cmake -DMIOPEN_BACKEND=HIP -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip" -D#CMAKE_CXX_FLAGS="-isystem /usr/include/x86_64-linux-gnu/" .. -DMIOPEN_MAKE_BOOST_PUBLIC=ON && \
 #    make -j $(nproc) && make package && dpkg -i ./MIOpen*.deb
 
+
+# Use the version of MIOpen from the develop branch.
+# It has fixes that bring immediate mode performance on par with Find mode.
+# Without these fixes, immediate mode is very slow!
+RUN cd $HOME && wget https://www.dropbox.com/s/1vtjoo8p87l7v0c/MIOpen-HIP-2.1.0-4c55c24-Linux.deb && dpkg -i ./MIOpen-HIP-2.1.0-4c55c24-Linux.deb
+
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This is the final (barring code review feedback updates) version of the code to integrate MIOpen Immediate Mode into the TF layer.

Notes
* CI runs will continue to fail until we upgrade to ROCm 2.6.
  The failure will be because the new Immediate Mode API is not present in the header files included in ROCm 2.5 and lower.
* best to review this PR commit by commit
* Immediate Mode replaces the existing "Find" mode, (i.e. there is no way to switch back to "Find" mode) Assumption is that once this PR gets merged, we will say bye-bye to Find mode (atleast as far as the TF Layer is concerned)

------------------------------------------------------

@whchung @jerryyin 