### PR TITLE
Update doc and Dockerfile to not install rocm-libs meta packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ drun rocm/tensorflow
 We maintain `tensorflow-rocm` whl packages on PyPI [here](https://pypi.org/project/tensorflow-rocm), to install tensorflow-rocm package using pip:
 ```
 # Install some ROCm dependencies
-sudo apt install rocm-libs miopen-hip cxlactivitylogger
+sudo apt install rocblas hipblas rocrand rocfft rccl miopen-hip cxlactivitylogger
 
 # Pip3 install the whl package from PyPI
 pip3 install --user tensorflow-rocm --upgrade

--- a/rocm_docs/tensorflow-install-basic.md
+++ b/rocm_docs/tensorflow-install-basic.md
@@ -59,7 +59,8 @@ Install ROCm pkgs:
 ```
 sudo apt-get update && \
     sudo apt-get install -y --allow-unauthenticated \
-    rocm-dkms rocm-dev rocm-libs rccl \
+    rocm-dkms rocm-dev \
+    rocblas hipblas rocrand rocfft rccl \
     rocm-device-libs \
     hsa-ext-rocr-dev hsakmt-roct-dev hsa-rocr-dev \
     rocm-opencl rocm-opencl-dev \

--- a/tensorflow/tools/ci_build/Dockerfile.rbe.rocm-ubuntu16.04
+++ b/tensorflow/tools/ci_build/Dockerfile.rbe.rocm-ubuntu16.04
@@ -15,7 +15,7 @@ RUN sh -c  "echo deb [arch=amd64] $DEB_ROCM_REPO xenial main > /etc/apt/sources.
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rocm-utils rocm-cmake \
+    rocm-dev rocm-utils rocm-cmake \
     rocfft miopen-hip miopengemm rocblas hipblas rocrand rccl \
     rocm-profiler cxlactivitylogger && \
     apt-get clean && \

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -57,7 +57,7 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rocm-utils rocm-cmake \
+    rocm-dev rocm-utils rocm-cmake \
     rocfft miopen-hip miopengemm rocblas hipblas rocrand rccl \
     rocm-profiler cxlactivitylogger && \
     apt-get clean && \

--- a/tensorflow/tools/ci_build/Dockerfile.rocm-hipclang
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm-hipclang
@@ -70,7 +70,8 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rocm-utils \
+    rocm-dev rocm-utils \
+    rocblas hipblas rocrand rocfft rccl \
     rocm-profiler cxlactivitylogger && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -213,7 +214,8 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rocm-utils \
+    rocm-dev rocm-utils \
+    rocblas hipblas rocrand rocfft rccl \
     rocm-profiler cxlactivitylogger && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/tensorflow/tools/docker/Dockerfile.devel-rocm
+++ b/tensorflow/tools/docker/Dockerfile.devel-rocm
@@ -68,7 +68,7 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rocm-utils \
+    rocm-dev rocm-utils \
     rocfft miopen-hip miopengemm rocblas hipblas rocrand rccl \
     rocm-profiler cxlactivitylogger && \
     apt-get clean && \


### PR DESCRIPTION
This PR is to revise our documentation and Dockerfiles to avoid installing rocm-libs meta-package, instead, we shall pick up the exact dependency libraries from ROCm. 