### PR TITLE
Re-enable the conv3d subtests, now that ROCm has support for conv3d

### DIFF
--- a/tensorflow/compiler/xla/tests/convolution_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_test.cc
@@ -408,8 +408,7 @@ class Convolve1D_1x2x5_1x2x2_WithPadding : public ConvolutionTest {
 TYPED_TEST_CASE(Convolve1D_1x2x5_1x2x2_WithPadding, TestTypes);
 TYPED_TEST(Convolve1D_1x2x5_1x2x2_WithPadding, Types) { this->RunTest(); }
 
-// 5D tensors are not yet supported in ROCm  
-XLA_TEST_F(ConvolutionTest, DISABLED_ON_GPU_ROCM(Convolve3D_1x4x2x3x3_2x2x2x3x3_Valid)) {
+XLA_TEST_F(ConvolutionTest, Convolve3D_1x4x2x3x3_2x2x2x3x3_Valid) {
   XlaBuilder builder(TestName());
   std::vector<int64> input_dims = {1, 4, 2, 3, 3};
   std::vector<int64> filter_dims = {2, 2, 2, 3, 3};
@@ -1947,7 +1946,7 @@ XLA_TEST_F(ConvolutionTest, ConvolveF32BackwardInputGroupedConvolution) {
 
 class ConvolutionHloTest : public HloTestBase {};
 
-// double datatype is not yet supported in ROCm  
+// double datatype is not yet supported in ROCm
 XLA_TEST_F(ConvolutionHloTest, DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64Forward))) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
@@ -1972,7 +1971,7 @@ ENTRY Test {
   EXPECT_TRUE(RunAndCompare(kHlo, ErrorSpec{0.001}));
 }
 
-// double datatype is not yet supported in ROCm  
+// double datatype is not yet supported in ROCm
 XLA_TEST_F(ConvolutionHloTest,DISABLED_ON_GPU_ROCM( DISABLED_ON_CPU(ConvolveF64BackwardFilter))) {
   constexpr char kHlo[] = R"(
 HloModule TestModule
@@ -1985,7 +1984,7 @@ ENTRY Test {
   EXPECT_TRUE(RunAndCompare(kHlo, ErrorSpec{0.001}));
 }
 
-// double datatype is not yet supported in ROCm  
+// double datatype is not yet supported in ROCm
 XLA_TEST_F(ConvolutionHloTest, DISABLED_ON_GPU_ROCM(DISABLED_ON_CPU(ConvolveF64BackwardInput))) {
   constexpr char kHlo[] = R"(
 HloModule TestModule

--- a/tensorflow/compiler/xla/tests/convolution_variants_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_variants_test.cc
@@ -1330,8 +1330,7 @@ XLA_TEST_F(ConvolutionVariantsTest, BackwardFilterEvenPadding1D) {
   ComputeAndCompareR3<float>(&builder, {{{13, 24, 130}}}, {}, error_spec_);
 }
 
-// 5D tensors are not yet supported in ROCm  
-XLA_TEST_F(ConvolutionVariantsTest, DISABLED_ON_GPU_ROCM(BackwardInputEvenPadding3D)) {
+XLA_TEST_F(ConvolutionVariantsTest, BackwardInputEvenPadding3D) {
   XlaBuilder builder(TestName());
 
   auto gradients_flat = LiteralUtil::CreateR1<float>({1});
@@ -1355,8 +1354,7 @@ XLA_TEST_F(ConvolutionVariantsTest, DISABLED_ON_GPU_ROCM(BackwardInputEvenPaddin
   ComputeAndCompareLiteral(&builder, expected_literal, {}, error_spec_);
 }
 
-// 5D tensors are not yet supported in ROCm  
-XLA_TEST_F(ConvolutionVariantsTest, DISABLED_ON_GPU_ROCM(BackwardFilterEvenPadding3D)) {
+XLA_TEST_F(ConvolutionVariantsTest, BackwardFilterEvenPadding3D) {
   XlaBuilder builder(TestName());
 
   auto activations_flat = LiteralUtil::CreateR1<float>({1, 2, 3, 4});

--- a/tensorflow/python/keras/backend_test.py
+++ b/tensorflow/python/keras/backend_test.py
@@ -1100,9 +1100,6 @@ class BackendNNOpsTest(test.TestCase, parameterized.TestCase):
       y = keras.backend.separable_conv2d(x, dk, pk, (2, 2, 2))
 
   def test_conv3d(self):
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     val = np.random.random((10, 4, 10, 10, 10))
     x = keras.backend.variable(val)
     kernel_val = np.random.random((3, 3, 3, 4, 5))

--- a/tensorflow/python/keras/layers/convolutional_test.py
+++ b/tensorflow/python/keras/layers/convolutional_test.py
@@ -192,20 +192,12 @@ class Conv3DTest(keras_parameterized.TestCase):
       ('data_format', {'data_format': 'channels_first'}),
   )
   def test_conv3d(self, kwargs, expected_output_shape=None):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     kwargs['filters'] = 2
     kwargs['kernel_size'] = (3, 3, 3)
     if 'data_format' not in kwargs or test.is_gpu_available(cuda_only=True):
       self._run_test(kwargs, expected_output_shape)
 
   def test_conv3d_regularizers(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     kwargs = {
         'filters': 3,
         'kernel_size': 3,
@@ -224,10 +216,6 @@ class Conv3DTest(keras_parameterized.TestCase):
       self.assertEqual(len(layer.losses), 3)
 
   def test_conv3d_constraints(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     k_constraint = lambda x: x
     b_constraint = lambda x: x
 
@@ -246,10 +234,6 @@ class Conv3DTest(keras_parameterized.TestCase):
       self.assertEqual(layer.bias.constraint, b_constraint)
 
   def test_conv3d_dynamic_shape(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     input_data = np.random.random((1, 3, 3, 3, 3)).astype(np.float32)
     with self.cached_session(use_gpu=True):
       # Won't raise error here.
@@ -406,10 +390,6 @@ class ZeroPaddingTest(keras_parameterized.TestCase):
         keras.layers.ZeroPadding2D(padding=None)
 
   def test_zero_padding_3d(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     num_samples = 2
     stack_size = 2
     input_len_dim1 = 4
@@ -542,10 +522,6 @@ class UpSamplingTest(keras_parameterized.TestCase):
               self.assertEqual(np_output.shape[2], length_col * input_num_col)
 
   def test_upsampling_3d(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     num_samples = 2
     stack_size = 2
     input_len_dim1 = 10
@@ -690,10 +666,6 @@ class CroppingTest(keras_parameterized.TestCase):
       keras.layers.Cropping2D(cropping=None)
 
   def test_cropping_3d(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     num_samples = 2
     stack_size = 2
     input_len_dim1 = 8

--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -1118,9 +1118,6 @@ class ConvolutionOrthogonal3dInitializerTest(test.TestCase):
       tmp_back = array_ops.slice(tmp, [0, 0, 0, 0, 0], [-1, -1, -1, end, -1])
       return array_ops.concat([tmp_front, tmp, tmp_back], 3)
 
-    if test.is_built_with_rocm():
-      self.skipTest("5D tensors are not yet supported in ROCm")
-
     cout = 32
     shape = [1, 7, 7, 7, 16]
     outputs_shape = shape[0:-1] + [cout]


### PR DESCRIPTION

Note that there will remain one conv3d based subtest that has not been enabled in this PR.

(this one : https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/blob/develop-upstream-deven-enable-conv3d-subtests/tensorflow/python/kernel_tests/init_ops_test.py#L750)

That is because that subtest is resulting in an MIOpen error (only on ROCm 2.6). Investigating that independently and will enable that subtest, once the error has been diagnosed and fixed.