### PR TITLE
[ROCm][XLA][CI] set TF2_BEHAVIOR=0 and fix 9 unit tests.

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -332,7 +332,6 @@ tf_xla_py_test(
     timeout = "moderate",
     srcs = ["matrix_triangular_solve_op_test.py"],
     tags = [
-        "no_rocm",
         "optonly",
     ],
     deps = [
@@ -994,7 +993,6 @@ tf_xla_py_test(
     # TensorArray ops are not implemented in the on-demand compilation model yet.
     disabled_backends = ["cpu_ondemand"],
     tags = [
-        "no_rocm",
         "config-cuda-only",
     ],
     use_xla_device = False,
@@ -1223,7 +1221,6 @@ cuda_py_test(
         "//tensorflow/python:nn_ops",
     ],
     shard_count = 5,
-    tags = ["no_rocm"],
     xla_enable_strict_auto_jit = False,
 )
 
@@ -1240,7 +1237,6 @@ cuda_py_test(
         "//tensorflow/python:layers",
         "//tensorflow/python:variables",
     ],
-    tags = ["no_rocm"],
     xla_enable_strict_auto_jit = False,
 )
 
@@ -1407,7 +1403,6 @@ tf_xla_py_test(
         "//tensorflow/python:platform_test",
         "@absl_py//absl/testing:parameterized",
     ],
-    tags = ["no_rocm"],
 )
 
 tf_xla_py_test(

--- a/tensorflow/compiler/xla/client/lib/BUILD
+++ b/tensorflow/compiler/xla/client/lib/BUILD
@@ -485,7 +485,6 @@ xla_test(
     shard_count = 10,
     tags = [
         "optonly",
-        "no_rocm",
     ],
     deps = [
         ":arithmetic",

--- a/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
+++ b/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
@@ -49,4 +49,36 @@ bazel test \
       --test_sharding_strategy=disabled \
       --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
       -- \
-      //tensorflow/compiler/...
+      //tensorflow/compiler/... \
+      -//tensorflow/compiler/tests:dense_layer_test \
+      -//tensorflow/compiler/tests:dense_layer_test_gpu \
+      -//tensorflow/compiler/tests:jit_test \
+      -//tensorflow/compiler/tests:jit_test_gpu \
+      -//tensorflow/compiler/tests:matrix_triangular_solve_op_test \
+      -//tensorflow/compiler/tests:tensor_array_ops_test \
+      -//tensorflow/compiler/tests:xla_ops_test \
+      -//tensorflow/compiler/xla/client/lib:svd_test \
+      -//tensorflow/compiler/tests:lstm_test \
+&& bazel test \
+      --config=rocm \
+      --config=xla \
+      -k \
+      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
+      --jobs=${N_JOBS} \
+      --local_test_jobs=${TF_GPU_COUNT} \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --test_env=TF2_BEHAVIOR=0 \
+      --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
+      -- \
+      //tensorflow/compiler/tests:dense_layer_test \
+      //tensorflow/compiler/tests:dense_layer_test_gpu \
+      //tensorflow/compiler/tests:jit_test \
+      //tensorflow/compiler/tests:jit_test_gpu \
+      //tensorflow/compiler/tests:matrix_triangular_solve_op_test \
+      //tensorflow/compiler/tests:tensor_array_ops_test \
+      //tensorflow/compiler/tests:xla_ops_test \
+      //tensorflow/compiler/xla/client/lib:svd_test \
+      //tensorflow/compiler/tests:lstm_test


### PR DESCRIPTION
The following tests are known to NOT work with TF2_BEHAVIOR:

//tensorflow/compiler/tests:dense_layer_test
//tensorflow/compiler/tests:dense_layer_test_gpu
//tensorflow/compiler/tests:jit_test
//tensorflow/compiler/tests:jit_test_gpu

//tensorflow/compiler/tests:matrix_triangular_solve_op_test
//tensorflow/compiler/tests:tensor_array_ops_test
//tensorflow/compiler/tests:xla_ops_test
//tensorflow/compiler/xla/client/lib:svd_test
//tensorflow/compiler/tests:lstm_test

Enable these tests, and change XLA ROCm test script to set

--test_env=TF2_BEHAVIOR=0
