### PR TITLE
cherry-picking commit to change eigen pointer, updating CI scripts to skip v1only tests

### DIFF
--- a/tensorflow/tools/api/tests/BUILD
+++ b/tensorflow/tools/api/tests/BUILD
@@ -45,11 +45,7 @@ py_test(
     srcs = ["deprecation_test.py"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
-    tags = [
-        "no_cuda",
-        "no_rocm",
-        "v1only",
-    ],
+    tags = ["v1only"],
     deps = [
         "//tensorflow:tensorflow_py",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -30,33 +30,38 @@ export PYTHON_BIN_PATH=`which python3`
 export CC_OPT_FLAGS='-mavx'
 
 export TF_NEED_ROCM=1
-export TF_NEED_CUDA=0
 export TF_GPU_COUNT=${N_GPUS}
 
 yes "" | $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
 bazel test \
-      --config=rocm --config=opt \
+      --config=rocm \
       -k \
-      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu \
-      --test_lang_filters=cc --jobs=${N_JOBS} --test_timeout 300,450,1200,3600 \
-      --build_tests_only --test_output=errors --local_test_jobs=${TF_GPU_COUNT}\
+      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
+      --test_lang_filters=cc \
+      --jobs=${N_JOBS} \
+      --local_test_jobs=${TF_GPU_COUNT}\
+      --test_timeout 300,450,1200,3600 \
+      --build_tests_only \
+      --test_output=errors \
       --test_sharding_strategy=disabled \
       --test_size_filters=small,medium \
-      --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
+      --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
+      -- \
       //tensorflow/... \
       -//tensorflow/compiler/... \
       -//tensorflow/lite/delegates/gpu/gl/... \
       -//tensorflow/lite/delegates/gpu/cl/... \
 && bazel test \
-      --config=rocm --config=opt \
+      --config=rocm \
       -k \
-      --test_tag_filters=-no_rocm \
-      --test_timeout 600,900,2400,7200 \
-      --test_output=errors \
+      --test_tag_filters=-no_gpu,-no_rocm,-v1only \
       --jobs=${N_JOBS} \
       --local_test_jobs=1 \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
       --test_sharding_strategy=disabled \
       -- \
       //tensorflow/core/nccl:nccl_manager_test

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -38,11 +38,11 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu,-no_gpu,-no_rocm,-benchmark-test,-no_oss,-oss_serial,-rocm_multi_gpu, \
-      --test_timeout 600,900,2400,7200 \
-      --test_output=errors \
+      --test_tag_filters=gpu,-no_gpu,-no_rocm,-benchmark-test,-no_oss,-oss_serial,-rocm_multi_gpu,-v1only \
       --jobs=${N_JOBS} \
       --local_test_jobs=${TF_GPU_COUNT} \
+      --test_timeout 600,900,2400,7200 \
+      --test_output=errors \
       --test_sharding_strategy=disabled \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
@@ -53,11 +53,11 @@ bazel test \
 && bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu \
-      --test_timeout 600,900,2400,7200 \
-      --test_output=errors \
+      --test_tag_filters=-no_gpu,-no_rocm,-v1only \
       --jobs=${N_JOBS} \
       --local_test_jobs=1 \
+      --test_timeout 600,900,2400,7200 \
+      --test_output=errors \
       --test_sharding_strategy=disabled \
       -- \
       //tensorflow/core/nccl:nccl_manager_test

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -35,9 +35,18 @@ export TF_GPU_COUNT=${N_GPUS}
 yes "" | $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
-bazel test --config=rocm --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test -k \
-    --test_lang_filters=py --jobs=${N_JOBS} --test_timeout 600,900,2400,7200 \
-    --build_tests_only --test_output=errors --local_test_jobs=${TF_GPU_COUNT} --config=opt \
-    --test_sharding_strategy=disabled \
-    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute -- \
-    //tensorflow/... -//tensorflow/compiler/...
+bazel test \
+      --config=rocm \
+      -k \
+      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
+      --test_lang_filters=py \
+      --jobs=${N_JOBS} \
+      --local_test_jobs=${TF_GPU_COUNT} \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
+      -- \
+      //tensorflow/... \
+      -//tensorflow/compiler/...

--- a/tensorflow/tools/compatibility/BUILD
+++ b/tensorflow/tools/compatibility/BUILD
@@ -164,11 +164,7 @@ py_test(
     srcs = ["tf_upgrade_v2_test.py"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
-    tags = [
-        "no_cuda",
-        "no_rocm",
-        "v1only",
-    ],
+    tags = ["v1only"],
     deps = [
         ":tf_upgrade_v2_lib",
         "//tensorflow:tensorflow_py",
@@ -253,11 +249,7 @@ py_test(
     srcs = ["testdata/test_file_v1_12.py"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
-    tags = [
-        "no_cuda",
-        "no_rocm",
-        "v1only",
-    ],
+    tags = ["v1only"],
     deps = [
         "//tensorflow:tensorflow_py",
     ],

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -172,11 +172,11 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
         name = "eigen_archive",
         build_file = clean_dep("//third_party:eigen.BUILD"),
         patch_file = clean_dep("//third_party/eigen3:gpu_packet_math.patch"),
-        sha256 = "6d8ed482addd14892d7b0bd98fec2c02f18fdab97775bda68c3f2a99ffb190fb",
-        strip_prefix = "eigen-eigen-66be6c76fc01",
+        sha256 = "add24720f99ab4f3222f4c8a887f2609554cf9187d4f7d24a777a151a0ee2548",
+        strip_prefix = "eigen-git-mirror-4898dcdb06f1b1b0441b8e15119764793f8997e2",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/bitbucket.org/eigen/eigen/get/66be6c76fc01.tar.gz",
-            "https://bitbucket.org/eigen/eigen/get/66be6c76fc01.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/eigenteam/eigen-git-mirror/archive/4898dcdb06f1b1b0441b8e15119764793f8997e2.tar.gz",
+            "https://github.com/eigenteam/eigen-git-mirror/archive/4898dcdb06f1b1b0441b8e15119764793f8997e2.tar.gz",
         ],
     )
 

--- a/third_party/eigen3/gpu_packet_math.patch
+++ b/third_party/eigen3/gpu_packet_math.patch
@@ -180,3 +180,27 @@
 +}  // end namespace Eigen
 +
 +#endif  // HIP_VECTOR_COMPATIBILITY_H
+--- a/Eigen/src/Core/GenericPacketMath.h
++++ b/Eigen/src/Core/GenericPacketMath.h
+@@ -247,7 +247,8 @@
+ template <typename Packet>
+ EIGEN_DEVICE_FUNC inline Packet pfrexp(const Packet& a, Packet& exponent) {
+   int exp;
+-  Packet result = std::frexp(a, &exp);
++  EIGEN_USING_STD_MATH(frexp);
++  Packet result = frexp(a, &exp);
+   exponent = static_cast<Packet>(exp);
+   return result;
+ }
+@@ -256,7 +257,10 @@
+   * See https://en.cppreference.com/w/cpp/numeric/math/ldexp
+   */
+ template<typename Packet> EIGEN_DEVICE_FUNC inline Packet
+-pldexp(const Packet &a, const Packet &exponent) { return std::ldexp(a, static_cast<int>(exponent)); }
++pldexp(const Packet &a, const Packet &exponent) {
++  EIGEN_USING_STD_MATH(ldexp);
++  return ldexp(a, static_cast<int>(exponent));
++}
+
+ /** \internal \returns zeros */
+ template<typename Packet> EIGEN_DEVICE_FUNC inline Packet


### PR DESCRIPTION
This PR does a couple of different things.

* It cherry-picks a commit from the upstream repo to download eigen from its github mirror, instead of from bit-bucket. Eigen repo is in the process of being moved from bitbucket to gitlab, and it seems the download links to bitbucket repo are not working.
  * This also requires pulling in a commit to fix the eigen breakage introduced by an eigen pointer update earlier this week

* updates the CI scripts to drop tests that have the `v1only` tag. Those tests are intended to be run with TF1.x only, and this branch now build TF2.x by default