### PR TITLE
Use CPU to generate random state in dropout

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4538,6 +4538,7 @@ tf_kernel_library(
     prefix = "dropout_op",
     deps = NN_DEPS + [
         ":conv_ops",
+        ":random_op",
     ],
 )
 

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -332,7 +332,7 @@ REGISTER_OP("Dropout")
     .Input("noise_shape: int32")
     .Input("seed: int64")
     .Output("output: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, half}")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("DropoutGrad")
@@ -341,7 +341,7 @@ REGISTER_OP("DropoutGrad")
     .Input("noise_shape: int32")
     .Input("seed: int64")
     .Output("backprops: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, half}")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 // --------------------------------------------------------------------------

--- a/tensorflow/core/util/guarded_philox_random.cc
+++ b/tensorflow/core/util/guarded_philox_random.cc
@@ -51,6 +51,11 @@ void GuardedPhiloxRandom::Init(random::PhiloxRandom::ResultType counter,
   initialized_ = true;
 }
 
+void GuardedPhiloxRandom::ResetSeeds(int64 seed, int64 seed2) {
+  mutex_lock lock(mu_);
+  generator_ = random::PhiloxRandom(seed, seed2);
+}
+
 random::PhiloxRandom GuardedPhiloxRandom::ReserveSamples128(int64 samples) {
   CHECK(initialized_);
   mutex_lock lock(mu_);

--- a/tensorflow/core/util/guarded_philox_random.h
+++ b/tensorflow/core/util/guarded_philox_random.h
@@ -52,6 +52,9 @@ class GuardedPhiloxRandom {
   void Init(random::PhiloxRandom::ResultType counter,
             random::PhiloxRandom::Key key);
 
+  // Used by dropout operator to reset seed to achieve same random state
+  void ResetSeeds(int64 seed, int64 seed2);
+
   // Reserve a certain number of 128-bit samples.
   // This function is thread safe.  The returned generator is valid for the
   // given number of samples, and can be used without a lock.

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -1079,7 +1079,7 @@ def ConditionalRegister(dec, condition):
 @ConditionalRegister(ops.RegisterGradient("Dropout"),build_info.is_rocm_build)
 def _DropoutGrad(op, grad):
   dx = 0
-  if op.inputs[0].dtype is dtypes.float32:
+  if op.inputs[0].dtype == dtypes.float32 or op.inputs[0].dtype == dtypes.float16:
     dx = gen_nn_ops.dropout_grad(
           grad, op.inputs[1], op.inputs[2], op.inputs[3])
   else:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4472,7 +4472,8 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
 
       # Should there be ROCm support, use it. Otherwise fallback to generic
       # implementation
-      if build_info.is_rocm_build and x.dtype is dtypes.float32:
+      if build_info.is_rocm_build and \
+         (x.dtype == dtypes.float32 or x.dtype == dtypes.float16):
         if seed is None:
           seed = 0
         return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
@@ -4525,7 +4526,8 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
 
       # Should there be ROCm support, use it. Otherwise fallback to generic
       # implementation
-      if build_info.is_rocm_build and x.dtype is dtypes.float32:
+      if build_info.is_rocm_build and \
+         (x.dtype == dtypes.float32 or x.dtype == dtypes.float16):
         if seed is None:
           seed = 0
         return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -306,6 +306,32 @@ class L2NormalizeTest(test_lib.TestCase):
 
 class DropoutTest(test_lib.TestCase):
 
+  def testDropoutFloat16(self):
+    # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
+    # that it is producing approximately the right number of ones over a large
+    # number of samples, based on the keep probability.
+    x_dim = 40
+    y_dim = 30
+    num_iter = 10
+    for keep_prob in [0.1, 0.5, 0.8]:
+      t = constant_op.constant(1.0, shape=[x_dim, y_dim], dtype=dtypes.float16)
+      dropout = nn_ops.dropout(t, rate=(1 - keep_prob))
+      final_count = 0
+      self.assertEqual([x_dim, y_dim], dropout.get_shape())
+      for _ in xrange(0, num_iter):
+        value = self.evaluate(dropout)
+        final_count += np.count_nonzero(value)
+        # Verifies that there are only two values: 0 and 1/keep_prob.
+        sorted_value = np.unique(np.sort(value))
+        self.assertEqual(0, sorted_value[0])
+        self.assertAllClose(1 / keep_prob, sorted_value[1], rtol=0.1, atol=0.1)
+
+      # Check that we are in the 15% error range
+      expected_count = x_dim * y_dim * keep_prob * num_iter
+      rel_error = math.fabs(final_count - expected_count) / expected_count
+      self.assertTrue(rel_error < 0.15)
+
+
   def testDropout(self):
     # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
     # that it is producing approximately the right number of ones over a large
@@ -331,6 +357,21 @@ class DropoutTest(test_lib.TestCase):
       rel_error = math.fabs(final_count - expected_count) / expected_count
       print(rel_error)
       self.assertTrue(rel_error < 0.15)
+
+  @test_util.run_deprecated_v1
+  def testDropoutGradFloat16(self):
+    if not test_lib.is_built_with_rocm():
+      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
+
+    x_dim = 40
+    y_dim = 30
+    shape = [x_dim, y_dim]
+    rate = 0.1
+    with self.cached_session(use_gpu=True):
+      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float16)
+      value = nn_ops.dropout(t, rate=rate)
+      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
+      self.assertLess(err, 0.5)
 
   @test_util.run_deprecated_v1
   def testDropoutGradFloat32(self):

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1672,21 +1672,9 @@ class DnnSupport {
       Stream* stream, const dnn::DropoutDescriptor& dropout_params,
       const dnn::BatchDescriptor& noise_dimensions,
       const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<double>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<double>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutForward not implemented for double.";
-    return false;
-  }
-
-  virtual bool DoDropoutForward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<float>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<float>* output_data,
+      DeviceMemory<float>* output_data, DeviceMemory<bool>* mask,
       ScratchAllocator* workspace_allocator = nullptr) {
     LOG(FATAL) << "DoDropoutForward not implemented for float.";
     return false;
@@ -1698,32 +1686,9 @@ class DnnSupport {
       const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<Eigen::half>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<Eigen::half>* output_data,
+      DeviceMemory<Eigen::half>* output_data, DeviceMemory<bool>* mask,
       ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutForward not implemented for Eigen::half.";
-    return false;
-  }
-
-  virtual bool DoDropoutForward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<int8>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<int8>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutForward not implemented for int8.";
-    return false;
-  }
-  virtual bool DoDropoutBackward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<double>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<double>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutBackward not implemented for double.";
+    LOG(FATAL) << "DoDropoutForward not implemented for half.";
     return false;
   }
 
