### PR TITLE
Changes to use bfloat16 (instead of float32) tensors for 2D convolutions

### DIFF
--- a/tensorflow/core/kernels/conv_2d_gpu_double.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_double.cu.cc
@@ -36,6 +36,8 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, double, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, double, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, double, 4>;
 template struct PadInput<Eigen::GpuDevice, double, int, 4>;
+template struct ConvertToBFloat16<Eigen::GpuDevice, double, 4>;
+template struct ConvertFromBFloat16<Eigen::GpuDevice, double, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, double, int, 5>;

--- a/tensorflow/core/kernels/conv_2d_gpu_float.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_float.cu.cc
@@ -49,6 +49,8 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, float, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, float, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, float, 4>;
 template struct PadInput<Eigen::GpuDevice, float, int, 4>;
+template struct ConvertToBFloat16<Eigen::GpuDevice, float, 4>;
+template struct ConvertFromBFloat16<Eigen::GpuDevice, float, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, float, int, 5>;

--- a/tensorflow/core/kernels/conv_2d_gpu_half.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_half.cu.cc
@@ -43,6 +43,8 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, Eigen::half, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, Eigen::half, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, Eigen::half, 4>;
 template struct PadInput<Eigen::GpuDevice, Eigen::half, int, 4>;
+template struct ConvertToBFloat16<Eigen::GpuDevice, Eigen::half, 4>;
+template struct ConvertFromBFloat16<Eigen::GpuDevice, Eigen::half, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, Eigen::half, int, 5>;

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -947,6 +947,53 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   auto input_ptr = AsDeviceMemory(transformed_input.template flat<T>().data(),
                                   transformed_input.template flat<T>().size());
 
+  Tensor bfloat16_out_backprop, bfloat16_input, bfloat16_filter_backprop;
+  se::DeviceMemory<bfloat16> bfloat16_out_backprop_ptr, bfloat16_input_ptr,
+      bfloat16_filter_backprop_ptr;
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    TensorShape out_backprop_shape = ShapeFromFormat(
+        FORMAT_NCHW, dims.batch_size, dims.spatial_dims[0].output_size,
+        dims.spatial_dims[1].output_size, dims.out_depth);
+    VLOG(3) << "Allocate temporary memory for bfloat16 out_backprop";
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, out_backprop_shape,
+                                           &bfloat16_out_backprop));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_out_backprop).tensor<T, 4>(),
+        bfloat16_out_backprop.tensor<bfloat16, 4>());
+
+    TensorShape input_shape = ShapeFromFormat(
+        compute_data_format, GetTensorDim(compatible_input, data_format, 'N'),
+        GetTensorDim(compatible_input, data_format, 'H'),
+        GetTensorDim(compatible_input, data_format, 'W'),
+        GetTensorDim(compatible_input, data_format, 'C'));
+    VLOG(3) << "Allocate temporary memory for bfloat16 input";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_BFLOAT16, input_shape, &bfloat16_input));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_input).tensor<T, 4>(),
+        bfloat16_input.tensor<bfloat16, 4>());
+
+    TensorShape filter_backprop_shape =
+        TensorShape({filter_shape.dim_size(3), filter_shape.dim_size(2),
+                     filter_shape.dim_size(0), filter_shape.dim_size(1)});
+    VLOG(3) << "Allocate temporary memory for bfloat16 filter_backprop";
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, filter_backprop_shape,
+                                           &bfloat16_filter_backprop));
+
+    bfloat16_out_backprop_ptr =
+        AsDeviceMemory(bfloat16_out_backprop.template flat<bfloat16>().data(),
+                       bfloat16_out_backprop.template flat<bfloat16>().size());
+    bfloat16_filter_backprop_ptr = AsDeviceMemory(
+        bfloat16_filter_backprop.template flat<bfloat16>().data(),
+        bfloat16_filter_backprop.template flat<bfloat16>().size());
+    bfloat16_input_ptr =
+        AsDeviceMemory(bfloat16_input.template flat<bfloat16>().data(),
+                       bfloat16_input.template flat<bfloat16>().size());
+  }
+
   static int64 ConvolveBackwardFilterScratchSize = GetDnnWorkspaceLimit(
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB by default
   );
@@ -1040,13 +1087,25 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
     ProfileResult best_result;
     DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
                                           ctx);
