### PR TITLE
Removing contrib code base and targets

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -63,7 +63,6 @@ bazel test \
       -- \
       //tensorflow/... \
       -//tensorflow/compiler/... \
-      -//tensorflow/contrib/... \
       -//tensorflow/lite/... \
       -//tensorflow/python/compiler/tensorrt/... \
 


### PR DESCRIPTION
1st commit: Cherry pick [the upstream commit](https://github.com/tensorflow/tensorflow/commit/ffc25308ce2be84240ec90502b38800bc5a4dd60)
2nd commit: Remove our contrib targets in CI

Note: This should be part of the task in develop-upstream-sync-190923 but git did not apply all the deletes when merging (Since the merge-base have all those files). Besides, this is a relatively big PR that deserves to be regressed individually.