@@ -1733,7 +1698,7 @@ class DnnSupport {
       const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<float>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<float>* output_data,
+      DeviceMemory<float>* output_data, DeviceMemory<bool>* mask,
       ScratchAllocator* workspace_allocator = nullptr) {
     LOG(FATAL) << "DoDropoutBackward not implemented for float.";
     return false;
@@ -1745,21 +1710,9 @@ class DnnSupport {
       const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<Eigen::half>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<Eigen::half>* output_data,
+      DeviceMemory<Eigen::half>* output_data, DeviceMemory<bool>* mask,
       ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutBackward not implemented for Eigen::half.";
-    return false;
-  }
-
-  virtual bool DoDropoutBackward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<int8>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<int8>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutBackward not implemented for int8.";
+    LOG(FATAL) << "DoDropoutBackward not implemented for half.";
     return false;
   }
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -431,25 +431,13 @@ class MIOpenSupport : public dnn::DnnSupport {
                   const DeviceMemory<float>& input_data,
                   DeviceMemory<float>* output_data, uint64 options) override;
 
-  bool DoDropoutForward(Stream* stream,
-                        const dnn::DropoutDescriptor& dropout_params,
-                        const dnn::BatchDescriptor& noise_dimensions,
-                        const dnn::BatchDescriptor& input_dimensions,
-                        const DeviceMemory<double>& input_data,
-                        const dnn::BatchDescriptor& output_dimensions,
-                        DeviceMemory<double>* output_data,
-                        ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(ERROR) << "miopen does not support dropout for dobule type yet";
-    return false;
-  }
-
   bool DoDropoutForward(
       Stream* stream, const dnn::DropoutDescriptor& dropout_params,
       const dnn::BatchDescriptor& noise_dimensions,
       const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<float>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<float>* output_data,
+      DeviceMemory<float>* output_data, DeviceMemory<bool>* mask,
       ScratchAllocator* workspace_allocator = nullptr) override;
 
   bool DoDropoutForward(
@@ -458,20 +446,8 @@ class MIOpenSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<Eigen::half>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<Eigen::half>* output_data,
+      DeviceMemory<Eigen::half>* output_data, DeviceMemory<bool>* mask,
       ScratchAllocator* workspace_allocator = nullptr) override;
