### PR TITLE
Remove the workarounds no longer required with ROCm2.6

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -71,15 +71,8 @@ RUN apt-get update --allow-insecure-repositories && \
 #RUN ln -s /opt/rocm/hcc-1.0 /opt/rocm/hcc
 
 # Build HIP from source
-# The switch to rocm2.5 introduces failures on the rocm-xla CI path,
-# Need the workaround for issue SWDEV-173477 to fix some of those failures
-RUN cd $HOME && git clone -b roc-2.5.x-with-swdev-173477-workaround https://github.com/deven-amd/HIP.git
-RUN cd $HOME/HIP && mkdir -p build && cd build && cmake .. && make package -j $(nproc) && dpkg -i ./hip*.deb
-
-# Roll back OpenCL toolset to ROCm2.2 base
-RUN cd $HOME && wget http://repo.radeon.com/rocm/apt/2.2/pool/main/r/rocm-opencl/rocm-opencl_1.2.0-2019030702_amd64.deb && \
-    wget http://repo.radeon.com/rocm/apt/2.2/pool/main/r/rocm-opencl-dev/rocm-opencl-dev_1.2.0-2019030702_amd64.deb && \
-    dpkg -i rocm-opencl*.deb && rm -rf rocm-rocm*.deb
+# RUN cd $HOME && git clone https://github.com/deven-amd/HIP.git
+# RUN cd $HOME/HIP && mkdir -p build && cd build && cmake .. && make package -j $(nproc) && dpkg -i ./hip*.deb
 
 # Set up paths
 ENV HCC_HOME=$ROCM_PATH/hcc

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -71,7 +71,7 @@ RUN apt-get update --allow-insecure-repositories && \
 #RUN ln -s /opt/rocm/hcc-1.0 /opt/rocm/hcc
 
 # Build HIP from source
-# RUN cd $HOME && git clone https://github.com/deven-amd/HIP.git
+# RUN cd $HOME && git clone https://github.com/ROCm-Developer-Tools/HIP.git
 # RUN cd $HOME/HIP && mkdir -p build && cd build && cmake .. && make package -j $(nproc) && dpkg -i ./hip*.deb
 
 # Set up paths


### PR DESCRIPTION
ROCm2.6 has included the fixes for OCL and HIP, we no longer need those workarounds in Dockerfile.rocm. 