### PR TITLE
[XLA:GPU] Refactor cudnn & miopen conv algorithm picker for find mode

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -638,6 +638,7 @@ cc_library(
         ":cudnn_conv_runner",
         ":gpu_executable",
         ":ir_emission_utils",
+        ":scratch_allocator",
         "//tensorflow/compiler/xla:literal_util",
         "//tensorflow/compiler/xla/service:compiler",
         "//tensorflow/compiler/xla/service:hlo",

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -596,10 +596,14 @@ cc_library(
 
 cc_library(
     name = "gpu_conv_algorithm_picker",
-    srcs = []
-    + if_rocm_is_configured(["miopen_conv_algorithm_picker.cc",])
-    + if_cuda_is_configured(["cudnn_conv_algorithm_picker.cc",]),
-    hdrs = []
+    srcs = ["gpu_conv_algorithm_picker.cc"]
+    + if_rocm_is_configured([
+        "miopen_conv_algorithm_picker.cc",
+    ])
+    + if_cuda_is_configured([
+        "cudnn_conv_algorithm_picker.cc",
+    ]),
+    hdrs = ["gpu_conv_algorithm_picker.h"]
     + if_rocm_is_configured(["miopen_conv_algorithm_picker.h",])
     + if_cuda_is_configured(["cudnn_conv_algorithm_picker.h",]),
     deps = [

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -595,9 +595,13 @@ cc_library(
 )
 
 cc_library(
-    name = "cudnn_conv_algorithm_picker",
-    srcs = ["cudnn_conv_algorithm_picker.cc"],
-    hdrs = ["cudnn_conv_algorithm_picker.h"],
+    name = "gpu_conv_algorithm_picker",
+    srcs = []
+    + if_rocm_is_configured(["miopen_conv_algorithm_picker.cc",])
+    + if_cuda_is_configured(["cudnn_conv_algorithm_picker.cc",]),
+    hdrs = []
+    + if_rocm_is_configured(["miopen_conv_algorithm_picker.h",])
+    + if_cuda_is_configured(["cudnn_conv_algorithm_picker.h",]),
     deps = [
         ":backend_configs",
         ":buffer_comparator",
@@ -619,39 +623,16 @@ cc_library(
         "//tensorflow/core:stream_executor_no_cuda",
         "//tensorflow/core/util/proto:proto_utils",
         "//tensorflow/stream_executor:device_memory_allocator",
-        "//tensorflow/stream_executor/cuda:redzone_allocator",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
-    ],
-)
-
-cc_library(
-    name = "miopen_conv_algorithm_picker",
-    srcs = ["miopen_conv_algorithm_picker.cc"],
-    hdrs = ["miopen_conv_algorithm_picker.h"],
-    deps = [
-        ":backend_configs",
-        ":buffer_comparator",
-        ":cudnn_conv_runner",
-        ":gpu_executable",
-        ":ir_emission_utils",
+    ] + if_cuda_is_configured([
+        "//tensorflow/stream_executor/cuda:redzone_allocator",
+    ]) + if_rocm_is_configured([
         ":scratch_allocator",
-        "//tensorflow/compiler/xla:literal_util",
-        "//tensorflow/compiler/xla/service:compiler",
-        "//tensorflow/compiler/xla/service:hlo",
-        "//tensorflow/compiler/xla/service:hlo_casting_utils",
-        "//tensorflow/compiler/xla/service:hlo_pass",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:stream_executor_no_cuda",
-        "//tensorflow/stream_executor:device_memory_allocator",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/time",
-        "@com_google_absl//absl/types:optional",
-    ],
+    ]),
 )
 
 cc_library(
@@ -1037,6 +1018,7 @@ cc_library(
         ":cudnn_conv_rewriter",
         ":fusion_merger",
         ":gpu_constants",
+        ":gpu_conv_algorithm_picker",
         ":gpu_copy_insertion",
         ":gpu_executable",
         ":gpu_hlo_schedule",
@@ -1111,7 +1093,6 @@ cc_library(
         "@com_google_absl//absl/types:span",
         "@llvm//:core",
     ] + if_cuda_is_configured([
-        ":cudnn_conv_algorithm_picker",
         ":cudnn_conv_pad_for_tensor_cores",
         ":cudnn_fused_conv_rewriter",
         ":cusolver_rewriter",
@@ -1120,11 +1101,11 @@ cc_library(
         "//tensorflow/core:cuda_libdevice_path",
         "//tensorflow/stream_executor/cuda:cuda_diagnostics",
         "//tensorflow/stream_executor/cuda:ptxas_utils",
-    ]) + if_rocm_is_configured([
-        ":miopen_conv_algorithm_picker",
+    ])
+    + if_rocm_is_configured([
         "//tensorflow/core:rocm_rocdl_path",
     ]),
-    alwayslink = True,
+    alwayslink = True,  # Contains compiler registration
 )
 
 cc_library(

--- a/tensorflow/compiler/xla/service/gpu/cudnn_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_conv_algorithm_picker.cc
@@ -69,18 +69,6 @@ std::vector<AlgorithmDesc> GetAlgorithms(CudnnConvKind kind,
   return algorithms;
 }
 
-string AlgorithmToString(const AlgorithmDesc& algo) {
-  if (algo.tensor_ops_enabled()) {
-    return absl::StrCat(algo.algo_id(), "+TC");
-  }
-  return absl::StrCat(algo.algo_id());
-}
-
-string NumBytesToString(int64 bytes) {
-  return absl::StrCat(tensorflow::strings::HumanReadableNumBytes(bytes), " (",
-                      bytes, "B)");
-}
-
 tensorflow::CudnnVersion GetCudnnVersion(se::StreamExecutor* stream_executor) {
   tensorflow::CudnnVersion cudnn_version;
   if (auto* dnn = stream_executor->AsDnn()) {
@@ -170,81 +158,7 @@ StatusOr<bool> CheckRedzones(const se::cuda::RedzoneAllocator& allocator,
   PrintPlatformInfo(stream);
   return false;
 }
-
-using ConvCacheKey =
-    std::tuple<se::StreamExecutor*, std::string, std::string, Shape,
-               std::vector<Shape>, std::string, std::string, int64>;
-
-struct ConvCacheStats {
-  int64 cache_hits = 0;
-  int64 cache_misses = 0;
-
-  void LogStats() {
-    VLOG(2) << "Cache hits: " << cache_hits;
-    VLOG(2) << "Cache misses: " << cache_misses;
-  }
-};
-
-StatusOr<ConvCacheKey> AutotuneCacheKeyfromInstruction(
-    const HloCustomCallInstruction* conv, se::StreamExecutor* se) {
-  TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
-                      conv->backend_config<CudnnConvBackendConfig>());
-  std::vector<Shape> operand_shapes;
-  absl::c_transform(conv->operands(), std::back_inserter(operand_shapes),
-                    [&](const HloInstruction* op) { return op->shape(); });
-
-  return std::make_tuple(
-      se, backend_config.SerializeAsString(), conv->custom_call_target(),
-      conv->shape(), std::move(operand_shapes),
-      conv->window().SerializeAsString(),
-      conv->convolution_dimension_numbers().SerializeAsString(),
-      conv->feature_group_count());
-}
-
-tensorflow::mutex autotune_cache_lock(tensorflow::LINKER_INITIALIZED);
-auto& autotune_cache GUARDED_BY(autotune_cache_lock) =
-    *new absl::flat_hash_map<ConvCacheKey, AutotuneResult>();
-auto& autotune_cache_stats GUARDED_BY(autotune_cache_lock) =
-    *new ConvCacheStats();
 }  // anonymous namespace
-
-StatusOr<AutotuneResult> CudnnConvAlgorithmPicker::PickBestAlgorithm(
-    const HloCustomCallInstruction* instr) {
-  // Don't run this function concurrently on the same GPU.
-  //
-  // This is a bit of a hack and doesn't protect us against arbitrary concurrent
-  // use of a GPU, but it's sufficient to let us compile two HLO modules
-  // concurrently and then run them sequentially.
-  //
-  // Putting the lock in here rather than in PickBestAlgorithmNoCache lets us
-  // avoid ever doing duplicate work.  If we have a cache miss, only one thread
-  // will run PickBestAlgorithmImpl for a particular device.
-  tensorflow::mutex_lock lock = LockGpu(stream_exec_);
-
-  // We cache the autotuning results to avoid doing the duplicate work,
-  // which can greatly improve both stability (deterministic numeric results
-  // within a process for a given input) and performance (2x speedup on some
-  // models).
-  TF_ASSIGN_OR_RETURN(ConvCacheKey key,
-                      AutotuneCacheKeyfromInstruction(instr, stream_exec_));
-  {
-    tensorflow::mutex_lock lock(autotune_cache_lock);
-    auto it = autotune_cache.find(key);
-    if (it != autotune_cache.end()) {
-      autotune_cache_stats.cache_hits++;
-      return it->second;
-    }
-    autotune_cache_stats.cache_misses++;
-  }
-
-  StatusOr<AutotuneResult> result_or = PickBestAlgorithmNoCache(instr);
-  if (result_or.ok()) {
-    tensorflow::mutex_lock lock(autotune_cache_lock);
-    CHECK(autotune_cache.insert({key, result_or.ValueOrDie()}).second);
-  }
-  return result_or;
-}
-
 
 StatusOr<AutotuneResult> CudnnConvAlgorithmPicker::PickBestAlgorithmNoCache(
     const HloCustomCallInstruction* instr) {
@@ -494,97 +408,6 @@ StatusOr<AutotuneResult> CudnnConvAlgorithmPicker::PickBestAlgorithmNoCache(
       "All algorithms tried for convolution %s failed.  Falling back to "
       "default algorithm.",
       instr->ToString());
-}
-
-StatusOr<bool> CudnnConvAlgorithmPicker::RunOnInstruction(
-    HloInstruction* instr) {
-  CHECK(IsCustomCallToDnnConvolution(*instr));
-
-  StatusOr<AutotuneResult> best_algo_or =
-      PickBestAlgorithm(Cast<HloCustomCallInstruction>(instr));
-  if (!best_algo_or.ok()) {
-    LOG(ERROR) << best_algo_or.status();
-    return false;
-  }
-
-  auto best_algo = std::move(best_algo_or).ValueOrDie();
-  VLOG(2) << "Setting cudnn conv to use algorithm "
-          << best_algo.conv().algorithm() << " and "
-          << NumBytesToString(best_algo.scratch_bytes())
-          << " of scratch memory: " << instr->ToString()
-          << " tensor_ops_enabled: " << best_algo.conv().tensor_ops_enabled();
-
-  // Replace instr with a new CustomCall which has the correct algorithm, and
-  // whose output shape has the appropriate amount of scratch memory.
-  HloComputation* computation = instr->parent();
-  Shape new_call_shape = ShapeUtil::MakeTupleShape(
-      {instr->shape().tuple_shapes(0),
-       ShapeUtil::MakeShape(U8, {best_algo.scratch_bytes()})});
-
-  TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
-                      instr->backend_config<CudnnConvBackendConfig>());
-  backend_config.set_algorithm(best_algo.conv().algorithm());
-  backend_config.set_tensor_ops_enabled(best_algo.conv().tensor_ops_enabled());
-
-  HloInstruction* new_call = computation->AddInstruction(
-      instr->CloneWithNewOperands(new_call_shape, instr->operands()));
-
-  VLOG(2) << "Replacing convolution " << instr->ToString() << " with "
-          << new_call->ToString();
-
-  TF_RETURN_IF_ERROR(new_call->set_backend_config(backend_config));
-
-  // Repackage new_call so it has the same shape as the original call, namely
-  // (conv_result, u8[0]).
-  HloInstruction* new_tuple =
-      computation->AddInstruction(HloInstruction::CreateTuple(
-          {computation->AddInstruction(HloInstruction::CreateGetTupleElement(
-               new_call_shape.tuple_shapes(0), new_call, 0)),
-           computation->AddInstruction(HloInstruction::CreateConstant(
-               LiteralUtil::CreateR1<uint8>({})))}));
-
-  TF_RETURN_IF_ERROR(instr->parent()->ReplaceInstruction(instr, new_tuple));
-  return true;
-}
-
-StatusOr<bool> CudnnConvAlgorithmPicker::RunOnComputation(
-    HloComputation* computation) {
-  std::vector<HloInstruction*> convs;
-  for (auto* instr : computation->instructions()) {
-    if (IsCustomCallToDnnConvolution(*instr)) {
-      convs.push_back(instr);
-    }
-  }
-
-  bool changed = false;
-  for (auto* instr : convs) {
-    TF_ASSIGN_OR_RETURN(bool result, RunOnInstruction(instr));
-    changed |= result;
-  }
-  return changed;
-}
-
-StatusOr<bool> CudnnConvAlgorithmPicker::Run(HloModule* module) {
-  XLA_SCOPED_LOGGING_TIMER("CudnnConvAlgorithmPicker");
-
-  if (module->config().debug_options().xla_gpu_disable_autotune()) {
-    VLOG(2) << "Convolution auto-tuning disabled, CudnnConvAlgorithmPicker "
-               "returning early.";
-    return false;
-  }
-
-  bool changed = false;
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
-    TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
-    changed |= result;
-  }
-
-  {
-    tensorflow::mutex_lock lock(autotune_cache_lock);
-    autotune_cache_stats.LogStats();
-  }
-
-  return changed;
 }
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -1,0 +1,220 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.h"
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/time/time.h"
+#include "absl/types/optional.h"
+#include "google/protobuf/any.pb.h"
+#include "tensorflow/compiler/xla/literal_util.h"
+#include "tensorflow/compiler/xla/service/gpu/backend_configs.pb.h"
+#include "tensorflow/compiler/xla/service/gpu/buffer_comparator.h"
+#include "tensorflow/compiler/xla/service/gpu/convolution_thunk.h"
+#include "tensorflow/compiler/xla/service/gpu/gpu_autotuning.pb.h"
+#include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
+#include "tensorflow/compiler/xla/service/gpu/stream_executor_util.h"
+#include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
+#include "tensorflow/compiler/xla/service/hlo_instructions.h"
+#include "tensorflow/compiler/xla/status_macros.h"
+#include "tensorflow/compiler/xla/util.h"
+#include "tensorflow/core/lib/strings/numbers.h"
+#include "tensorflow/core/platform/logger.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/util/proto/proto_utils.h"
+
+namespace xla {
+namespace gpu {
+
+using absl::optional;
+using se::DeviceMemoryBase;
+using se::dnn::AlgorithmDesc;
+using tensorflow::AutotuneResult;
+
+namespace {
+using ConvCacheKey =
+    std::tuple<se::StreamExecutor*, std::string, std::string, Shape,
+               std::vector<Shape>, std::string, std::string, int64>;
+
+struct ConvCacheStats {
+  int64 cache_hits = 0;
+  int64 cache_misses = 0;
+
+  void LogStats() {
+    VLOG(2) << "Cache hits: " << cache_hits;
+    VLOG(2) << "Cache misses: " << cache_misses;
+  }
+};
+
+StatusOr<ConvCacheKey> AutotuneCacheKeyfromInstruction(
+    const HloCustomCallInstruction* conv, se::StreamExecutor* se) {
+  TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
+                      conv->backend_config<CudnnConvBackendConfig>());
+  std::vector<Shape> operand_shapes;
+  absl::c_transform(conv->operands(), std::back_inserter(operand_shapes),
+                    [&](const HloInstruction* op) { return op->shape(); });
+
+  return std::make_tuple(
+      se, backend_config.SerializeAsString(), conv->custom_call_target(),
+      conv->shape(), std::move(operand_shapes),
+      conv->window().SerializeAsString(),
+      conv->convolution_dimension_numbers().SerializeAsString(),
+      conv->feature_group_count());
+}
+
+tensorflow::mutex autotune_cache_lock(tensorflow::LINKER_INITIALIZED);
+auto& autotune_cache GUARDED_BY(autotune_cache_lock) =
+    *new absl::flat_hash_map<ConvCacheKey, AutotuneResult>();
+auto& autotune_cache_stats GUARDED_BY(autotune_cache_lock) =
+    *new ConvCacheStats();
+}  // anonymous namespace
+
+string NumBytesToString(int64 bytes) {
+  return absl::StrCat(tensorflow::strings::HumanReadableNumBytes(bytes), " (",
+                      bytes, "B)");
+}
+
+StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithm(
+    const HloCustomCallInstruction* instr) {
+  // Don't run this function concurrently on the same GPU.
+  //
+  // This is a bit of a hack and doesn't protect us against arbitrary concurrent
+  // use of a GPU, but it's sufficient to let us compile two HLO modules
+  // concurrently and then run them sequentially.
+  //
+  // Putting the lock in here rather than in PickBestAlgorithmNoCache lets us
+  // avoid ever doing duplicate work.  If we have a cache miss, only one thread
+  // will run PickBestAlgorithmImpl for a particular device.
+  tensorflow::mutex_lock lock = LockGpu(stream_exec_);
+
+  // We cache the autotuning results to avoid doing the duplicate work,
+  // which can greatly improve both stability (deterministic numeric results
+  // within a process for a given input) and performance (2x speedup on some
+  // models).
+  TF_ASSIGN_OR_RETURN(ConvCacheKey key,
+                      AutotuneCacheKeyfromInstruction(instr, stream_exec_));
+  {
+    tensorflow::mutex_lock lock(autotune_cache_lock);
+    auto it = autotune_cache.find(key);
+    if (it != autotune_cache.end()) {
+      autotune_cache_stats.cache_hits++;
+      return it->second;
+    }
+    autotune_cache_stats.cache_misses++;
+  }
+
+  StatusOr<AutotuneResult> result_or = PickBestAlgorithmNoCache(instr);
+  if (result_or.ok()) {
+    tensorflow::mutex_lock lock(autotune_cache_lock);
+    CHECK(autotune_cache.insert({key, result_or.ValueOrDie()}).second);
+  }
+  return result_or;
+}
+
+StatusOr<bool> GpuConvAlgorithmPicker::Run(HloModule* module) {
+  XLA_SCOPED_LOGGING_TIMER("GpuConvAlgorithmPicker");
+
+  if (module->config().debug_options().xla_gpu_disable_autotune()) {
+    VLOG(2) << "Convolution auto-tuning disabled, GpuConvAlgorithmPicker "
+               "returning early.";
+    return false;
+  }
+
+  bool changed = false;
+  for (HloComputation* computation : module->MakeNonfusionComputations()) {
+    TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
+    changed |= result;
+  }
+
+  {
+    tensorflow::mutex_lock lock(autotune_cache_lock);
+    autotune_cache_stats.LogStats();
+  }
+
+  return changed;
+}
+
+StatusOr<bool> GpuConvAlgorithmPicker::RunOnInstruction(HloInstruction* instr) {
+  CHECK(IsCustomCallToDnnConvolution(*instr));
+
+  StatusOr<AutotuneResult> best_algo_or =
+      PickBestAlgorithm(Cast<HloCustomCallInstruction>(instr));
+  if (!best_algo_or.ok()) {
+    LOG(ERROR) << best_algo_or.status();
+    return false;
+  }
+
+  auto best_algo = std::move(best_algo_or).ValueOrDie();
+  VLOG(2) << "Setting cudnn conv to use algorithm "
+          << best_algo.conv().algorithm() << " and "
+          << NumBytesToString(best_algo.scratch_bytes())
+          << " of scratch memory: " << instr->ToString()
+          << " tensor_ops_enabled: " << best_algo.conv().tensor_ops_enabled();
+
+  // Replace instr with a new CustomCall which has the correct algorithm, and
+  // whose output shape has the appropriate amount of scratch memory.
+  HloComputation* computation = instr->parent();
+  Shape new_call_shape = ShapeUtil::MakeTupleShape(
+      {instr->shape().tuple_shapes(0),
+       ShapeUtil::MakeShape(U8, {best_algo.scratch_bytes()})});
+
+  TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
+                      instr->backend_config<CudnnConvBackendConfig>());
+  backend_config.set_algorithm(best_algo.conv().algorithm());
+  backend_config.set_tensor_ops_enabled(best_algo.conv().tensor_ops_enabled());
+  backend_config.set_scratch_size(best_algo.scratch_bytes());
+
+  HloInstruction* new_call = computation->AddInstruction(
+      instr->CloneWithNewOperands(new_call_shape, instr->operands()));
+
+  VLOG(1) << "Replacing convolution " << instr->ToString() << " with "
+          << new_call->ToString();
+
+  TF_RETURN_IF_ERROR(new_call->set_backend_config(backend_config));
+
+  // Repackage new_call so it has the same shape as the original call, namely
+  // (conv_result, u8[0]).
+  HloInstruction* new_tuple =
+      computation->AddInstruction(HloInstruction::CreateTuple(
+          {computation->AddInstruction(HloInstruction::CreateGetTupleElement(
+               new_call_shape.tuple_shapes(0), new_call, 0)),
+           computation->AddInstruction(HloInstruction::CreateConstant(
+               LiteralUtil::CreateR1<uint8>({})))}));
+
+  TF_RETURN_IF_ERROR(instr->parent()->ReplaceInstruction(instr, new_tuple));
+  return true;
+}
+
+StatusOr<bool> GpuConvAlgorithmPicker::RunOnComputation(
+    HloComputation* computation) {
+  std::vector<HloInstruction*> convs;
+  for (auto* instr : computation->instructions()) {
+    if (IsCustomCallToDnnConvolution(*instr)) {
+      convs.push_back(instr);
+    }
+  }
+
+  bool changed = false;
+  for (auto* instr : convs) {
+    TF_ASSIGN_OR_RETURN(bool result, RunOnInstruction(instr));
+    changed |= result;
+  }
+  return changed;
+}
+
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.h
@@ -57,8 +57,10 @@ class GpuConvAlgorithmPicker : public HloModulePass {
   StatusOr<bool> RunOnInstruction(HloInstruction* instr);
   StatusOr<tensorflow::AutotuneResult> PickBestAlgorithm(
       const HloCustomCallInstruction* instr);
+
   virtual StatusOr<tensorflow::AutotuneResult> PickBestAlgorithmNoCache(
-      const HloCustomCallInstruction* instr) = 0;
+      const HloCustomCallInstruction& instr,
+      se::DeviceMemoryAllocator* allocator, se::Stream* stream) = 0;
 
   se::StreamExecutor* stream_exec_;       // never null
   se::DeviceMemoryAllocator* allocator_;  // may be null

--- a/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h"
+
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/optional.h"
@@ -22,6 +23,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/buffer_comparator.h"
 #include "tensorflow/compiler/xla/service/gpu/convolution_thunk.h"
 #include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
+#include "tensorflow/compiler/xla/service/gpu/scratch_allocator.h"
 #include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 #include "tensorflow/core/platform/mutex.h"
@@ -34,49 +36,6 @@ using absl::optional;
 using se::DeviceMemoryBase;
 using se::dnn::AlgorithmConfig;
 using se::dnn::AlgorithmDesc;
-
-class ScratchAllocator : public se::ScratchAllocator {
- public:
-  ScratchAllocator(int device_ordinal, se::DeviceMemoryAllocator* memory_allocator)
-      : device_ordinal_(device_ordinal), memory_allocator_(memory_allocator) {}
-
-  int64 GetMemoryLimitInBytes(se::Stream* stream) override {
-    return 1LL << 32;  // 4GB.  TODO(jlebar): Tune this?
-  }
-  int64 TotalAllocatedBytes() { return total_allocated_bytes_; }
-
-  StatusOr<se::DeviceMemory<uint8>> AllocateBytes(se::Stream* stream,
-                                                  int64 byte_size) override;
-
- private:
-  const int device_ordinal_;
-  se::DeviceMemoryAllocator* memory_allocator_;
-  std::vector<se::OwningDeviceMemory> allocated_buffers_;
-  int64 total_allocated_bytes_ = 0;
-};
-
-StatusOr<se::DeviceMemory<uint8>> ScratchAllocator::AllocateBytes(
-    se::Stream* stream, int64 byte_size) {
-  CHECK_GE(byte_size, 0) << "byte_size must be positive.";
-  if (byte_size > GetMemoryLimitInBytes(stream)) {
-    return se::port::Status(
-        se::port::error::RESOURCE_EXHAUSTED,
-        absl::StrFormat(
-            "Allocating %d bytes exceeds the memory limit of %d bytes.",
-            byte_size, GetMemoryLimitInBytes(stream)));
-  }
-
-  TF_ASSIGN_OR_RETURN(se::OwningDeviceMemory allocated_buffer,
-                      memory_allocator_->Allocate(device_ordinal_, byte_size,
-                                                  /*retry_on_failure=*/false));
-  total_allocated_bytes_ += byte_size;
-
-  se::DeviceMemoryBase buffer_addr = *allocated_buffer;
-
-  allocated_buffers_.push_back(std::move(allocated_buffer));
-  return se::DeviceMemory<uint8>(buffer_addr);
-}
-
 
 string AlgorithmToString(const AlgorithmDesc& algo) {
   if (algo.tensor_ops_enabled()) {

--- a/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.cc
@@ -15,100 +15,42 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h"
 
+#include "absl/algorithm/container.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/time/time.h"
 #include "absl/types/optional.h"
+#include "google/protobuf/any.pb.h"
 #include "tensorflow/compiler/xla/literal_util.h"
 #include "tensorflow/compiler/xla/service/gpu/backend_configs.pb.h"
 #include "tensorflow/compiler/xla/service/gpu/buffer_comparator.h"
 #include "tensorflow/compiler/xla/service/gpu/convolution_thunk.h"
+#include "tensorflow/compiler/xla/service/gpu/gpu_autotuning.pb.h"
 #include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/scratch_allocator.h"
+#include "tensorflow/compiler/xla/service/gpu/stream_executor_util.h"
 #include "tensorflow/compiler/xla/service/hlo_casting_utils.h"
+#include "tensorflow/compiler/xla/status_macros.h"
+#include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/core/lib/strings/numbers.h"
+#include "tensorflow/core/platform/logger.h"
 #include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/util/proto/proto_utils.h"
 
 namespace xla {
 namespace gpu {
-namespace {
 
 using absl::optional;
 using se::DeviceMemoryBase;
 using se::dnn::AlgorithmConfig;
 using se::dnn::AlgorithmDesc;
+using tensorflow::AutotuneResult;
 
-string AlgorithmToString(const AlgorithmDesc& algo) {
-  if (algo.tensor_ops_enabled()) {
-    return absl::StrCat(algo.algo_id(), "+TC");
-  }
-  return absl::StrCat(algo.algo_id());
-}
-
-string NumBytesToString(int64 bytes) {
-  return absl::StrCat(tensorflow::strings::HumanReadableNumBytes(bytes), " (",
-                      bytes, "B)");
-}
-
-// Acquires a process-global lock on the device pointed to by the given
-// StreamExecutor.
-//
-// This is used to prevent other XLA instances from trying to autotune on this
-// device while we're using it.
-tensorflow::mutex_lock LockGpu(const se::StreamExecutor* stream_exec) {
-  static tensorflow::mutex mu(tensorflow::LINKER_INITIALIZED);
-  // se::Platform*s are global singletons guaranteed to live forever.
-  static auto* mutexes =
-      new std::map<std::pair<const se::Platform*, /*device_ordinal*/ int64>,
-                   tensorflow::mutex>();
-
-  tensorflow::mutex_lock global_lock(mu);
-  auto it = mutexes
-                ->emplace(std::piecewise_construct,
-                          std::make_tuple(stream_exec->platform(),
-                                          stream_exec->device_ordinal()),
-                          std::make_tuple())
-                .first;
-  return tensorflow::mutex_lock{it->second};
-}
-
-}  // anonymous namespace
-
-// We could have caching here so that we don't redo this work for two identical
-// convolutions.  Unfortunately our cache key would have to be a tuple
-// containing the protos passed to this function, and we have no utility for
-// hashing protos.  We could write our own hash functions, but they'd silently
-// break if we ever added a field to one of the protos.  Perhaps we could hack
-// using the binary-encoded proto as the hash key, on the assumption that two
-// protos being binary-equal is a sufficient, if not necessary, condition for
-// proper equality.  But that would still leave us open to having unnecessary
-// cache misses and doing extra work.  Overall, caching doesn't seem worth the
-// trouble, but we may want to revisit this if we ever find a model where
-// caching would speed up compilation a lot.
-StatusOr<MiopenConvAlgorithmPicker::AutotuneResult>
-MiopenConvAlgorithmPicker::PickBestAlgorithm(
+StatusOr<AutotuneResult> MiopenConvAlgorithmPicker::PickBestAlgorithmNoCache(
     const HloCustomCallInstruction* instr) {
-  // TODO(timshen): for now only check fp16. It can be expanded to other types,
-  // with some work on the HLO routines.
-
-  // FIXME(rocm): disable cross_check temporarily
-  // The cross_check functionality for the Eigen::half datatype, will call
-  // "ThenMemset32" with a value that > 255. This results in a failed check in
-  // the code rocm_driver.cpp, which then leads to test failure.
-  //
-  // This is an known bug which is being in the process of being fixed
-  // disabling this check until then
-
-  // const bool cross_check_enabled =
-  //     instr->shape().tuple_shapes(0).element_type() == xla::F16;
-
-  const bool cross_check_enabled = false;
-
-  // Don't run this function concurrently on the same GPU.
-  //
-  // This is a bit of a hack and doesn't protect us against arbitrary concurrent
-  // use of a GPU, but it's sufficient to let us compile two HLO modules
-  // concurrently and then run them sequentially.
-  tensorflow::mutex_lock lock = LockGpu(stream_exec_);
+  XLA_SCOPED_LOGGING_TIMER(
+      absl::StrCat("CudnnConvAlgorithmPicker::PickBestAlgorithmImpl for ",
+                   instr->ToString()));
 
   // Make sure any previous activity on this executor is done. We don't want to
   // interfere with programs that are still running on the GPU.
@@ -128,41 +70,16 @@ MiopenConvAlgorithmPicker::PickBestAlgorithm(
   if (allocator_ != nullptr) {
     allocator = allocator_;
   } else {
-    se_allocator.emplace(stream_exec_->platform(),
-                         absl::Span<se::StreamExecutor* const>({stream_exec_}));
+    se_allocator.emplace(stream_exec_);
     allocator = &*se_allocator;
   }
 
-  const auto initialize_buffer = [&stream, cross_check_enabled](
-                                     DeviceMemoryBase buffer) {
-    if (cross_check_enabled) {
-      // Broadcast a constant to the buffer, instead of zeroing the buffer. A
-      // non-zero constant is useful for the cross checking, because zero-inputs
-      // may not always reveal the bugs.
-      CHECK_EQ(0, (uintptr_t)buffer.opaque() % 4);
-      size_t left_over_bytes = buffer.size() % 4;
-      CHECK_EQ(0, left_over_bytes % 2);
-
-      constexpr float kBroadcastedConstant = 0.1f;
-      static const Eigen::half halfs[2] = {Eigen::half(kBroadcastedConstant),
-                                           Eigen::half(kBroadcastedConstant)};
-      uint32 bits;
-      static_assert(sizeof(bits) == sizeof(halfs), "");
-      memcpy(&bits, halfs, sizeof(bits));
-
-      size_t aligned_size = buffer.size() / 4 * 4;
-      stream.ThenMemset32(&buffer, bits, aligned_size);
-
-      DeviceMemoryBase left_over(
-          static_cast<char*>(buffer.opaque()) + aligned_size, left_over_bytes);
-      stream.ThenMemcpy(&left_over, halfs, left_over_bytes);
-    } else {
-      // Although we don't have evidence this matters, zero out the buffers
-      // before autotuning.  It's conceivable that using uninitialized memory as
-      // the inputs might affect performance if e.g. the inputs contain
-      // denormals, and this is easy enough.
-      stream.ThenMemZero(&buffer, buffer.size());
-    }
+  const auto initialize_buffer = [&stream](DeviceMemoryBase buffer) {
+    // Although we don't have evidence this matters, zero out the buffers
+    // before autotuning.  It's conceivable that using uninitialized memory as
+    // the inputs might affect performance if e.g. the inputs contain
+    // denormals, and this is easy enough.
+    stream.ThenMemZero(&buffer, buffer.size());
   };
 
   // Allocate space for the input, filter, and output of the convolution.  We
@@ -183,128 +100,38 @@ MiopenConvAlgorithmPicker::PickBestAlgorithm(
           &stream, ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(0))));
   initialize_buffer(result_buffer);
 
-  se::dnn::ProfileResult best_result;
-  int64 best_result_bytes_used = 0;
-  TF_ASSIGN_OR_RETURN(auto backend_config,
-                      instr->backend_config<CudnnConvBackendConfig>());
-
   ScratchAllocator scratch_allocator(device_ordinal, allocator);
   se::dnn::ProfileResult profile_result;
   VLOG(3) << "Auto-tuning for " << instr->ToString();
   RunConvOptions options;
   options.profile_result = &profile_result;
   options.first_call_from_algorithm_picker = true;
+
   bool launch_ok =
-        RunCudnnConv(instr, absl::MakeSpan(operand_buffers), result_buffer,
-                     &scratch_allocator, &stream, options)
-            .ok();
+      RunCudnnConv(instr, absl::MakeSpan(operand_buffers), result_buffer,
+                   &scratch_allocator, &stream, options)
+          .ok();
 
+  AutotuneResult best_result;
   if (launch_ok && profile_result.is_valid()) {
+    best_result.mutable_conv()->set_algorithm(
+        profile_result.algorithm().algo_id());
+    best_result.mutable_conv()->set_tensor_ops_enabled(
+        profile_result.algorithm().tensor_ops_enabled());
     int64 scratch_bytes_used = scratch_allocator.TotalAllocatedBytes();
-    VLOG(3) << "Auto-tuning succeeded, taking "
-            << profile_result.elapsed_time_in_ms() << "ms and using "
-            << NumBytesToString(scratch_bytes_used)
-            << " of scratch (Best result: " << best_result.elapsed_time_in_ms()
-            << "ms, " << NumBytesToString(best_result_bytes_used)
-            << " of scratch)";
-    best_result = profile_result;
-    best_result_bytes_used = scratch_bytes_used;
-  } else {
-    VLOG(3) << "Auto-tuning failed.";
+    best_result.set_scratch_bytes(scratch_bytes_used);
+    *best_result.mutable_run_time() = tensorflow::proto_utils::ToDurationProto(
+        absl::Milliseconds(profile_result.elapsed_time_in_ms()));
+
+    return best_result;
   }
 
-  if (best_result.is_valid()) {
-    VLOG(2) << "Best algorithm for " << instr->ToString() << ": "
-            << AlgorithmToString(best_result.algorithm()) << ", takes "
-            << best_result.elapsed_time_in_ms() << "ms, and uses "
-            << best_result_bytes_used << "B of scratch memory.";
-    return AutotuneResult{best_result.algorithm().algo_id(),
-                          best_result.algorithm().tensor_ops_enabled(),
-                          best_result_bytes_used,
-                          absl::Milliseconds(best_result.elapsed_time_in_ms())};
-  }
+  // TODO ROCm: Log the autotuning result.
 
   return InternalError(
       "All algorithms tried for convolution %s failed.  Falling back to "
       "default algorithm.",
       instr->ToString());
-}
-
-StatusOr<bool> MiopenConvAlgorithmPicker::RunOnInstruction(
-    HloInstruction* instr) {
-  CHECK(IsCustomCallToDnnConvolution(*instr));
-
-  StatusOr<AutotuneResult> best_algo_or =
-      PickBestAlgorithm(Cast<HloCustomCallInstruction>(instr));
-  if (!best_algo_or.ok()) {
-    LOG(ERROR) << best_algo_or.status();
-    return false;
-  }
-
-  auto best_algo = std::move(best_algo_or).ValueOrDie();
-  VLOG(1) << "Setting cudnn conv to use algorithm " << best_algo.algorithm
-          << " and " << NumBytesToString(best_algo.scratch_bytes)
-          << " of scratch memory: " << instr->ToString()
-          << " tensor_ops_enabled: " << best_algo.tensor_ops_enabled;
-
-  // Replace instr with a new CustomCall which has the correct algorithm, and
-  // whose output shape has the appropriate amount of scratch memory.
-  HloComputation* computation = instr->parent();
-  Shape new_call_shape = ShapeUtil::MakeTupleShape(
-      {instr->shape().tuple_shapes(0),
-       ShapeUtil::MakeShape(U8, {best_algo.scratch_bytes})});
-
-  TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
-                      instr->backend_config<CudnnConvBackendConfig>());
-  backend_config.set_algorithm(best_algo.algorithm);
-  backend_config.set_tensor_ops_enabled(best_algo.tensor_ops_enabled);
-  backend_config.set_scratch_size(best_algo.scratch_bytes);
-
-  HloInstruction* new_call = computation->AddInstruction(
-      instr->CloneWithNewOperands(new_call_shape, instr->operands()));
-
-  VLOG(1) << "Replacing convolution " << instr->ToString() << " with "
-          << new_call->ToString();
-
-  TF_RETURN_IF_ERROR(new_call->set_backend_config(backend_config));
-
-  // Repackage new_call so it has the same shape as the original call, namely
-  // (conv_result, u8[0]).
-  HloInstruction* new_tuple =
-      computation->AddInstruction(HloInstruction::CreateTuple(
-          {computation->AddInstruction(HloInstruction::CreateGetTupleElement(
-               new_call_shape.tuple_shapes(0), new_call, 0)),
-           computation->AddInstruction(HloInstruction::CreateConstant(
-               LiteralUtil::CreateR1<uint8>({})))}));
-
-  TF_RETURN_IF_ERROR(instr->parent()->ReplaceInstruction(instr, new_tuple));
-  return true;
-}
-
-StatusOr<bool> MiopenConvAlgorithmPicker::RunOnComputation(
-    HloComputation* computation) {
-  std::vector<HloInstruction*> convs;
-  for (auto* instr : computation->instructions()) {
-    if (IsCustomCallToDnnConvolution(*instr)) {
-      convs.push_back(instr);
-    }
-  }
-
-  bool changed = false;
-  for (auto* instr : convs) {
-    TF_ASSIGN_OR_RETURN(bool result, RunOnInstruction(instr));
-    changed |= result;
-  }
-  return changed;
-}
-
-StatusOr<bool> MiopenConvAlgorithmPicker::Run(HloModule* module) {
-  bool changed = false;
-  for (HloComputation* computation : module->MakeNonfusionComputations()) {
-    TF_ASSIGN_OR_RETURN(bool result, RunOnComputation(computation));
-    changed |= result;
-  }
-  return changed;
 }
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h
+++ b/tensorflow/compiler/xla/service/gpu/miopen_conv_algorithm_picker.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/compiler.h"
 #include "tensorflow/compiler/xla/service/gpu/cudnn_conv_runner.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.h"
+#include "tensorflow/compiler/xla/service/gpu/scratch_allocator.h"
 #include "tensorflow/compiler/xla/service/hlo_instructions.h"
 #include "tensorflow/compiler/xla/service/hlo_module.h"
 #include "tensorflow/compiler/xla/service/hlo_pass_interface.h"
@@ -46,9 +47,16 @@ class MiopenConvAlgorithmPicker : public GpuConvAlgorithmPicker {
     return "miopen-conv-algorithm-picker";
   }
 
-protected:
+ protected:
   StatusOr<tensorflow::AutotuneResult> PickBestAlgorithmNoCache(
-                  const HloCustomCallInstruction* instr);
+      const HloCustomCallInstruction& instr,
+      se::DeviceMemoryAllocator* allocator, se::Stream* stream);
+
+  Status AllocateInitializeBuffers(
+      const HloCustomCallInstruction& instr,
+      se::ScratchAllocator* input_output_allocator, se::Stream* stream,
+      std::vector<se::DeviceMemoryBase>* operand_buffers,
+      se::DeviceMemoryBase* result_buffer);
 };
 
 }  // namespace gpu


### PR DESCRIPTION
Note:
Immediate mode implementation is in `develop-upstream-miopen-immediate-mode-integration-zyin-merge` branch @deven-amd. Feel free to base any future implementation on that branch, it is a re-implementation to certain degree and very hard to rebase.

Brief description of this PR:
Extract common logic between Cuda and ROCm algorithm picker to a common base class `GpuConAlgorithmPicker`. The only remaining difference between the two platform is `PickBestAlgorithmNoCache()` function. I also refactored this function such that when immediate mode implementation is in, we have a very similar process with that from Cuda.

--------
Test performed: 
No regression happend for //tensorflow/compiler/xla/tests:convolution_test target