### PR TITLE
NCCL Participant should wait on new event, not stream

### DIFF
--- a/tensorflow/core/nccl/BUILD
+++ b/tensorflow/core/nccl/BUILD
@@ -32,6 +32,7 @@ cc_library(
     copts = tf_copts(),
     deps = if_nccl([
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:gpu_headers_lib",

--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -545,7 +545,7 @@ void NcclManager::RunCollective(Collective* collective) {
       // Wait to ensure that the kernel that produces the data in the input
       // tensor has finished running before the nccl kernel runs on the
       // communication stream.
-      nccl_stream->stream->ThenWaitFor(p->input_event);
+      nccl_stream->stream->ThenWaitFor(p->input_event.get());
     }
     if (p->root) {
       CHECK_EQ(collective->root_rank, -1);

--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -545,7 +545,7 @@ void NcclManager::RunCollective(Collective* collective) {
       // Wait to ensure that the kernel that produces the data in the input
       // tensor has finished running before the nccl kernel runs on the
       // communication stream.
-      nccl_stream->stream->ThenWaitFor(p->tensor_stream);
+      nccl_stream->stream->ThenWaitFor(p->input_event);
     }
     if (p->root) {
       CHECK_EQ(collective->root_rank, -1);


### PR DESCRIPTION
The Collective will not start until all Participant instances arrive.
However, the Participant will call ThenWaitFor on the compute stream
which will wait for all enqueued kernels instead of just the kernel
that is producing the input tensor.  This greatly affects mGPU perf.