### PR TITLE
force initialization of compute and nccl streams

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -254,12 +254,14 @@ class BaseGPUDevice::StreamGroupFactory {
       VLOG(2) << "Created nccl_stream[" << stream_group_within_gpu
               << "] = " << group->nccl;
 
+#if TENSORFLOW_USE_ROCM
       // ROCm streams are lightweight and will not necessarily trigger device
       // queue init until they are first used. For optimal performance,
       // compute and nccl streams must be immediate siblings.
       // Force underlying resource creation now.
       group->compute->ThenWaitFor(group->nccl);
       group->nccl->ThenWaitFor(group->compute);
+#endif
 
       group->host_to_device = new se::Stream(executor);
       group->host_to_device->Init();


### PR DESCRIPTION
This causes the underlying device queue creation so that the compute
and nccl streams are immediate siblings, for optimal performance.