### PR TITLE
MLIR unit test updates in the XLA testsuite

### DIFF
--- a/tensorflow/compiler/mlir/glob_lit_test.bzl
+++ b/tensorflow/compiler/mlir/glob_lit_test.bzl
@@ -10,7 +10,7 @@
 _default_test_file_exts = ["mlir", ".pbtxt", ".td"]
 _default_driver = "@local_config_mlir//:run_lit.sh"
 _default_size = "small"
-_default_tags = ["no_rocm"]
+_default_tags = []
 
 # These are patterns which we should never match, for tests, subdirectories, or
 # test input data files.

--- a/tensorflow/compiler/mlir/lite/tests/end2end/BUILD
+++ b/tensorflow/compiler/mlir/lite/tests/end2end/BUILD
@@ -11,6 +11,12 @@ glob_lit_tests(
     test_file_exts = [
         "pbtxt",
     ],
+    tags_override = {
+        "add.pbtxt" : ["no_rocm"],
+        "conv_2d.pbtxt" : ["no_rocm"],
+        "fake_quant_per_channel.pbtxt" : ["no_rocm"],
+        "ophint_lstm.pbtxt" : ["no_rocm"],
+    },
 )
 
 # Bundle together all of the test utilities that are used by tests.

--- a/tensorflow/compiler/mlir/tensorflow/BUILD
+++ b/tensorflow/compiler/mlir/tensorflow/BUILD
@@ -505,7 +505,6 @@ tf_cc_test(
     name = "convert_tensor_test",
     size = "small",
     srcs = ["utils/convert_tensor_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":convert_tensor",
         "//tensorflow/compiler/xla:test",
@@ -693,7 +692,6 @@ cc_library(
 tf_cc_test(
     name = "error_util_test",
     srcs = ["utils/error_util_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":error_util",
         "//tensorflow/compiler/xla:test",
@@ -787,7 +785,6 @@ tf_cc_test(
     name = "compile_mlir_util_test",
     size = "small",
     srcs = ["utils/compile_mlir_util_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":compile_mlir_util",
         "//tensorflow/compiler/tf2xla:common",

--- a/tensorflow/compiler/mlir/tensorflow/utils/error_util_test.cc
+++ b/tensorflow/compiler/mlir/tensorflow/utils/error_util_test.cc
@@ -58,7 +58,11 @@ TEST(ErrorUtilTest, StatusScopedDiagnosticHandler) {
       emitError(loc) << "Second diagnostic message reported";
       return tensorflow::errors::Internal("Passed in error");
     };
-    Status s = StatusScopedDiagnosticHandler(&context).Combine(function());
+
+    // For this test to work correctly, the StatusScopedDiagnosticHandler must
+    // be instantiated before "function" gets called.
+    StatusScopedDiagnosticHandler handler(&context);
+    Status s = handler.Combine(function());
     ASSERT_TRUE(tensorflow::errors::IsInternal(s));
     EXPECT_THAT(s.error_message(), HasSubstr("Passed in error"));
     EXPECT_THAT(s.error_message(), HasSubstr("Diagnostic message reported"));


### PR DESCRIPTION
This PR 
* removes the "no_rocm" tag that was being added by default to all the MLIR tests. 
* adds the "no_rocm" tag to the specific MLIR tests that are failing on the ROCm platform. 
*  fixes one of the failing MLIR tests