### PR TITLE
Add back alwayslink build attributes

### DIFF
--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -268,6 +268,7 @@ cc_library(
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/synchronization",
     ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/tensorflow/core/platform/default/build_refactor.bzl
+++ b/tensorflow/core/platform/default/build_refactor.bzl
@@ -210,6 +210,7 @@ TF_DEFAULT_PLATFORM_LIBRARIES = {
         ],
         "visibility": ["//visibility:private"],
         "tags": ["no_oss", "manual"],
+        "alwayslink": 1,
     },
     "notification": {
         "name": "notification_impl",
@@ -298,6 +299,7 @@ TF_DEFAULT_PLATFORM_LIBRARIES = {
         ],
         "tags": ["no_oss", "manual"],
         "visibility": ["//visibility:private"],
+        "alwayslink": 1,
     },
     "test": {
         "name": "test_impl",

--- a/tensorflow/lite/python/testdata/BUILD
+++ b/tensorflow/lite/python/testdata/BUILD
@@ -61,6 +61,7 @@ cc_library(
     deps = [
         "//tensorflow/lite/c:c_api_internal",
     ],
+    alwayslink = 1,
 )
 
 cc_binary(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -442,6 +442,7 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:protos_all_cc",
     ],
+    alwayslink = 1,
 )
 
 tf_python_pybind_extension(

--- a/third_party/icu/data/BUILD.bazel
+++ b/third_party/icu/data/BUILD.bazel
@@ -40,4 +40,5 @@ cc_library(
     name = "conversion_data",
     srcs = [":conversion_data.c"],
     deps = ["@icu//:headers"],
+    alwayslink = 1,
 )


### PR DESCRIPTION
Adding back alwayslink lines to avoid undefined symbol errors during builds of the develop-upstream-sync-191104

TF CI for our weekly upstream-sync was hitting these errors:
```
ImportError: /root/.cache/bazel/_bazel_root/86706540226bed5af3f7ba9c1699e357/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/python/keras/api/create_tensorflow.python_api_2_keras_python_api_gen_compat_v2.runfiles/org_tensorflow/tensorflow/python/_pywrap_tensorflow_internal.so: 
undefined symbol: _ZN10tensorflow6Logger12GetSingletonEv
Failed to load the native TensorFlow runtime.
FAILED: Build did NOT complete successfully
```
We found that multiple instances of `alwayslink` were recently removed from `BUILD` files, and these are conflicting with the upstream-sync process.  