### PR TITLE
Upgrade CI to use ROCm2.8 userbits packages

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -550,7 +550,7 @@ static std::vector<string> GetROCDLPaths(int amdgpu_version,
       {"hc.amdgcn.bc", "opencl.amdgcn.bc", "ocml.amdgcn.bc", "ockl.amdgcn.bc",
        "oclc_finite_only_off.amdgcn.bc", "oclc_daz_opt_off.amdgcn.bc",
        "oclc_correctly_rounded_sqrt_on.amdgcn.bc",
-       "oclc_unsafe_math_off.amdgcn.bc"});
+       "oclc_unsafe_math_off.amdgcn.bc", "oclc_wavefrontsize64_on.amdgcn.bc"});
 
   // Construct full path to ROCDL bitcode libraries.
   std::vector<string> result;

--- a/tensorflow/compiler/xla/tests/BUILD
+++ b/tensorflow/compiler/xla/tests/BUILD
@@ -1400,9 +1400,7 @@ xla_test(
     name = "reduce_test",
     srcs = ["reduce_test.cc"],
     shard_count = 31,
-    tags = [
-        "optonly",
-    ],
+    tags = ["optonly", "no_rocm"],
     deps = [
         ":test_macros_header",
         "//tensorflow/compiler/xla:array2d",
@@ -1479,9 +1477,7 @@ xla_test(
     name = "select_and_scatter_test",
     timeout = "long",
     srcs = ["select_and_scatter_test.cc"],
-    tags = [
-        "optonly",
-    ],
+    tags = ["optonly", "no_rocm"],
     deps = [
         ":test_macros_header",
         "//tensorflow/compiler/xla:array2d",

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -3,7 +3,7 @@
 FROM ubuntu:xenial
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
-ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/2.6/
+ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/2.8.0/
 ARG ROCM_PATH=/opt/rocm
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -75,11 +75,11 @@ RUN apt-get update --allow-insecure-repositories && \
 # RUN cd $HOME/HIP && mkdir -p build && cd build && cmake .. && make package -j $(nproc) && dpkg -i ./hip*.deb
 #
 # Temporary workaround for HIP runtime: https://github.com/ROCm-Developer-Tools/HIP/pull/1464
-# The debian packages are based on rocm2.6. Need to manually update when we bump ROCm
-RUN wget https://www.dropbox.com/s/5jqnfi7h58ousg5/hip_base-1.5.19384.deb && dpkg -i hip_base*.deb
-RUN wget https://www.dropbox.com/s/32aycdpw7gaiffz/hip_hcc-1.5.19384.deb && dpkg -i hip_hcc*.deb
-RUN wget https://www.dropbox.com/s/px2rbqi2o15077g/hip_doc-1.5.19384.deb && dpkg -i hip_doc*.deb
-RUN wget https://www.dropbox.com/s/1dorsng8qe9i1av/hip_samples-1.5.19384.deb && dpkg -i hip_samples*.deb
+# The debian packages are based on rocm2.8. Need to manually update when we bump ROCm
+RUN wget https://www.dropbox.com/s/i9vro42u59h1768/hip_base-2.8.19386.4040-35e68f-amd64.deb && dpkg -i hip_base*.deb
+RUN wget https://www.dropbox.com/s/b2uh80ng6ahsej5/hip_hcc-2.8.19386.4040-35e68f-amd64.deb && dpkg -i hip_hcc*.deb
+RUN wget https://www.dropbox.com/s/ti2clu8lc8vyxcj/hip_doc-2.8.19386.4040-35e68f-amd64.deb && dpkg -i hip_doc*.deb
+RUN wget https://www.dropbox.com/s/z64fscz4kwc5jjh/hip_samples-2.8.19386.4040-35e68f-amd64.deb && dpkg -i hip_samples*.deb
 RUN rm hip_*.deb
 
 # Set up paths

--- a/tensorflow/tools/ci_build/builds/docker_test.sh
+++ b/tensorflow/tools/ci_build/builds/docker_test.sh
@@ -109,7 +109,7 @@ if [ "${IMAGE_TYPE}" == "gpu" ]; then
   libs=$(\ls /usr/lib/x86_64-linux-gnu/libcuda.* | xargs -I{} echo '-v {}:{}')
   GPU_EXTRA_PARAMS="${devices} ${libs}"
 elif [ "${IMAGE_TYPE}" == "rocm" ]; then
-  ROCM_EXTRA_PARAMS="--device=/dev/kfd --device=/dev/dri --group-add video"
+  ROCM_EXTRA_PARAMS="--device=/dev/kfd --device=/dev/dri --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --group-add video"
 else
   GPU_EXTRA_PARAMS=""
   ROCM_EXTRA_PARAMS=""

--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -111,7 +111,7 @@ fi
 
 # Add extra params for rocm devices and libraries for ROCm container.
 if [[ "${CONTAINER_TYPE}" == "rocm" ]]; then
-  ROCM_EXTRA_PARAMS="--device=/dev/kfd --device=/dev/dri --group-add video"
+  ROCM_EXTRA_PARAMS="--device=/dev/kfd --device=/dev/dri --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --group-add video"
 else
   ROCM_EXTRA_PARAMS=""
 fi


### PR DESCRIPTION
This PR is part of the process to move TF-ROCM CI builds to use ROCm2.8 as the base. 
Additional docker run options `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined` is required by the THUNK library, for details, refer to the following notes:
https://github.com/RadeonOpenCompute/ROCm#docker-container-environment-variable-setting