### PR TITLE
R1.13 rocm fix unit tests

### DIFF
--- a/build_rocm
+++ b/build_rocm
@@ -24,4 +24,4 @@ yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
 pip uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm --action_env=HIP_PLATFORM=hcc //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
-pip install $TF_PKG_LOC/tensorflow-1.13.3-cp27-cp27m-linux_x86_64.whl
+pip install $TF_PKG_LOC/tensorflow-1.13.4-cp27-cp27m-linux_x86_64.whl

--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -25,4 +25,4 @@ yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
 pip3 uninstall -y tensorflow || true
 bazel build -s --config=opt --config=rocm --action_env=HIP_PLATFORM=hcc //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
-pip3 install $TF_PKG_LOC/tensorflow-1.13.3-cp35-cp35m-linux_x86_64.whl
+pip3 install $TF_PKG_LOC/tensorflow-1.13.4-cp35-cp35m-linux_x86_64.whl

--- a/build_rocm_verbs
+++ b/build_rocm_verbs
@@ -12,4 +12,4 @@ yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
 pip uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm --config=verbs --config=gdr //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip install /tmp/tensorflow_pkg/tensorflow-1.13.3-cp27-cp27m-linux_x86_64.whl
+pip install /tmp/tensorflow_pkg/tensorflow-1.13.4-cp27-cp27m-linux_x86_64.whl

--- a/tensorflow/python/kernel_tests/map_stage_op_test.py
+++ b/tensorflow/python/kernel_tests/map_stage_op_test.py
@@ -25,7 +25,7 @@ from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
 
-TIMEOUT = 10
+TIMEOUT = 1
 
 
 class MapStageTest(test.TestCase):

--- a/tensorflow/python/kernel_tests/stage_op_test.py
+++ b/tensorflow/python/kernel_tests/stage_op_test.py
@@ -24,7 +24,7 @@ from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
 
-TIMEOUT = 10
+TIMEOUT = 1
 
 
 class StageTest(test.TestCase):

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -45,7 +45,7 @@ DOCLINES = __doc__.split('\n')
 # This version string is semver compatible, but incompatible with pip.
 # For pip, we will remove all '-' characters from this string, and use the
 # result for pip.
-_VERSION = '1.13.3'
+_VERSION = '1.13.4'
 
 REQUIRED_PACKAGES = [
     'absl-py >= 0.1.6',


### PR DESCRIPTION
Fix four failed unit tests related to the commit 4be16b2, and bump the minor version for ROCm2.6 whl package. 