### PR TITLE
Pruning cpp tests to setup the `rocm-cpp` CI job

### DIFF
--- a/tensorflow/cc/BUILD
+++ b/tensorflow/cc/BUILD
@@ -438,6 +438,7 @@ cc_library(
 tf_cc_test(
     name = "gradients_nn_grad_test",
     srcs = ["gradients/nn_grad_test.cc"],
+    tags = ["no_rocm"],
     deps = [
         ":cc_ops",
         ":cc_ops_internal",

--- a/tensorflow/core/api_def/BUILD
+++ b/tensorflow/core/api_def/BUILD
@@ -101,6 +101,7 @@ tf_cc_test(
         ":base_api_def",
         ":python_api_def",
     ],
+    tags = ["no_rocm"],
     deps = [
         ":excluded_ops_lib",
         "//tensorflow/core:framework",

--- a/tensorflow/core/distributed_runtime/BUILD
+++ b/tensorflow/core/distributed_runtime/BUILD
@@ -578,6 +578,7 @@ tf_cc_test(
     name = "collective_param_resolver_distributed_test",
     size = "small",
     srcs = ["collective_param_resolver_distributed_test.cc"],
+    tags = ["no_rocm"],
     deps = [
         ":collective_param_resolver_distributed",
         ":device_resolver_distributed",

--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -114,7 +114,10 @@ tf_cc_test(
     shard_count = 5,
     # Running cuda on cpu will trigger tests guarded by GOOGLE_CUDA but NCHW
     # won't be available, which result in test failures. So disable that.
-    tags = ["no_cuda_on_cpu_tap"],
+    tags = [
+        "no_cuda_on_cpu_tap",
+        "no_rocm",
+    ],
     deps = [
         ":constant_folding",
         ":dependency_optimizer",

--- a/tensorflow/lite/delegates/gpu/common/memory_management/internal.cc
+++ b/tensorflow/lite/delegates/gpu/common/memory_management/internal.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "tensorflow/lite/delegates/gpu/common/memory_management/internal.h"
 
+#include <algorithm>
+
 namespace tflite {
 namespace gpu {
 

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -1,6 +1,7 @@
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_portable_test_suite_combined")
 load("//tensorflow:tensorflow.bzl", "tf_opts_nortti_if_android")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 
 package(
     default_visibility = [
@@ -342,6 +343,7 @@ cc_library(
 cc_test(
     name = "cpu_backend_gemm_test",
     srcs = ["cpu_backend_gemm_test.cc"],
+    linkopts = if_rocm(["-lm"]),
     tags = ["notsan"],
     deps = [
         ":cpu_backend_context",

--- a/tensorflow/lite/kernels/internal/BUILD
+++ b/tensorflow/lite/kernels/internal/BUILD
@@ -1,6 +1,7 @@
 load("//tensorflow:tensorflow.bzl", "transitive_hdrs")
 load("//tensorflow/lite:build_def.bzl", "tflite_copts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_portable_test_suite_combined")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 
 package(
     default_visibility = [
@@ -343,6 +344,7 @@ cc_library(
 cc_test(
     name = "quantization_util_test",
     srcs = ["quantization_util_test.cc"],
+    linkopts = if_rocm(["-lm"]),
     deps = [
         ":quantization_util",
         "@com_google_googletest//:gtest_main",

--- a/tensorflow/lite/tools/evaluation/stages/utils/BUILD
+++ b/tensorflow/lite/tools/evaluation/stages/utils/BUILD
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 load("//tensorflow/lite:build_def.bzl", "tflite_copts", "tflite_linkopts")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 
 package(
     default_visibility = ["//tensorflow/lite:__subpackages__"],
@@ -34,7 +35,7 @@ cc_library(
 cc_test(
     name = "image_metrics_test",
     srcs = ["image_metrics_test.cc"],
-    linkopts = tflite_linkopts(),
+    linkopts = tflite_linkopts() + if_rocm(["-lm"]),
     linkstatic = 1,
     deps = [
         ":image_metrics",

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -30,6 +30,7 @@ export PYTHON_BIN_PATH=`which python3`
 export CC_OPT_FLAGS='-mavx'
 
 export TF_NEED_ROCM=1
+export TF_NEED_CUDA=0
 export TF_GPU_COUNT=${N_GPUS}
 
 yes "" | $PYTHON_BIN_PATH configure.py
@@ -41,4 +42,7 @@ bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm
     --test_sharding_strategy=disabled \
     --test_size_filters=small,medium \
     --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
-    //tensorflow/... -//tensorflow/compiler/...
+    //tensorflow/... \
+    -//tensorflow/compiler/... \
+    -//tensorflow/lite/delegates/gpu/gl/... \
+    -//tensorflow/lite/delegates/gpu/cl/...


### PR DESCRIPTION
This PR basically does the following
* adds `no_rocm` tag to 4 failing test in the CPP testsuite
* prune the dirs `tensorflow/lite/delegates/gpu/[cl,gl]` from the list of dirs to test 
  * targets within those dirs are causing compile errors...they seem to require the host platform to have header files ( `EGL/egl.h`, others) that do not seem to present on the ROCm platform. Perhaps these dirs need to be excluded from `--config=rocm` build anyway
* couple of other minor tweaks to fix compile time errors.

-----------------------------

@whchung @parallelo 
