### PR TITLE
[XLA:GPU] Introduce platform_id_ member variable

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -384,7 +384,13 @@ Status PrepareHloModuleForIrEmitting(HloModule* hlo_module) {
 
 AMDGPUCompiler::AMDGPUCompiler()
     : pointer_size_(llvm::DataLayout(kDataLayout)
-                        .getPointerSize(0 /* default address space */)) {}
+                        .getPointerSize(0 /* default address space */)),
+      platform_id_(se::rocm::kROCmPlatformId) {}
+
+AMDGPUCompiler::AMDGPUCompiler(se::Platform::Id platform_id)
+    : pointer_size_(llvm::DataLayout(kDataLayout)
+                        .getPointerSize(0 /* default address space */)),
+      platform_id_(platform_id) {}
 
 StatusOr<std::unique_ptr<HloModule>> AMDGPUCompiler::RunHloPasses(
     std::unique_ptr<HloModule> module, se::StreamExecutor* stream_exec,

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -562,7 +562,7 @@ AMDGPUCompiler::CompileAheadOfTime(std::unique_ptr<HloModuleGroup> module_group,
 }
 
 se::Platform::Id AMDGPUCompiler::PlatformId() const {
-  return se::rocm::kROCmPlatformId;
+  return platform_id_;
 }
 
 }  // namespace gpu
@@ -571,7 +571,7 @@ se::Platform::Id AMDGPUCompiler::PlatformId() const {
 static bool InitModule() {
   xla::Compiler::RegisterCompilerFactory(
       stream_executor::rocm::kROCmPlatformId,
-      []() { return absl::make_unique<xla::gpu::AMDGPUCompiler>(); });
+      []() { return absl::make_unique<xla::gpu::AMDGPUCompiler>(stream_executor::rocm::kROCmPlatformId); });
   return true;
 }
 static bool module_initialized = InitModule();

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
@@ -39,7 +39,7 @@ namespace gpu {
 // The GPU compiler generates efficient GPU executables.
 class AMDGPUCompiler : public LLVMCompiler {
  public:
-  AMDGPUCompiler();
+  AMDGPUCompiler(se::Platform::Id platform_id);
   ~AMDGPUCompiler() override {}
 
   // Bring in
@@ -79,6 +79,8 @@ class AMDGPUCompiler : public LLVMCompiler {
   static const char* kDataLayout;
 
  private:
+  se::Platform::Id platform_id_;
+
   // The size in bytes of a pointer. Used by ShapeSizeBytesFunction.
   const int64 pointer_size_;
 

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
@@ -39,6 +39,7 @@ namespace gpu {
 // The GPU compiler generates efficient GPU executables.
 class AMDGPUCompiler : public LLVMCompiler {
  public:
+  AMDGPUCompiler();
   AMDGPUCompiler(se::Platform::Id platform_id);
   ~AMDGPUCompiler() override {}
 

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
@@ -456,9 +456,10 @@ void WarnIfBadDriverJITVersion() {
 
 }  // namespace
 
-NVPTXCompiler::NVPTXCompiler()
+NVPTXCompiler::NVPTXCompiler(se::Platform::Id platform_id)
     : pointer_size_(llvm::DataLayout(kDataLayout)
-                        .getPointerSize(0 /* default address space */)) {}
+                        .getPointerSize(0 /* default address space */)),
+      platform_id_(platform_id) {}
 
 StatusOr<std::unique_ptr<HloModule>> NVPTXCompiler::RunHloPasses(
     std::unique_ptr<HloModule> module, se::StreamExecutor* stream_exec,
@@ -734,7 +735,7 @@ NVPTXCompiler::CompileAheadOfTime(std::unique_ptr<HloModuleGroup> module_group,
 }
 
 se::Platform::Id NVPTXCompiler::PlatformId() const {
-  return se::cuda::kCudaPlatformId;
+  return platform_id_;
 }
 
 }  // namespace gpu
@@ -743,7 +744,7 @@ se::Platform::Id NVPTXCompiler::PlatformId() const {
 static bool InitModule() {
   xla::Compiler::RegisterCompilerFactory(
       stream_executor::cuda::kCudaPlatformId,
-      []() { return absl::make_unique<xla::gpu::NVPTXCompiler>(); });
+      []() { return absl::make_unique<xla::gpu::NVPTXCompiler>(stream_executor::cuda::kCudaPlatformId); });
   return true;
 }
 static bool module_initialized = InitModule();

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
@@ -456,6 +456,11 @@ void WarnIfBadDriverJITVersion() {
 
 }  // namespace
 
+NVPTXCompiler::NVPTXCompiler()
+    : pointer_size_(llvm::DataLayout(kDataLayout)
+                        .getPointerSize(0 /* default address space */)),
+      platform_id_(se::cuda::kCudaPlatformId) {}
+
 NVPTXCompiler::NVPTXCompiler(se::Platform::Id platform_id)
     : pointer_size_(llvm::DataLayout(kDataLayout)
                         .getPointerSize(0 /* default address space */)),

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.h
@@ -41,7 +41,7 @@ namespace gpu {
 // The GPU compiler generates efficient GPU executables.
 class NVPTXCompiler : public LLVMCompiler {
  public:
-  NVPTXCompiler();
+  NVPTXCompiler(se::Platform::Id platform_id);
   ~NVPTXCompiler() override {}
 
   // Bring in
@@ -74,6 +74,8 @@ class NVPTXCompiler : public LLVMCompiler {
   }
 
  private:
+  se::Platform::Id platform_id_;
+
   // The size in bytes of a pointer. Used by ShapeSizeBytesFunction.
   const int64 pointer_size_;
 

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.h
@@ -41,6 +41,7 @@ namespace gpu {
 // The GPU compiler generates efficient GPU executables.
 class NVPTXCompiler : public LLVMCompiler {
  public:
+  NVPTXCompiler();
   NVPTXCompiler(se::Platform::Id platform_id);
   ~NVPTXCompiler() override {}
 


### PR DESCRIPTION
Initial step to extract commonality between `nvptx_compiler` and `amdgpu_compiler`.