### PR TITLE
[ROCm][XLA][CI] Enable 2 tests in //tensorflow/compiler/xla/service/cpu/test.

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/tests/BUILD
@@ -102,7 +102,6 @@ tf_cc_test(
 tf_cc_test(
     name = "cpu_intrinsic_test",
     srcs = ["cpu_intrinsic_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":cpu_codegen_test",
         "//tensorflow/compiler/xla/service:hlo",
@@ -135,7 +134,6 @@ tf_cc_test(
 tf_cc_test(
     name = "cpu_profiling_test",
     srcs = ["cpu_profiling_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":cpu_codegen_test",
         "//tensorflow/compiler/xla/service:hlo",

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1289,6 +1289,7 @@ cc_library(
         "amdgpu_compiler.h"
     ],
     deps = [
+        ":gemm_rewriter",
         ":gpu_compiler",
         ":gpu_conv_algorithm_picker",
         ":gpu_conv_padding_legalization",

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/gpu_conv_padding_legalization.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_conv_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.h"
+#include "tensorflow/compiler/xla/service/gpu/gemm_rewriter.h"
 #include "tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "tensorflow/compiler/xla/service/gpu/reduction_degenerate_dim_remover.h"
 #include "tensorflow/compiler/xla/service/gpu/reduction_dimension_grouper.h"
@@ -103,6 +104,9 @@ Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
   AlgebraicSimplifierOptions options;
   options.set_is_layout_sensitive(true);
   pipeline.AddPass<HloPassFix<AlgebraicSimplifier>>(options);
+
+  // Rewrite GEMMs into custom calls.
+  pipeline.AddPass<GemmRewriter>();
 
   pipeline.AddPass<GpuConvAlgorithmPicker>(stream_exec, device_allocator);
 


### PR DESCRIPTION
    Enable 2 tests in //tensorflow/compiler/xla/service/cpu/test.
    
    //tensorflow/compiler/xla/service/cpu/tests:cpu_intrinsic_test
    //tensorflow/compiler/xla/service/cpu/tests:cpu_profiling_test
    
    These 2 tests are passing on ROCm.
