### PR TITLE
[TF2.0] Disable XLA as default build option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1428,7 +1428,7 @@ def main():
   if is_ppc64le():
     write_action_env_to_bazelrc('OMP_NUM_THREADS', 1)
 
-  xla_enabled_by_default = is_linux() or is_macos()
+  xla_enabled_by_default = False
   set_build_var(environ_cp, 'TF_ENABLE_XLA', 'XLA JIT', 'with_xla_support',
                 xla_enabled_by_default, 'xla')
 


### PR DESCRIPTION
Synced up with @whchung and we agreed that this is the more appropriate way to disable xla support.