-
-  bool DoDropoutBackward(Stream* stream,
-                         const dnn::DropoutDescriptor& dropout_params,
-                         const dnn::BatchDescriptor& noise_dimensions,
-                         const dnn::BatchDescriptor& input_diff_dimensions,
-                         const DeviceMemory<double>& input_diff_data,
-                         const dnn::BatchDescriptor& output_diff_dimensions,
-                         DeviceMemory<double>* output_data,
-                         ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(ERROR) << "miopen does not support dropout for dobule type yet";
-    return false;
-  }
 
   bool DoDropoutBackward(Stream* stream,
                          const dnn::DropoutDescriptor& dropout_params,
@@ -480,6 +456,7 @@ class MIOpenSupport : public dnn::DnnSupport {
                          const DeviceMemory<float>& input_diff_data,
                          const dnn::BatchDescriptor& output_diff_dimensions,
                          DeviceMemory<float>* output_data,
+                         DeviceMemory<bool>* mask,
                          ScratchAllocator* workspace_allocator) override;
 
   bool DoDropoutBackward(Stream* stream,
@@ -489,6 +466,7 @@ class MIOpenSupport : public dnn::DnnSupport {
                          const DeviceMemory<Eigen::half>& input_diff_data,
                          const dnn::BatchDescriptor& output_diff_dimensions,
                          DeviceMemory<Eigen::half>* output_data,
+                         DeviceMemory<bool>* mask,
                          ScratchAllocator* workspace_allocator) override;
 
   bool DoPoolForward(Stream* stream,

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -1517,33 +1517,15 @@ Stream& Stream::ThenDropoutForward(
     const dnn::DropoutDescriptor& dropout_params,
     const dnn::BatchDescriptor& noise_dimensions,
     const dnn::BatchDescriptor& input_dimensions,
-    const DeviceMemory<double>& input_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<double>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutForward(
-          this, dropout_params, noise_dimensions, input_dimensions, input_data,
-          output_dimensions, output_data, workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
-Stream& Stream::ThenDropoutForward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_dimensions,
     const DeviceMemory<float>& input_data,
     const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<float>* output_data, ScratchAllocator* workspace_allocator) {
+    DeviceMemory<float>* output_data, DeviceMemory<bool>* mask,
+    ScratchAllocator* workspace_allocator) {
   if (ok()) {
     if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
       CheckError(dnn->DoDropoutForward(
           this, dropout_params, noise_dimensions, input_dimensions, input_data,
-          output_dimensions, output_data, workspace_allocator));
+          output_dimensions, output_data, mask, workspace_allocator));
     } else {
       SetErrorAndLogNoDnnSupport();
     }
@@ -1557,52 +1539,13 @@ Stream& Stream::ThenDropoutForward(
     const dnn::BatchDescriptor& input_dimensions,
     const DeviceMemory<Eigen::half>& input_data,
     const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<Eigen::half>* output_data,
+    DeviceMemory<Eigen::half>* output_data, DeviceMemory<bool>* mask,
     ScratchAllocator* workspace_allocator) {
   if (ok()) {
     if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
       CheckError(dnn->DoDropoutForward(
           this, dropout_params, noise_dimensions, input_dimensions, input_data,
-          output_dimensions, output_data, workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
-Stream& Stream::ThenDropoutForward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_dimensions,
-    const DeviceMemory<int8>& input_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<int8>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutForward(
-          this, dropout_params, noise_dimensions, input_dimensions, input_data,
-          output_dimensions, output_data, workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
-Stream& Stream::ThenDropoutBackward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_diff_dimensions,
-    const DeviceMemory<double>& input_diff_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<double>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
-                                        input_diff_dimensions, input_diff_data,
-                                        output_dimensions, output_data,
-                                        workspace_allocator));
+          output_dimensions, output_data, mask, workspace_allocator));
     } else {
       SetErrorAndLogNoDnnSupport();
     }
@@ -1616,32 +1559,13 @@ Stream& Stream::ThenDropoutBackward(
     const dnn::BatchDescriptor& input_diff_dimensions,
     const DeviceMemory<float>& input_diff_data,
     const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<float>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
-                                        input_diff_dimensions, input_diff_data,
-                                        output_dimensions, output_data,
-                                        workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-Stream& Stream::ThenDropoutBackward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_diff_dimensions,
-    const DeviceMemory<Eigen::half>& input_diff_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<Eigen::half>* output_data,
+    DeviceMemory<float>* output_data, DeviceMemory<bool>* mask,
     ScratchAllocator* workspace_allocator) {
   if (ok()) {
     if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
       CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
                                         input_diff_dimensions, input_diff_data,
-                                        output_dimensions, output_data,
+                                        output_dimensions, output_data, mask,
                                         workspace_allocator));
     } else {
       SetErrorAndLogNoDnnSupport();
@@ -1654,14 +1578,15 @@ Stream& Stream::ThenDropoutBackward(
     const dnn::DropoutDescriptor& dropout_params,
     const dnn::BatchDescriptor& noise_dimensions,
     const dnn::BatchDescriptor& input_diff_dimensions,
-    const DeviceMemory<int8>& input_diff_data,
+    const DeviceMemory<Eigen::half>& input_diff_data,
     const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<int8>* output_data, ScratchAllocator* workspace_allocator) {
+    DeviceMemory<Eigen::half>* output_data, DeviceMemory<bool>* mask,
+    ScratchAllocator* workspace_allocator) {
   if (ok()) {
     if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
       CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
                                         input_diff_dimensions, input_diff_data,
-                                        output_dimensions, output_data,
+                                        output_dimensions, output_data, mask,
                                         workspace_allocator));
     } else {
       SetErrorAndLogNoDnnSupport();

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -599,17 +599,10 @@ class Stream {
   Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
                              const dnn::BatchDescriptor& noise_dimensions,
                              const dnn::BatchDescriptor& input_dimensions,
-                             const DeviceMemory<double>& input_data,
-                             const dnn::BatchDescriptor& output_dimensions,
-                             DeviceMemory<double>* output_data,
-                             ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
-                             const dnn::BatchDescriptor& noise_dimensions,
-                             const dnn::BatchDescriptor& input_dimensions,
                              const DeviceMemory<float>& input_data,
                              const dnn::BatchDescriptor& output_dimensions,
                              DeviceMemory<float>* output_data,
+                             DeviceMemory<bool>* mask,
                              ScratchAllocator* workspace_allocator = nullptr);
 
   Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
@@ -618,23 +611,8 @@ class Stream {
                              const DeviceMemory<Eigen::half>& input_data,
                              const dnn::BatchDescriptor& output_dimensions,
                              DeviceMemory<Eigen::half>* output_data,
+                             DeviceMemory<bool>* mask,
                              ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
-                             const dnn::BatchDescriptor& noise_dimensions,
-                             const dnn::BatchDescriptor& input_dimensions,
-                             const DeviceMemory<int8>& input_data,
-                             const dnn::BatchDescriptor& output_dimensions,
-                             DeviceMemory<int8>* output_data,
-                             ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
-                              const dnn::BatchDescriptor& noise_dimensions,
-                              const dnn::BatchDescriptor& input_diff_dimensions,
-                              const DeviceMemory<double>& input_diff_data,
-                              const dnn::BatchDescriptor& output_dimensions,
-                              DeviceMemory<double>* output_data,
-                              ScratchAllocator* workspace_allocator = nullptr);
 
   Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
                               const dnn::BatchDescriptor& noise_dimensions,
@@ -642,6 +620,7 @@ class Stream {
                               const DeviceMemory<float>& input_diff_data,
                               const dnn::BatchDescriptor& output_dimensions,
                               DeviceMemory<float>* output_data,
+                              DeviceMemory<bool>* mask,
                               ScratchAllocator* workspace_allocator = nullptr);
 
   Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
@@ -650,14 +629,7 @@ class Stream {
                               const DeviceMemory<Eigen::half>& input_diff_data,
                               const dnn::BatchDescriptor& output_dimensions,
                               DeviceMemory<Eigen::half>* output_data,
-                              ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
-                              const dnn::BatchDescriptor& noise_dimensions,
-                              const dnn::BatchDescriptor& input_diff_dimensions,
-                              const DeviceMemory<int8>& input_diff_data,
-                              const dnn::BatchDescriptor& output_dimensions,
-                              DeviceMemory<int8>* output_data,
+                              DeviceMemory<bool>* mask,
                               ScratchAllocator* workspace_allocator = nullptr);
 
   Stream &ThenPoolForward(const dnn::PoolingDescriptor &pooling_dimensions,


### PR DESCRIPTION
MIOpen's `XORWOW` random generator has been 100x slower than a CPU random state generator. This review use the CPU random generator instead. To pass in the external random state to stream executor results in an interface change in stream executor and dnn interface.

This PR also refactored the dropout type infrastructures and kept only fp16 and fp32 implementations.