### PR TITLE
missing TENSORFLOW_USE_ROCM in collective_param_resolver_distributed_…

### DIFF
--- a/tensorflow/core/distributed_runtime/BUILD
+++ b/tensorflow/core/distributed_runtime/BUILD
@@ -578,7 +578,6 @@ tf_cc_test(
     name = "collective_param_resolver_distributed_test",
     size = "small",
     srcs = ["collective_param_resolver_distributed_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":collective_param_resolver_distributed",
         ":device_resolver_distributed",

--- a/tensorflow/core/distributed_runtime/collective_param_resolver_distributed_test.cc
+++ b/tensorflow/core/distributed_runtime/collective_param_resolver_distributed_test.cc
@@ -315,7 +315,7 @@ TEST_F(DeviceResDistTest, Workers2Devices2) {
   ValidateCollectiveParams(num_workers, num_devices);
 }
 
-#ifndef GOOGLE_CUDA
+#if !GOOGLE_CUDA && !TENSORFLOW_USE_ROCM
 namespace {
 // A mock NcclReducer for testing group runtime details initialization with CPU
 // builds.  The only meaningful function in this class is


### PR DESCRIPTION
…test.cc