### PR TITLE
[XLA:GPU] Emit llvm::Intrinsic::nvvm_atomic_load_add_f32 only on NVPTX

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -230,17 +230,15 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
   }
 
   if (root_opcode == HloOpcode::kAdd) {
-// TODO: Add ROCm support for atomicAdd 
-#if GOOGLE_CUDA
+    llvm::Triple target_triple = llvm::Triple(module_->getTargetTriple());
     // NVPTX supports atomicAdd on F32 and integer types.
-    if (element_type == F32) {
+    if (target_triple.isNVPTX() && (element_type == F32)) {
       // F32 + F32
       llvm_ir::EmitCallToIntrinsic(llvm::Intrinsic::nvvm_atomic_load_add_f32,
                                    {output_address, source},
                                    {output_address->getType()}, &b_);
       return true;
     }
-#endif // GOOGLE_CUDA
     if (is_atomic_integral) {
       // integral + integral
       AtomicRMW(llvm::AtomicRMWInst::Add, output_address, source,


### PR DESCRIPTION
Emit llvm::Intrinsic::nvvm_atomic_load_add_f32 only on NVPTX

Instead of using ugly macro, use LLVM API to check.