### PR TITLE
batch_gemm operator: Making num of gradient output equal to input

### DIFF
--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1735,7 +1735,7 @@ def _BatchMatMulV2(op, grad):
 def _BatchGemm(op, grad):
   """Returns the gradient of x and y given the gradient of alpha * x * y."""
   alpha = op.get_attr("alpha")
-  return [math_ops.multiply(grad, alpha) for grad in _BatchMatMulV2(op, grad)]
+  return [math_ops.multiply(grad, alpha) for grad in _BatchMatMulV2(op, grad)] + [None]
 
 
 ops.NotDifferentiable("Range")


### PR DESCRIPTION
Trivial fix to make batch_gemm op training works. The batch_gemm op is 

`C_out = alpha*A*B + beta*C_in`

There should not be any gradient output to C_in because it is a constant, not a feed-in variable. Populating None so that the number of gradient is similar to number of input.