### PR TITLE
remove no_rocm tag from //tensorflow/python:nn_fused_batchnorm_test

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -4489,7 +4489,6 @@ cuda_py_test(
         "//third_party/py/numpy",
     ],
     shard_count = 16,
-    tags = ["no_rocm"],
 )
 
 cuda_py_test(


### PR DESCRIPTION
This test in our repo is size medium while upstream master has it as large.  Test is passing when run on my workstation. @deven-amd will follow up with info on possible mystery failure that he observed previously for this test.