### PR TITLE
[DO NOT MERGE] Develop upstream amend gpu selection

### DIFF
--- a/rocm_docs/tensorflow-quickstart.md
+++ b/rocm_docs/tensorflow-quickstart.md
@@ -68,7 +68,7 @@ Run the training:
 ```
 cd ~/models/tutorials/image/cifar10
 
-export HIP_VISIBLE_DEVICES=0
+export ROCR_VISIBLE_DEVICES=0
 python3 ./cifar10_train.py
 ```
 
@@ -88,13 +88,13 @@ You should see output similar to this:
 
 #### Evaluation (via terminal #2)
 
-Note: If you have a second GPU, you can run the evaluation in parallel with the training -- to do so, just change `HIP_VISIBLE_DEVICES` to your second GPU's ID.  If you only have a single GPU, it is best to wait until training is complete, otherwise you risk running out of device memory.  
+Note: If you have a second GPU, you can run the evaluation in parallel with the training -- to do so, just change `ROCR_VISIBLE_DEVICES` to your second GPU's ID.  If you only have a single GPU, it is best to wait until training is complete, otherwise you risk running out of device memory.
 
 To run the evaluation, follow this:  
 ```
 cd ~/models/tutorials/image/cifar10
 
-export HIP_VISIBLE_DEVICES=0
+export ROCR_VISIBLE_DEVICES=0
 python3 ./cifar10_eval.py
 ```
 

--- a/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
+++ b/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
@@ -68,7 +68,7 @@ for j in `seq 0 $((TF_TESTS_PER_GPU-1))`; do
         # This export only works within the brackets, so it is isolated to one
         # single command.
         export CUDA_VISIBLE_DEVICES=$i
-        export HIP_VISIBLE_DEVICES=$i
+        export ROCR_VISIBLE_DEVICES=$i
         echo "Running test $TEST_BINARY $* on GPU $CUDA_VISIBLE_DEVICES"
         "$TEST_BINARY" $@
       )

--- a/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
+++ b/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
@@ -67,7 +67,6 @@ for j in `seq 0 $((TF_TESTS_PER_GPU-1))`; do
       (
         # This export only works within the brackets, so it is isolated to one
         # single command.
-        export CUDA_VISIBLE_DEVICES=$i
         export ROCR_VISIBLE_DEVICES=$i
         echo "Running test $TEST_BINARY $* on GPU $CUDA_VISIBLE_DEVICES"
         "$TEST_BINARY" $@


### PR DESCRIPTION
This PR amend the GPU selection method in TF CI check to use ROCR_VISIBLE_DEVICES instead of HIP_VISIBLE_DEVICES for better resources isolation. 