### PR TITLE
fix distribute_lib_test

### DIFF
--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -171,10 +171,6 @@ py_test(
     srcs = ["distribute_lib_test.py"],
     python_version = "PY2",
     srcs_version = "PY2AND3",
-    tags = [
-        "no_rocm",
-        "no_cuda",
-    ],
     deps = [
         ":combinations",
         ":distribute_lib",

--- a/tensorflow/python/distribute/distribute_lib_test.py
+++ b/tensorflow/python/distribute/distribute_lib_test.py
@@ -147,7 +147,7 @@ def _run_in_and_out_of_scope(unbound_test_method):
     _assert_in_default_state(test_case)
     # When run under a different strategy the test method should fail.
     another_strategy = _TestStrategy()
-    msg = "Mixing different .*Strategy objects"
+    msg = "Mixing different .*Strategy objects|Variable creator scope nesting error"
     with test_case.assertRaisesRegexp(RuntimeError, msg):
       with another_strategy.scope():
         unbound_test_method(test_case, dist)


### PR DESCRIPTION
This fix allows both cuda and rocm builds to pass CI.

It's not clear to me how this test was working upstream.  I built upstream TF on CUDA and this test also failed in the same way as our CI.  In any case, this PR should fix it.

The important part of the test that was failing was that it was asserting that an error would be raised, but it was asserting the wrong error message.  The error message depends on particular subtest being run.  This PR changes the regexp used to compare the error message, using an OR condition so we capture the two different error message cases..