### PR TITLE
Updating CSB script to run the conv_ops_test_gpu standalone.

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -38,7 +38,29 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu,-no_gpu,-no_rocm,-benchmark-test,-no_oss,-oss_serial,-rocm_multi_gpu,-v1only \
+      --test_tag_filters=gpu,-no_gpu,-no_rocm,-v1only \
+      --jobs=${N_JOBS} \
+      --local_test_jobs=1 \
+      --test_timeout 600,900,2400,7200 \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      -- \
+      //tensorflow/python/kernel_tests:conv_ops_test_gpu \
+&& bazel test \
+      --config=rocm \
+      -k \
+      --test_tag_filters=gpu,-no_gpu,-no_rocm,-v1only \
+      --jobs=${N_JOBS} \
+      --local_test_jobs=1 \
+      --test_timeout 600,900,2400,7200 \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      -- \
+      //tensorflow/core/nccl:nccl_manager_test \
+&& bazel test \
+      --config=rocm \
+      -k \
+      --test_tag_filters=gpu,-no_gpu,-no_rocm,-v1only,-benchmark-test,-no_oss,-oss_serial,-rocm_multi_gpu \
       --jobs=${N_JOBS} \
       --local_test_jobs=${TF_GPU_COUNT} \
       --test_timeout 600,900,2400,7200 \
@@ -50,15 +72,5 @@ bazel test \
       -//tensorflow/compiler/... \
       -//tensorflow/lite/... \
       -//tensorflow/python/compiler/tensorrt/... \
-&& bazel test \
-      --config=rocm \
-      -k \
-      --test_tag_filters=-no_gpu,-no_rocm,-v1only \
-      --jobs=${N_JOBS} \
-      --local_test_jobs=1 \
-      --test_timeout 600,900,2400,7200 \
-      --test_output=errors \
-      --test_sharding_strategy=disabled \
-      -- \
-      //tensorflow/core/nccl:nccl_manager_test
+      -//tensorflow/python/kernel_tests:conv_ops_test_gpu
 


### PR DESCRIPTION
The `//tensorflow/python/kernel_tests:conv_ops_test_gpu` often times out when run as part of the CSN testsuite, which leads to the Nightly CSB run failing.

The timeout in that test seems to happen only when it is run in parallel with other tests. The timeout value is 900s, and even in cases where the test does not timeout, it only does so on the 2nd or 3rd run (note that tests that either fail or timeout are rerun upto 3 times).

A likely theory is that
* the first run which is almost always guranteed to run in parallel wih other tests, and hence always timesout.
* if the 2nd or 3rd run of the test happens, once other tests have finished, then it will succeed
* else all 3 attempts timeout

When running in a standalone mode, the same test runs in under 300s (as opposed to taking more than 900s and timing out, when run in parallel).


-----------------------

/cc @whchung @jerryyin 