-    bool miopen_find_status =
-        stream
-            ->ThenConvolveBackwardFilterWithAlgorithm(
-                input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
-                filter_desc, &filter_backprop_ptr, &scratch_allocator,
-                AlgorithmConfig(), &best_result)
-            .ok();
+    bool miopen_find_status = true;
+    if (TestMIOpenBFloat16Support<T>()) {
+      miopen_find_status =
+          stream
+              ->ThenConvolveBackwardFilterWithAlgorithm(
+                  input_desc, bfloat16_input_ptr, output_desc,
+                  bfloat16_out_backprop_ptr, conv_desc, filter_desc,
+                  &bfloat16_filter_backprop_ptr, &scratch_allocator,
+                  AlgorithmConfig(), &best_result)
+              .ok();
+    } else {
+      miopen_find_status =
+          stream
+              ->ThenConvolveBackwardFilterWithAlgorithm(
+                  input_desc, input_ptr, output_desc, out_backprop_ptr,
+                  conv_desc, filter_desc, &filter_backprop_ptr,
+                  &scratch_allocator, AlgorithmConfig(), &best_result)
+              .ok();
+    }
     OP_REQUIRES(ctx, miopen_find_status && best_result.is_valid(),
                 errors::NotFound("Failed to find backward filter algorithm!"));
     algorithm_config.set_algorithm(best_result.algorithm());
@@ -1056,20 +1115,40 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                                                  algorithm_config);
   }
   DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize, ctx);
-  bool cudnn_launch_status =
-      stream
-          ->ThenConvolveBackwardFilterWithAlgorithm(
-              input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
-              filter_desc, &filter_backprop_ptr, &scratch_allocator,
-              algorithm_config, nullptr)
-          .ok();
-
+  bool cudnn_launch_status = true;
+  if (TestMIOpenBFloat16Support<T>()) {
+    cudnn_launch_status = stream
+                              ->ThenConvolveBackwardFilterWithAlgorithm(
+                                  input_desc, bfloat16_input_ptr, output_desc,
+                                  bfloat16_out_backprop_ptr, conv_desc,
+                                  filter_desc, &bfloat16_filter_backprop_ptr,
+                                  &scratch_allocator, algorithm_config, nullptr)
+                              .ok();
+  } else {
+    cudnn_launch_status =
+        stream
+            ->ThenConvolveBackwardFilterWithAlgorithm(
+                input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
+                filter_desc, &filter_backprop_ptr, &scratch_allocator,
+                algorithm_config, nullptr)
+            .ok();
+  }
   if (!cudnn_launch_status) {
     ctx->SetStatus(errors::Internal(
         "DNN Backward Filter function launch failure : input shape(",
         input.shape().DebugString(), ") filter shape(",
         filter_shape.DebugString(), ")"));
     return;
+  }
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    VLOG(3)
+        << "Convert the filter_backprop tensor back from bfloat16 to float.";
+    functor::ConvertFromBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(bfloat16_filter_backprop)
+            .tensor<bfloat16, 4>(),
+        pre_transformed_filter_backprop.tensor<T, 4>());
   }
 
   FilterTensorFormat src_filter_format =

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -30,6 +30,7 @@ limitations under the License.
 
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
+#include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/dnn.pb.h"
 #include "tensorflow/stream_executor/lib/array_slice.h"
