### PR TITLE
Adding an explicit error message in the case where the call to workspace memory allocator fails

### DIFF
--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <tuple>
 #include <unordered_map>
 
+#include "absl/strings/str_cat.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
@@ -60,7 +61,10 @@ class DnnScratchAllocator : public se::ScratchAllocator {
                               "Requested negative byte size!"};
     }
     if (byte_size > memory_limit_) {
-      return se::port::StatusOr<se::DeviceMemory<uint8>>();
+      return se::port::Status{se::port::error::UNAVAILABLE,
+                              absl::StrCat("Requested memory size (", byte_size,
+                                           ") exceeds the max memory limit (",
+                                           memory_limit_, ").")};
     }
     AllocationAttributes allocation_attr;
     allocation_attr.no_retry_on_failure = true;
@@ -68,7 +72,10 @@ class DnnScratchAllocator : public se::ScratchAllocator {
         DT_UINT8, TensorShape({byte_size}), &temporary_memory,
         AllocatorAttributes(), allocation_attr));
     if (!allocation_status.ok()) {
-      return se::port::StatusOr<se::DeviceMemory<uint8>>();
+      return se::port::Status{
+          se::port::error::UNAVAILABLE,
+          absl::StrCat("Failed to allocate the requested memory size (",
+                       byte_size, ").")};
     }
     // Hold the reference of the allocated tensors until the end of the
     // allocator.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2662,6 +2662,14 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
       auto allocated = scratch_allocator->AllocateBytes(size_in_bytes);
       if (allocated.ok()) {
         scratch_memory_temp = allocated.ValueOrDie();
+      } else {
+        LOG(ERROR)
+            << "Failed to allocate scratch memory - "
+            << allocated.status().error_message() << "\n"
+            << "\tYou can set the env var TF_CUDNN_WORKSPACE_LIMIT_IN_MB to a "
+               "larger number (e.g. 8192) to increase the max memory limit.\n"
+            << "\tIncreasing the max memory limit might help resolve this "
+               "error";
       }
     }
 


### PR DESCRIPTION
Adding an explicit error message in the case where the call to workspace memory allocator fails

(in the routine MIOpenSupport::DoPrepareForConvolution).

Prior to this commit, the failure was getting ignored leading to misleading behaviour down the line.
 * In one case (alexnet, batch_size=1024, see MIOpen issue 1947), the subsequent call to "Find" (with allocated workspace memory size == 0) would fail, leading to a misleading error message indicating that "Find" failed to find an algorithm for the given convolution)
 * In another case (vgg16, see MIOpen issue 2052), the subsequent call to "Find" (with allocated workspace memory size == 0) returns a slower algorithm (than the algorithm that would have been returned if the call to allocate workspace memory had succeeded and consequently the workspace memory size argument to "Find" would have been set to the correct value)


In the first scenario above, adding the explicit error message is the right thing to do.                                                                                                                                                                           
                                                                                                                                                                                                                                                                   
In the second scenario above, a warning (instead of a error) is something to consider.                                                                                                                                                                             
In this case, we have (by accident, not ny design) the ability to "fall-back" to a "slower" algorithm (if one exists) when the workspace memory allocation fails.                                                                                                  
 * If we use a warning instead of error, we will continue to have this "fall-back" capability.                                                                                                                                                                     
 * On the flip-side a warning is easy to miss/ignore, and is not necssarily something folks check for when trying to debug performance issues.              


@whchung @sunway513 should we change error to a warning?
