### PR TITLE
Do not uninstall existing tensorflow before build is done

### DIFF
--- a/build_rocm
+++ b/build_rocm
@@ -21,7 +21,6 @@ TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
 
 yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
-pip uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
-pip install $TF_PKG_LOC/tensorflow*.whl
+pip install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -20,9 +20,7 @@
 TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
 
-
 yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
-pip3 uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
-pip3 install $TF_PKG_LOC/tensorflow*.whl
+pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/build_rocm_verbs
+++ b/build_rocm_verbs
@@ -9,7 +9,6 @@
 # press enter all the way
 #
 yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
-pip uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm --config=verbs --config=gdr //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
-pip install /tmp/tensorflow_pkg/tensorflow-1.12.0rc0-cp27-cp27m-linux_x86_64.whl
+pip install --upgrade /tmp/tensorflow_pkg/tensorflow-1.12.0rc0-cp27-cp27m-linux_x86_64.whl

--- a/build_rocm_xla_python3
+++ b/build_rocm_xla_python3
@@ -20,9 +20,7 @@
 TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
 
-
 yes "" | TF_NEED_ROCM=1 TF_ENABLE_XLA=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
-pip3 uninstall -y tensorflow || true
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
-pip3 install $TF_PKG_LOC/tensorflow*.whl
+pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl


### PR DESCRIPTION
Currently `build_rocm` scripts uninstall existing tensorflow before starting `Bazel` build.
Well, the build might fail. In that case the user needs to reinstall old tensorflow. User might not have old tensorflow wheel.
I think it would be better if we keep old tensorflow until the build if done.
Also, instead of uninstalling old and installing new tensorflow explicitly we can use pip parameter `--upgrade`. Command `pip --upgrade <whl>` will uninstall old and installing new tensorflow wheel.