### PR TITLE
Make ROCm Install more explicit in README + info about 2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please follow the instructions
 to set up your ROCm stack.
 
 A Docker container:
-**[rocm/tensorflow:latest](https://hub.docker.com/r/rocm/tensorflow/)**
+**[rocm/tensorflow:latest](https://hub.docker.com/r/rocm/tensorflow/tags)**
 is readily available to be used:
 ```
 $ alias drun='sudo docker run -it --network=host --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $HOME/dockerx:/dockerx'

--- a/README.md
+++ b/README.md
@@ -32,19 +32,27 @@ See all the [mailing lists](https://www.tensorflow.org/community/forums).
 
 ## TensorFlow ROCm port
 
-This project is based on TensorFlow 1.14.0. It has been verified to work with
-the latest [ROCm2.6](https://github.com/RadeonOpenCompute/ROCm) release.
+This repository hosts the port of TensorFlow on [ROCm](https://rocm.github.io/)
+open platform. It uses various ROCm technologies such as
+[HIP](https://github.com/ROCm-Developer-Tools/HIP) and
+[MIOpen](https://github.com/ROCmSoftwarePlatform/MIOpen).
+For details on TensorFlow ROCm port,
+see [ROCm-specific README file](README.ROCm.md).
 
-We maintain `tensorflow-rocm` Python wheel packages on [PyPI](https://pypi.org/project/tensorflow-rocm).
+- TensorFlow ROCm 1.14 works with ROCm2.6.
+- TensorFlow ROCm 2.0 works with ROCm2.9.
 
-For details on TensorFlow ROCm port, please take a look at the [ROCm-specific README file](README.ROCm.md).
+We maintain `tensorflow-rocm` Python wheel packages
+on [PyPI](https://pypi.org/project/tensorflow-rocm).
 
 ## Install (TensorFlow ROCm port)
 
-Please follow the instructions [here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md)
+Please follow the instructions
+[here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md)
 to set up your ROCm stack.
 
-A Docker container: **[rocm/tensorflow:latest](https://hub.docker.com/r/rocm/tensorflow/)**
+A Docker container:
+**[rocm/tensorflow:latest](https://hub.docker.com/r/rocm/tensorflow/)**
 is readily available to be used:
 ```
 $ alias drun='sudo docker run -it --network=host --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $HOME/dockerx:/dockerx'

--- a/README.md
+++ b/README.md
@@ -30,25 +30,41 @@ to
 [announce@tensorflow.org](https://groups.google.com/a/tensorflow.org/forum/#!forum/announce).
 See all the [mailing lists](https://www.tensorflow.org/community/forums).
 
-**Tensorflow ROCm port**
-This project is based on TensorFlow 1.14.0. It has been verified to work with the latest ROCm2.6 release.
-Please follow the instructions [here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md) to set up your ROCm stack.
-A docker container: **rocm/tensorflow:latest(https://hub.docker.com/r/rocm/tensorflow/)** is readily available to be used:
-```
-alias drun='sudo docker run -it --network=host --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $HOME/dockerx:/dockerx'
-drun rocm/tensorflow
-```
-We maintain `tensorflow-rocm` whl packages on PyPI [here](https://pypi.org/project/tensorflow-rocm), to install tensorflow-rocm package using pip:
-```
-# Install some ROCm dependencies
-sudo apt install rocm-libs hipcub miopen-hip
+## TensorFlow ROCm port
 
-# Pip3 install the whl package from PyPI
-pip3 install --user tensorflow-rocm --upgrade
-```
-For details on Tensorflow ROCm port, please take a look at the [ROCm-specific README file](README.ROCm.md).
+This project is based on TensorFlow 1.14.0. It has been verified to work with
+the latest [ROCm2.6](https://github.com/RadeonOpenCompute/ROCm) release.
 
-## Install
+We maintain `tensorflow-rocm` Python wheel packages on [PyPI](https://pypi.org/project/tensorflow-rocm).
+
+For details on TensorFlow ROCm port, please take a look at the [ROCm-specific README file](README.ROCm.md).
+
+## Install (TensorFlow ROCm port)
+
+Please follow the instructions [here](https://github.com/RadeonOpenCompute/ROCm-docker/blob/master/quick-start.md)
+to set up your ROCm stack.
+
+A Docker container: **[rocm/tensorflow:latest](https://hub.docker.com/r/rocm/tensorflow/)**
+is readily available to be used:
+```
+$ alias drun='sudo docker run -it --network=host --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $HOME/dockerx:/dockerx'
+
+$ drun rocm/tensorflow
+```
+
+To install ROCm dependencies:
+
+```
+$ sudo apt install rocm-libs hipcub miopen-hip
+```
+
+To install the current release of TensorFlow ROCm port:
+
+```
+$ pip install --user --upgrade tensorflow-rocm
+```
+
+## Install (official TensorFlow)
 
 See the [TensorFlow install guide](https://www.tensorflow.org/install) for the
 [pip package](https://www.tensorflow.org/install/pip), to


### PR DESCRIPTION
- Fix Docker link
- Make command line style consistent with original TensorFlow README (use $ to mark prompt)
- Make sections to make the ROCm installation instructions more visible
- Add info about TensorFlow 2.0 ROCm port release