@@ -132,6 +133,10 @@ struct ToDataType<int8> {
 template <>
 struct ToDataType<int32> {
   static constexpr DataType value = DataType::kInt32;
+};
+template <>
+struct ToDataType<tensorflow::bfloat16> {
+  static constexpr DataType value = DataType::kBFloat16;
 };
 
 // Specifies the types of a RNN model.

--- a/tensorflow/stream_executor/dnn.proto
+++ b/tensorflow/stream_executor/dnn.proto
@@ -10,6 +10,7 @@ enum DataType {
   kHalf = 2;
   kInt8 = 3;
   kInt32 = 4;
+  kBFloat16 = 5;
 }
 
 // Describes how a convolution input or output layer's data is formatted.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -1539,6 +1539,8 @@ miopenDataType_t ToMIOpenDataType(
   switch (data_type) {
     case dnn::DataType::kFloat:
       return miopenFloat;
+    case dnn::DataType::kBFloat16:
+      return miopenBFloat16;
     case dnn::DataType::kHalf:
       return miopenHalf;
     case dnn::DataType::kDouble:
@@ -1597,6 +1599,8 @@ int MIOpenDataTypeToByteSize(miopenDataType_t data_type) {
       return sizeof(float);
     case miopenHalf:
       return sizeof(Eigen::half);
+    case dnn::DataType::kBFloat16:
+      return sizeof(tensorflow::bfloat16);
     default:
       LOG(FATAL) << "Invalid DNN data type: " << static_cast<int>(data_type);
   }
@@ -1613,6 +1617,7 @@ dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
     case dnn::DataType::kDouble:
       return data_type;
     case dnn::DataType::kHalf:
+    case dnn::DataType::kBFloat16:
       // FIXME: Check if MIOpen can switch dynamically change accumulator type
       return dnn::DataType::kFloat;
     case dnn::DataType::kInt8:

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <memory>
 
 #include "absl/synchronization/mutex.h"
+#include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/stream_executor/blas.h"
 #include "tensorflow/stream_executor/device_memory.h"
@@ -332,16 +333,28 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
-  Stream &ThenConvolveWithAlgorithm(
-      const dnn::BatchDescriptor &input_descriptor,
-      const DeviceMemory<Eigen::half> &input_data,
-      const dnn::FilterDescriptor &filter_descriptor,
-      const DeviceMemory<Eigen::half> &filter_data,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::BatchDescriptor &output_descriptor,
-      DeviceMemory<Eigen::half> *output, ScratchAllocator *scratch_allocator,
-      const dnn::AlgorithmConfig &algorithm_config,
-      dnn::ProfileResult *output_profile_result);
+  Stream& ThenConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<tensorflow::bfloat16>* output,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<Eigen::half>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<Eigen::half>* output, ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenConvolveWithAlgorithm(
       const dnn::BatchDescriptor &input_descriptor,
@@ -470,17 +483,29 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
-  Stream &ThenConvolveBackwardDataWithAlgorithm(
-      const dnn::FilterDescriptor &filter_descriptor,
-      const DeviceMemory<Eigen::half> &filter_data,
-      const dnn::BatchDescriptor &output_descriptor,
+  Stream& ThenConvolveBackwardDataWithAlgorithm(
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<tensorflow::bfloat16> backward_output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& input_descriptor,
+      DeviceMemory<tensorflow::bfloat16>* backward_input_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveBackwardDataWithAlgorithm(
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<Eigen::half>& filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<Eigen::half> backward_output_data,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::BatchDescriptor &input_descriptor,
-      DeviceMemory<Eigen::half> *backward_input_data,
-      ScratchAllocator *scratch_allocator,
-      const dnn::AlgorithmConfig &algorithm_config,
-      dnn::ProfileResult *output_profile_result);
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& input_descriptor,
+      DeviceMemory<Eigen::half>* backward_input_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenConvolveBackwardFilterWithAlgorithm(
       const dnn::BatchDescriptor &input_descriptor,
@@ -506,17 +531,29 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
-  Stream &ThenConvolveBackwardFilterWithAlgorithm(
-      const dnn::BatchDescriptor &input_descriptor,
-      const DeviceMemory<Eigen::half> &input_data,
-      const dnn::BatchDescriptor &output_descriptor,
+  Stream& ThenConvolveBackwardFilterWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& input_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<tensorflow::bfloat16> backward_output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemory<tensorflow::bfloat16>* backward_filter_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveBackwardFilterWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<Eigen::half> backward_output_data,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::FilterDescriptor &filter_descriptor,
-      DeviceMemory<Eigen::half> *backward_filter_data,
-      ScratchAllocator *scratch_allocator,
-      const dnn::AlgorithmConfig &algorithm_config,
-      dnn::ProfileResult *output_profile_result);
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemory<Eigen::half>* backward_filter_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenConvolveBackwardBias(const dnn::BatchDescriptor &input_descriptor,
                                    const DeviceMemory<double> &input_data,


### PR DESCRIPTION
These are the changes used to test the MIOpen convolution APIs for the `blfoat16` datatype.

They work by changing the call to `float32` 2D convolutions as follows:
* convert the input tensors from `float32` to `bfloat16`
* call the MIOpen `blfoat16` conv API (instead of the `float32` version)
* convert the output tensors back from `bfloat16` to `float32`

The above changes are only activated when the env var `TF_ROCM_USE_BFLOAT16_FOR_CONV` is set. The use of the env var to activate this feature is required because these changes need to be merged into the main develop branch, where the default path for `float32` needs to remain unchanged.

This change is for testing the functionality of the MIOpen `blfoat16` conv apis only. Because the need to convert tensors `float32  <---> bfloat16` (and the associated memory allocations), performance is quite slower than the default `float32` path.

----------------------------------------

@whchung @sunway513 @dagamayank 

