### PR TITLE
[DO NOT MERGE] Fixing se::dnn::ToDataType linker issue in dbg build

### DIFF
--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -22,6 +22,19 @@ limitations under the License.
 namespace stream_executor {
 namespace dnn {
 
+template <>
+constexpr DataType ToDataType<float>::value;
+template <>
+constexpr DataType ToDataType<double>::value;
+template <>
+constexpr DataType ToDataType<Eigen::half>::value;
+template <>
+constexpr DataType ToDataType<int8>::value;
+template <>
+constexpr DataType ToDataType<int32>::value;
+template <>
+constexpr DataType ToDataType<tensorflow::bfloat16>::value;
+
 uint64 AlgorithmDesc::hash() const {
   auto p = std::make_pair(algo_id(), tensor_ops_enabled());
   return absl::Hash<decltype(p)>()(p);


### PR DESCRIPTION
More detailed explanation see stackoverflow, [here](https://stackoverflow.com/questions/8452952/c-linker-error-with-class-static-constexpr).

`ToDataType<T>::value` is declared but never defined, so there is no storage for it. It is fine to use it as an r-value, but errors out as a linker issue when used as an l-value.

For example, [ir_emission_utils.cc](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/blob/develop-upstream/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc#L466-L471), ToDataType<T>::value served as an input to StatusOr<T>() constructor. However, with ToDataType not move constructible, the StatusOr(const Status& status) takes and l-value. This makes the runtime to fail with a linker error.