### PR TITLE
[XLA:GPU] Reverting cuda->gpu symbol change in cuda runtime

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_runtime_10_0.inc
+++ b/tensorflow/stream_executor/cuda/cuda_runtime_10_0.inc
@@ -535,11 +535,11 @@ cudaDestroyExternalSemaphore(cudaExternalSemaphore_t extSem) {
 }
 
 extern __host__ cudaError_t CUDARTAPI
-GpuLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args,
+cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args,
                  size_t sharedMem, cudaStream_t stream) {
   using FuncPtr = cudaError_t(CUDARTAPI *)(const void *, dim3, dim3, void **,
                                            size_t, cudaStream_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("GpuLaunchKernel");
+  static auto func_ptr = LoadSymbol<FuncPtr>("cudaLaunchKernel");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(func, gridDim, blockDim, args, sharedMem, stream);
 }

--- a/tensorflow/stream_executor/cuda/cuda_runtime_10_1.inc
+++ b/tensorflow/stream_executor/cuda/cuda_runtime_10_1.inc
@@ -571,11 +571,11 @@ cudaDestroyExternalSemaphore(cudaExternalSemaphore_t extSem) {
 }
 
 extern __host__ cudaError_t CUDARTAPI
-GpuLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args,
+cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args,
                  size_t sharedMem, cudaStream_t stream) {
   using FuncPtr = cudaError_t(CUDARTAPI *)(const void *, dim3, dim3, void **,
                                            size_t, cudaStream_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("GpuLaunchKernel");
+  static auto func_ptr = LoadSymbol<FuncPtr>("cudaLaunchKernel");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(func, gridDim, blockDim, args, sharedMem, stream);
 }

--- a/tensorflow/stream_executor/cuda/cuda_runtime_9_0.inc
+++ b/tensorflow/stream_executor/cuda/cuda_runtime_9_0.inc
@@ -437,11 +437,11 @@ extern __host__ cudaError_t CUDARTAPI cudaEventElapsedTime(float *ms,
 }
 
 extern __host__ cudaError_t CUDARTAPI
-GpuLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args,
+cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args,
                  size_t sharedMem, cudaStream_t stream) {
   using FuncPtr = cudaError_t(CUDARTAPI *)(const void *, dim3, dim3, void **,
                                            size_t, cudaStream_t);
-  static auto func_ptr = LoadSymbol<FuncPtr>("GpuLaunchKernel");
+  static auto func_ptr = LoadSymbol<FuncPtr>("cudaLaunchKernel");
   if (!func_ptr) return GetSymbolNotFoundError();
   return func_ptr(func, gridDim, blockDim, args, sharedMem, stream);
 }


### PR DESCRIPTION
We should not touch cuda runtime wrappers. Reverting cuda runtime wrappers to correct symbols fix the follow linker error when compiling cuda xla target `//tensorflow/compiler/xla/tests:convolution_test`. 

For reference, the failure message is very misleading: 

> /usr/bin/ld: bazel-out/k8-opt/bin/tensorflow/compiler/xla/tests/convolution_test_gpu: hidden symbol `cudaLaunchKernel' in bazel-out/k8-opt/genfiles/external/local_config_cuda/cuda/cuda/lib/libcudart_static.a(libcudart_static.a.o) is referenced by DSO
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status

The reason why it failed in this way:

The linker cannot find `cudaLaunchKernel` symbol anywhere else, so it has to resolve to the only place where it can find it: in `libcudart_static.a`. It panic when seeing the hidden symbol being referenced elsewhere. This PR makes `cudart` wrapper able to find the explicit symbol correctly. (Wrapper logic can be referred from [here](https://github.com/tensorflow/tensorflow/blob/7bd23b650b79e68662f834a0a5625897785b5c06/tensorflow/stream_executor/cuda/cudart_stub.cc))

> ~/tensorflow-upstream/bazel-out/k8-opt/genfiles/external/local_config_cuda/cuda/cuda/lib objdump -t libcudart_static.a | grep cudaLaunchKernel
00000000000500c0 g     F .text  00000000000002e2 .hidden cudaLaunchKernel

