### PR TITLE
[DO NOT MERGE] Add new ROCm-Device-Libs bitcode library for ROCm 2.7.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -550,7 +550,7 @@ static std::vector<string> GetROCDLPaths(int amdgpu_version,
       {"hc.amdgcn.bc", "opencl.amdgcn.bc", "ocml.amdgcn.bc", "ockl.amdgcn.bc",
        "oclc_finite_only_off.amdgcn.bc", "oclc_daz_opt_off.amdgcn.bc",
        "oclc_correctly_rounded_sqrt_on.amdgcn.bc",
-       "oclc_unsafe_math_off.amdgcn.bc"});
+       "oclc_unsafe_math_off.amdgcn.bc", "oclc_wavefrontsize64_on.amdgcn.bc"});
 
   // Construct full path to ROCDL bitcode libraries.
   std::vector<string> result;


### PR DESCRIPTION
Follow-up to #589 .

Do not merge as the new bitcode library is NOT present in current ROCm 2.6 right now.

Discussing with ROCm-Device-Libs maintainers are ongoing to devise a consistent approach to deliver bitcode libraries from ROCm-Device-Libs.