### PR TITLE
[DO NOT MERGE] Porting ROCm blfoat16 support to master-rocm-enhanced

### DIFF
--- a/tensorflow/core/kernels/conv_2d.h
+++ b/tensorflow/core/kernels/conv_2d.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/kernels/eigen_backward_spatial_convolutions.h"
 #include "tensorflow/core/kernels/eigen_spatial_convolutions.h"
+#include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/util/tensor_format.h"
 
 namespace tensorflow {
@@ -377,6 +378,19 @@ struct ReverseTransformFilter {
                   typename TTypes<T, NDIMS>::Tensor out);
 };
 
+template <typename Device, typename T, int NDIMS>
+struct ConvertToBFloat16 {
+  void operator()(const Device& d, typename TTypes<T, NDIMS>::ConstTensor in,
+                  typename TTypes<bfloat16, NDIMS>::Tensor out);
+};
+
+template <typename Device, typename T, int NDIMS>
+struct ConvertFromBFloat16 {
+  void operator()(const Device& d,
+                  typename TTypes<bfloat16, NDIMS>::ConstTensor in,
+                  typename TTypes<T, NDIMS>::Tensor out);
+};
+
 }  // namespace functor
 
 template <class T>
@@ -384,6 +398,19 @@ class ConvAlgorithmMap;
 
 template <>
 class ConvAlgorithmMap<Eigen::ThreadPoolDevice> {};
+
+template <typename T>
+bool TestMIOpenBFloat16Support() {
+  static bool kTestMIOpenBFloat16Support = [] {
+    bool use_bfloat16 = false;
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_ROCM_USE_BFLOAT16_FOR_CONV", false,
+                                   &use_bfloat16));
+    return use_bfloat16;
+  }();
+
+  return kTestMIOpenBFloat16Support && (DataTypeToEnum<T>::value == DT_FLOAT);
+}
+
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_KERNELS_CONV_2D_H_

--- a/tensorflow/core/kernels/conv_2d_gpu_double.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_double.cu.cc
@@ -36,6 +36,8 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, double, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, double, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, double, 4>;
 template struct PadInput<Eigen::GpuDevice, double, int, 4>;
+template struct ConvertToBFloat16<Eigen::GpuDevice, double, 4>;
+template struct ConvertFromBFloat16<Eigen::GpuDevice, double, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, double, int, 5>;

--- a/tensorflow/core/kernels/conv_2d_gpu_float.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_float.cu.cc
@@ -45,6 +45,8 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, float, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, float, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, float, 4>;
 template struct PadInput<Eigen::GpuDevice, float, int, 4>;
+template struct ConvertToBFloat16<Eigen::GpuDevice, float, 4>;
+template struct ConvertFromBFloat16<Eigen::GpuDevice, float, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, float, int, 5>;

--- a/tensorflow/core/kernels/conv_2d_gpu_half.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_half.cu.cc
@@ -37,6 +37,8 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, Eigen::half, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, Eigen::half, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, Eigen::half, 4>;
 template struct PadInput<Eigen::GpuDevice, Eigen::half, int, 4>;
+template struct ConvertToBFloat16<Eigen::GpuDevice, Eigen::half, 4>;
+template struct ConvertFromBFloat16<Eigen::GpuDevice, Eigen::half, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, Eigen::half, int, 5>;

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -950,11 +950,63 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   auto input_ptr = AsDeviceMemory(transformed_input.template flat<T>().data(),
                                   transformed_input.template flat<T>().size());
 
+  Tensor bfloat16_out_backprop, bfloat16_input, bfloat16_filter_backprop;
+  se::DeviceMemory<bfloat16> bfloat16_out_backprop_ptr, bfloat16_input_ptr,
+      bfloat16_filter_backprop_ptr;
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    TensorShape out_backprop_shape = ShapeFromFormat(
+        FORMAT_NCHW, dims.batch_size, dims.spatial_dims[0].output_size,
+        dims.spatial_dims[1].output_size, dims.out_depth);
+    VLOG(3) << "Allocate temporary memory for bfloat16 out_backprop";
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, out_backprop_shape,
+                                           &bfloat16_out_backprop));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_out_backprop).tensor<T, 4>(),
+        bfloat16_out_backprop.tensor<bfloat16, 4>());
+
+    TensorShape input_shape = ShapeFromFormat(
+        compute_data_format, GetTensorDim(compatible_input, data_format, 'N'),
+        GetTensorDim(compatible_input, data_format, 'H'),
+        GetTensorDim(compatible_input, data_format, 'W'),
+        GetTensorDim(compatible_input, data_format, 'C'));
+    VLOG(3) << "Allocate temporary memory for bfloat16 input";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_BFLOAT16, input_shape, &bfloat16_input));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_input).tensor<T, 4>(),
+        bfloat16_input.tensor<bfloat16, 4>());
+
+    TensorShape filter_backprop_shape =
+        TensorShape({filter_shape.dim_size(3), filter_shape.dim_size(2),
+                     filter_shape.dim_size(0), filter_shape.dim_size(1)});
+    VLOG(3) << "Allocate temporary memory for bfloat16 filter_backprop";
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, filter_backprop_shape,
+                                           &bfloat16_filter_backprop));
+
+    bfloat16_out_backprop_ptr =
+        AsDeviceMemory(bfloat16_out_backprop.template flat<bfloat16>().data(),
+                       bfloat16_out_backprop.template flat<bfloat16>().size());
+    bfloat16_filter_backprop_ptr = AsDeviceMemory(
+        bfloat16_filter_backprop.template flat<bfloat16>().data(),
+        bfloat16_filter_backprop.template flat<bfloat16>().size());
+    bfloat16_input_ptr =
+        AsDeviceMemory(bfloat16_input.template flat<bfloat16>().data(),
+                       bfloat16_input.template flat<bfloat16>().size());
+  }
+
   static int64 ConvolveBackwardFilterScratchSize = GetDnnWorkspaceLimit(
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB by default
   );
   int device_id = stream->parent()->device_ordinal();
   DataType dtype = input.dtype();
+#if TENSORFLOW_USE_ROCM
+  if (TestMIOpenBFloat16Support<T>()) {
+    dtype = DT_BFLOAT16;
+  }
+#endif
   ConvParameters conv_parameters = {
       dims.batch_size,                     // batch
       dims.in_depth,                       // in_depths
@@ -1044,17 +1096,32 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                                           ctx);
 
     std::vector<ProfileResult> algorithms;
-    OP_REQUIRES(
-        ctx,
-        stream->parent()->GetMIOpenConvolveAlgorithms(
-            se::dnn::ConvolutionKind::BACKWARD_FILTER,
-            se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
-            filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
-            conv_desc, &scratch_allocator, &algorithms),
-        errors::Unknown(
-            "Failed to get convolution algorithm. This is probably "
-            "because MIOpen failed to initialize, so try looking to "
-            "see if a warning log message was printed above."));
+    if (TestMIOpenBFloat16Support<T>()) {
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::BACKWARD_FILTER,
+              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
+              bfloat16_input_ptr, filter_desc, bfloat16_filter_backprop_ptr,
+              output_desc, bfloat16_out_backprop_ptr, conv_desc,
+              &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
+    } else {
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::BACKWARD_FILTER,
+              se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
+              filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
+              conv_desc, &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
+    }
 
     std::vector<tensorflow::AutotuneResult> results;
     if (algorithms.size() == 1) {
@@ -1074,16 +1141,29 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
         auto profile_algorithm = miopen_algorithm.algorithm();
         ProfileResult profile_result;
         bool miopen_launch_status = true;
-        miopen_launch_status =
-            stream
-                ->ThenConvolveBackwardFilterWithAlgorithm(
-                    input_desc, input_ptr, output_desc, out_backprop_ptr,
-                    conv_desc, filter_desc, &filter_backprop_ptr,
-                    &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm,
-                                    miopen_algorithm.scratch_size()),
-                    &profile_result)
-                .ok();
+        if (TestMIOpenBFloat16Support<T>()) {
+          miopen_launch_status =
+              stream
+                  ->ThenConvolveBackwardFilterWithAlgorithm(
+                      input_desc, bfloat16_input_ptr, output_desc,
+                      bfloat16_out_backprop_ptr, conv_desc, filter_desc,
+                      &bfloat16_filter_backprop_ptr, &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
+                  .ok();
+        } else {
+          miopen_launch_status =
+              stream
+                  ->ThenConvolveBackwardFilterWithAlgorithm(
+                      input_desc, input_ptr, output_desc, out_backprop_ptr,
+                      conv_desc, filter_desc, &filter_backprop_ptr,
+                      &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
+                  .ok();
+        }
 
         if (miopen_launch_status && profile_result.is_valid()) {
           results.emplace_back();
@@ -1108,20 +1188,40 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                                                  algorithm_config);
   }
   DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize, ctx);
-  bool cudnn_launch_status =
-      stream
-          ->ThenConvolveBackwardFilterWithAlgorithm(
-              input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
-              filter_desc, &filter_backprop_ptr, &scratch_allocator,
-              algorithm_config, nullptr)
-          .ok();
-
+  bool cudnn_launch_status = true;
+  if (TestMIOpenBFloat16Support<T>()) {
+    cudnn_launch_status = stream
+                              ->ThenConvolveBackwardFilterWithAlgorithm(
+                                  input_desc, bfloat16_input_ptr, output_desc,
+                                  bfloat16_out_backprop_ptr, conv_desc,
+                                  filter_desc, &bfloat16_filter_backprop_ptr,
+                                  &scratch_allocator, algorithm_config, nullptr)
+                              .ok();
+  } else {
+    cudnn_launch_status =
+        stream
+            ->ThenConvolveBackwardFilterWithAlgorithm(
+                input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
+                filter_desc, &filter_backprop_ptr, &scratch_allocator,
+                algorithm_config, nullptr)
+            .ok();
+  }
   if (!cudnn_launch_status) {
     ctx->SetStatus(errors::Internal(
         "DNN Backward Filter function launch failure : input shape(",
         input.shape().DebugString(), ") filter shape(",
         filter_shape.DebugString(), ")"));
     return;
+  }
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    VLOG(3)
+        << "Convert the filter_backprop tensor back from bfloat16 to float.";
+    functor::ConvertFromBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(bfloat16_filter_backprop)
+            .tensor<bfloat16, 4>(),
+        pre_transformed_filter_backprop.tensor<T, 4>());
   }
 
   FilterTensorFormat src_filter_format =

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1113,12 +1113,65 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
       AsDeviceMemory(pre_transformed_in_backprop.template flat<T>().data(),
                      pre_transformed_in_backprop.template flat<T>().size());
 
+  Tensor bfloat16_out_backprop, bfloat16_filter, bfloat16_in_backprop;
+  se::DeviceMemory<bfloat16> bfloat16_out_backprop_ptr, bfloat16_filter_ptr,
+      bfloat16_in_backprop_ptr;
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    TensorShape out_backprop_shape = ShapeFromFormat(
+        FORMAT_NCHW, dims.batch_size, dims.spatial_dims[0].output_size,
+        dims.spatial_dims[1].output_size, dims.out_depth);
+    VLOG(3) << "Allocate temporary memory for bfloat16 out_backprop";
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, out_backprop_shape,
+                                           &bfloat16_out_backprop));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_out_backprop).tensor<T, 4>(),
+        bfloat16_out_backprop.tensor<bfloat16, 4>());
+
+    TensorShape filter_shape =
+        TensorShape({filter.dim_size(3), filter.dim_size(2), filter.dim_size(0),
+                     filter.dim_size(1)});
+    VLOG(3) << "Allocate temporary memory for bfloat16 filter";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_BFLOAT16, filter_shape, &bfloat16_filter));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_filter).tensor<T, 4>(),
+        bfloat16_filter.tensor<bfloat16, 4>());
+
+    TensorShape in_backprop_shape =
+        ShapeFromFormat(compute_data_format,
+                        GetTensorDim(compatible_input_shape, data_format, 'N'),
+                        GetTensorDim(compatible_input_shape, data_format, 'H'),
+                        GetTensorDim(compatible_input_shape, data_format, 'W'),
+                        GetTensorDim(compatible_input_shape, data_format, 'C'));
+    VLOG(3) << "Allocate temporary memory for bfloat16 in backprop";
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, in_backprop_shape,
+                                           &bfloat16_in_backprop));
+
+    bfloat16_out_backprop_ptr =
+        AsDeviceMemory(bfloat16_out_backprop.template flat<bfloat16>().data(),
+                       bfloat16_out_backprop.template flat<bfloat16>().size());
+    bfloat16_filter_ptr =
+        AsDeviceMemory(bfloat16_filter.template flat<bfloat16>().data(),
+                       bfloat16_filter.template flat<bfloat16>().size());
+    bfloat16_in_backprop_ptr =
+        AsDeviceMemory(bfloat16_in_backprop.template flat<bfloat16>().data(),
+                       bfloat16_in_backprop.template flat<bfloat16>().size());
+  }
+
   static int64 ConvolveBackwardDataScratchSize = GetDnnWorkspaceLimit(
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB by default
   );
   DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize, ctx);
   int device_id = stream->parent()->device_ordinal();
   DataType dtype = out_backprop.dtype();
+#if TENSORFLOW_USE_ROCM
+  if (TestMIOpenBFloat16Support<T>()) {
+    dtype = DT_BFLOAT16;
+  }
+#endif
   ConvParameters conv_parameters = {
       dims.batch_size,                     // batch
       dims.in_depth,                       // in_depths
@@ -1204,17 +1257,32 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
 #elif TENSORFLOW_USE_ROCM
     DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize, ctx);
     std::vector<ProfileResult> algorithms;
-    OP_REQUIRES(
-        ctx,
-        stream->parent()->GetMIOpenConvolveAlgorithms(
-            se::dnn::ConvolutionKind::BACKWARD_DATA,
-            se::dnn::ToDataType<T>::value, stream, input_desc, in_backprop_ptr,
-            filter_desc, filter_ptr, output_desc, out_backprop_ptr, conv_desc,
-            &scratch_allocator, &algorithms),
-        errors::Unknown(
-            "Failed to get convolution algorithm. This is probably "
-            "because MIOpen failed to initialize, so try looking to "
-            "see if a warning log message was printed above."));
+    if (TestMIOpenBFloat16Support<T>()) {
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::BACKWARD_DATA,
+              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
+              bfloat16_in_backprop_ptr, filter_desc, bfloat16_filter_ptr,
+              output_desc, bfloat16_out_backprop_ptr, conv_desc,
+              &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
+    } else {
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::BACKWARD_DATA,
+              se::dnn::ToDataType<T>::value, stream, input_desc,
+              in_backprop_ptr, filter_desc, filter_ptr, output_desc,
+              out_backprop_ptr, conv_desc, &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
+    }
 
     std::vector<tensorflow::AutotuneResult> results;
     if (algorithms.size() == 1) {
@@ -1234,15 +1302,29 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
         auto profile_algorithm = miopen_algorithm.algorithm();
         ProfileResult profile_result;
         bool miopen_launch_status = true;
-        miopen_launch_status =
-            stream
-                ->ThenConvolveBackwardDataWithAlgorithm(
-                    filter_desc, filter_ptr, output_desc, out_backprop_ptr,
-                    conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm,
-                                    miopen_algorithm.scratch_size()),
-                    &profile_result)
-                .ok();
+        if (TestMIOpenBFloat16Support<T>()) {
+          miopen_launch_status =
+              stream
+                  ->ThenConvolveBackwardDataWithAlgorithm(
+                      filter_desc, bfloat16_filter_ptr, output_desc,
+                      bfloat16_out_backprop_ptr, conv_desc, input_desc,
+                      &bfloat16_in_backprop_ptr, &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
+                  .ok();
+        } else {
+          miopen_launch_status =
+              stream
+                  ->ThenConvolveBackwardDataWithAlgorithm(
+                      filter_desc, filter_ptr, output_desc, out_backprop_ptr,
+                      conv_desc, input_desc, &in_backprop_ptr,
+                      &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
+                  .ok();
+        }
 
         if (miopen_launch_status && profile_result.is_valid()) {
           results.emplace_back();
@@ -1265,13 +1347,24 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
     AutoTuneConvBwdData::GetInstance()->Insert(conv_parameters,
                                                algorithm_config);
   }
-  bool cudnn_launch_status =
-      stream
-          ->ThenConvolveBackwardDataWithAlgorithm(
-              filter_desc, filter_ptr, output_desc, out_backprop_ptr, conv_desc,
-              input_desc, &in_backprop_ptr, &scratch_allocator,
-              algorithm_config, nullptr)
-          .ok();
+  bool cudnn_launch_status = true;
+  if (TestMIOpenBFloat16Support<T>()) {
+    cudnn_launch_status = stream
+                              ->ThenConvolveBackwardDataWithAlgorithm(
+                                  filter_desc, bfloat16_filter_ptr, output_desc,
+                                  bfloat16_out_backprop_ptr, conv_desc,
+                                  input_desc, &bfloat16_in_backprop_ptr,
+                                  &scratch_allocator, algorithm_config, nullptr)
+                              .ok();
+  } else {
+    cudnn_launch_status =
+        stream
+            ->ThenConvolveBackwardDataWithAlgorithm(
+                filter_desc, filter_ptr, output_desc, out_backprop_ptr,
+                conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
+                algorithm_config, nullptr)
+            .ok();
+  }
 
   if (!cudnn_launch_status) {
     ctx->SetStatus(errors::Internal(
@@ -1279,6 +1372,14 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
         input_shape.DebugString(), ") filter shape(",
         filter_shape.DebugString(), ")"));
     return;
+  }
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    VLOG(3) << "Convert the in_backprop tensor back from bfloat16 to float.";
+    functor::ConvertFromBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(bfloat16_in_backprop).tensor<bfloat16, 4>(),
+        pre_transformed_in_backprop.tensor<T, 4>());
   }
 
   if (padding_top != padding_bottom || padding_left != padding_right) {

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -958,6 +958,49 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       AsDeviceMemory(transformed_output.template flat<T>().data(),
                      transformed_output.template flat<T>().size());
 
+  Tensor bfloat16_input, bfloat16_filter, bfloat16_output;
+  se::DeviceMemory<bfloat16> bfloat16_input_ptr, bfloat16_filter_ptr,
+      bfloat16_output_ptr;
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    TensorShape input_shape =
+        ShapeFromFormat(FORMAT_NCHW, in_batch, in_rows, in_cols, in_depths);
+    VLOG(3) << "Allocate temporary memory for bfloat16 input";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_BFLOAT16, input_shape, &bfloat16_input));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(input).tensor<T, 4>(),
+        bfloat16_input.tensor<bfloat16, 4>());
+
+    TensorShape filter_shape =
+        TensorShape({filter.dim_size(3), filter.dim_size(2), filter.dim_size(0),
+                     filter.dim_size(1)});
+    VLOG(3) << "Allocate temporary memory for bfloat16 filter";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_BFLOAT16, filter_shape, &bfloat16_filter));
+    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_filter).tensor<T, 4>(),
+        bfloat16_filter.tensor<bfloat16, 4>());
+
+    TensorShape output_shape =
+        ShapeFromFormat(FORMAT_NCHW, out_batch, out_rows, out_cols, out_depths);
+    VLOG(3) << "Allocate temporary memory for bfloat16 output";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_BFLOAT16, output_shape, &bfloat16_output));
+
+    bfloat16_input_ptr =
+        AsDeviceMemory(bfloat16_input.template flat<bfloat16>().data(),
+                       bfloat16_input.template flat<bfloat16>().size());
+    bfloat16_filter_ptr =
+        AsDeviceMemory(bfloat16_filter.template flat<bfloat16>().data(),
+                       bfloat16_filter.template flat<bfloat16>().size());
+    bfloat16_output_ptr =
+        AsDeviceMemory(bfloat16_output.template flat<bfloat16>().data(),
+                       bfloat16_output.template flat<bfloat16>().size());
+  }
+
   static int64 ConvolveScratchSize = GetDnnWorkspaceLimit(
       // default value is in bytes despite the name of the environment variable
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB
@@ -965,6 +1008,11 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
 
   int device_id = stream->parent()->device_ordinal();
   DataType dtype = input.dtype();
+#if TENSORFLOW_USE_ROCM
+  if (TestMIOpenBFloat16Support<T>()) {
+    dtype = DT_BFLOAT16;
+  }
+#endif
   ConvParameters conv_parameters = {in_batch,             // batch
                                     in_depths,            // in_depths
                                     {{in_rows,            // in_rows
@@ -1055,16 +1103,30 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
 
     std::vector<ProfileResult> algorithms;
-    OP_REQUIRES(
-        ctx,
-        stream->parent()->GetMIOpenConvolveAlgorithms(
-            se::dnn::ConvolutionKind::FORWARD, se::dnn::ToDataType<T>::value,
-            stream, input_desc, input_ptr, filter_desc, filter_ptr, output_desc,
-            output_ptr, conv_desc, &scratch_allocator, &algorithms),
-        errors::Unknown(
-            "Failed to get convolution algorithm. This is probably "
-            "because MIOpen failed to initialize, so try looking to "
-            "see if a warning log message was printed above."));
+    if (TestMIOpenBFloat16Support<T>()) {
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::FORWARD,
+              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
+              bfloat16_input_ptr, filter_desc, bfloat16_filter_ptr, output_desc,
+              bfloat16_output_ptr, conv_desc, &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
+    } else {
+      OP_REQUIRES(ctx,
+                  stream->parent()->GetMIOpenConvolveAlgorithms(
+                      se::dnn::ConvolutionKind::FORWARD,
+                      se::dnn::ToDataType<T>::value, stream, input_desc,
+                      input_ptr, filter_desc, filter_ptr, output_desc,
+                      output_ptr, conv_desc, &scratch_allocator, &algorithms),
+                  errors::Unknown(
+                      "Failed to get convolution algorithm. This is probably "
+                      "because MIOpen failed to initialize, so try looking to "
+                      "see if a warning log message was printed above."));
+    }
     se::DeviceMemory<T> output_tensor = output_ptr;
 
     std::vector<tensorflow::AutotuneResult> results;
@@ -1085,15 +1147,28 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
         auto profile_algorithm = miopen_algorithm.algorithm();
         ProfileResult profile_result;
         bool miopen_launch_status = false;
-        miopen_launch_status =
-            stream
-                ->ThenConvolveWithAlgorithm(
-                    input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
-                    output_desc, &output_ptr, &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm,
-                                    miopen_algorithm.scratch_size()),
-                    &profile_result)
-                .ok();
+        if (TestMIOpenBFloat16Support<T>()) {
+          miopen_launch_status =
+              stream
+                  ->ThenConvolveWithAlgorithm(
+                      input_desc, bfloat16_input_ptr, filter_desc,
+                      bfloat16_filter_ptr, conv_desc, output_desc,
+                      &bfloat16_output_ptr, &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
+                  .ok();
+        } else {
+          miopen_launch_status =
+              stream
+                  ->ThenConvolveWithAlgorithm(
+                      input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
+                      output_desc, &output_ptr, &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
+                  .ok();
+        }
         if (miopen_launch_status && profile_result.is_valid()) {
           results.emplace_back();
           auto& result = results.back();
@@ -1122,18 +1197,37 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
           << algorithm_config.algorithm()->tensor_ops_enabled();
 
   DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
-  bool cudnn_launch_status =
-      stream
-          ->ThenConvolveWithAlgorithm(input_desc, input_ptr, filter_desc,
-                                      filter_ptr, conv_desc, output_desc,
-                                      &output_ptr, &scratch_allocator,
-                                      algorithm_config, nullptr)
-          .ok();
+  bool cudnn_launch_status = false;
+  if (TestMIOpenBFloat16Support<T>()) {
+    cudnn_launch_status = stream
+                              ->ThenConvolveWithAlgorithm(
+                                  input_desc, bfloat16_input_ptr, filter_desc,
+                                  bfloat16_filter_ptr, conv_desc, output_desc,
+                                  &bfloat16_output_ptr, &scratch_allocator,
+                                  algorithm_config, nullptr)
+                              .ok();
+  } else {
+    cudnn_launch_status =
+        stream
+            ->ThenConvolveWithAlgorithm(input_desc, input_ptr, filter_desc,
+                                        filter_ptr, conv_desc, output_desc,
+                                        &output_ptr, &scratch_allocator,
+                                        algorithm_config, nullptr)
+            .ok();
+  }
 
   if (!cudnn_launch_status) {
     ctx->SetStatus(errors::Internal(
         "cuDNN launch failure : input shape(", input.shape().DebugString(),
         ") filter shape(", filter.shape().DebugString(), ")"));
+  }
+
+  if (TestMIOpenBFloat16Support<T>()) {
+    VLOG(3) << "Convert the output tensor back from bfloat16 to float.";
+    functor::ConvertFromBFloat16<GPUDevice, T, 4>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(bfloat16_output).tensor<bfloat16, 4>(),
+        transformed_output.tensor<T, 4>());
   }
 
   if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -30,6 +30,7 @@ limitations under the License.
 
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
+#include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/dnn.pb.h"
 #include "tensorflow/stream_executor/lib/array_slice.h"
@@ -132,6 +133,10 @@ struct ToDataType<int8> {
 template <>
 struct ToDataType<int32> {
   static constexpr DataType value = DataType::kInt32;
+};
+template <>
+struct ToDataType<tensorflow::bfloat16> {
+  static constexpr DataType value = DataType::kBFloat16;
 };
 
 // Specifies the types of a RNN model.

--- a/tensorflow/stream_executor/dnn.proto
+++ b/tensorflow/stream_executor/dnn.proto
@@ -12,6 +12,7 @@ enum DataType {
   kHalf = 2;
   kInt8 = 3;
   kInt32 = 4;
+  kBFloat16 = 5;
 }
 
 // Describes how a convolution input or output layer's data is formatted.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -1648,6 +1648,8 @@ miopenDataType_t ToMIOpenDataType(
   switch (data_type) {
     case dnn::DataType::kFloat:
       return miopenFloat;
+    case dnn::DataType::kBFloat16:
+      return miopenBFloat16;
     case dnn::DataType::kHalf:
       return miopenHalf;
     case dnn::DataType::kDouble:

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -727,16 +727,59 @@ Stream &Stream::ThenConvolveWithAlgorithm(
   return *this;
 }
 
-Stream &Stream::ThenConvolveWithAlgorithm(
-    const dnn::BatchDescriptor &input_descriptor,
-    const DeviceMemory<Eigen::half> &input_data,
-    const dnn::FilterDescriptor &filter_descriptor,
-    const DeviceMemory<Eigen::half> &filter_data,
-    const dnn::ConvolutionDescriptor &convolution_descriptor,
-    const dnn::BatchDescriptor &output_descriptor,
-    DeviceMemory<Eigen::half> *output, ScratchAllocator *scratch_allocator,
-    const dnn::AlgorithmConfig &algorithm_config,
-    dnn::ProfileResult *output_profile_result) {
+Stream& Stream::ThenConvolveWithAlgorithm(
+    const dnn::BatchDescriptor& input_descriptor,
+    const DeviceMemory<tensorflow::bfloat16>& input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<tensorflow::bfloat16>& filter_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemory<tensorflow::bfloat16>* output,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
+            PARAM(filter_descriptor), PARAM(filter_data),
+            PARAM(convolution_descriptor), PARAM(output_descriptor),
+            PARAM(output), PARAM(algorithm_config));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      DeviceMemory<uint8> scratch_memory;
+      dnn::AlgorithmDesc algorithm_desc;
+      auto status =
+          dnn->PrepareForConvolution(
+                 dnn::ConvolutionKind::FORWARD, this, input_descriptor,
+                 input_data, filter_descriptor, filter_data, output_descriptor,
+                 *output, convolution_descriptor, algorithm_config,
+                 scratch_allocator, &algorithm_desc, &scratch_memory)
+              .ok();
+      if (status) {
+        status = dnn->DoConvolve(
+            this, input_descriptor, input_data, filter_descriptor, filter_data,
+            convolution_descriptor, output_descriptor, output, algorithm_desc,
+            &scratch_memory, output_profile_result);
+      }
+      if (!status && !output_profile_result) {
+        SetError();
+      }
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenConvolveWithAlgorithm(
+    const dnn::BatchDescriptor& input_descriptor,
+    const DeviceMemory<Eigen::half>& input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<Eigen::half>& filter_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemory<Eigen::half>* output, ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
             PARAM(filter_descriptor), PARAM(filter_data),
             PARAM(convolution_descriptor), PARAM(output_descriptor),
@@ -1045,17 +1088,62 @@ Stream &Stream::ThenConvolveBackwardDataWithAlgorithm(
   return *this;
 }
 
-Stream &Stream::ThenConvolveBackwardDataWithAlgorithm(
-    const dnn::FilterDescriptor &filter_descriptor,
-    const DeviceMemory<Eigen::half> &filter_data,
-    const dnn::BatchDescriptor &output_descriptor,
+Stream& Stream::ThenConvolveBackwardDataWithAlgorithm(
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<tensorflow::bfloat16>& filter_data,
+    const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemory<tensorflow::bfloat16> backward_output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& input_descriptor,
+    DeviceMemory<tensorflow::bfloat16>* backward_input_data,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
+  VLOG_CALL(PARAM(filter_descriptor), PARAM(filter_data),
+            PARAM(output_descriptor), PARAM(backward_output_data),
+            PARAM(convolution_descriptor), PARAM(input_descriptor),
+            PARAM(backward_input_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      DeviceMemory<uint8> scratch_memory;
+      dnn::AlgorithmDesc algorithm_desc;
+      auto status =
+          dnn->PrepareForConvolution(
+                 dnn::ConvolutionKind::BACKWARD_DATA, this, input_descriptor,
+                 *backward_input_data, filter_descriptor, filter_data,
+                 output_descriptor, backward_output_data,
+                 convolution_descriptor, algorithm_config, scratch_allocator,
+                 &algorithm_desc, &scratch_memory)
+              .ok();
+      if (status) {
+        status = dnn->DoConvolveBackwardData(
+            this, filter_descriptor, filter_data, output_descriptor,
+            backward_output_data, convolution_descriptor, input_descriptor,
+            backward_input_data, algorithm_desc, &scratch_memory,
+            output_profile_result);
+      }
+      if (!status && !output_profile_result) {
+        SetError();
+      }
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenConvolveBackwardDataWithAlgorithm(
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<Eigen::half>& filter_data,
+    const dnn::BatchDescriptor& output_descriptor,
     DeviceMemory<Eigen::half> backward_output_data,
-    const dnn::ConvolutionDescriptor &convolution_descriptor,
-    const dnn::BatchDescriptor &input_descriptor,
-    DeviceMemory<Eigen::half> *backward_input_data,
-    ScratchAllocator *scratch_allocator,
-    const dnn::AlgorithmConfig &algorithm_config,
-    dnn::ProfileResult *output_profile_result) {
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& input_descriptor,
+    DeviceMemory<Eigen::half>* backward_input_data,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(filter_descriptor), PARAM(filter_data),
             PARAM(output_descriptor), PARAM(backward_output_data),
             PARAM(convolution_descriptor), PARAM(input_descriptor),
@@ -1146,6 +1234,51 @@ Stream &Stream::ThenConvolveBackwardFilterWithAlgorithm(
     ScratchAllocator *scratch_allocator,
     const dnn::AlgorithmConfig &algorithm_config,
     dnn::ProfileResult *output_profile_result) {
+  VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
+            PARAM(output_descriptor), PARAM(backward_output_data),
+            PARAM(convolution_descriptor), PARAM(filter_descriptor),
+            PARAM(backward_filter_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      DeviceMemory<uint8> scratch_memory;
+      dnn::AlgorithmDesc algorithm_desc;
+      auto status =
+          dnn->PrepareForConvolution(
+                 dnn::ConvolutionKind::BACKWARD_FILTER, this, input_descriptor,
+                 input_data, filter_descriptor, *backward_filter_data,
+                 output_descriptor, backward_output_data,
+                 convolution_descriptor, algorithm_config, scratch_allocator,
+                 &algorithm_desc, &scratch_memory)
+              .ok();
+      if (status) {
+        status = dnn->DoConvolveBackwardFilter(
+            this, input_descriptor, input_data, output_descriptor,
+            backward_output_data, convolution_descriptor, filter_descriptor,
+            backward_filter_data, algorithm_desc, &scratch_memory,
+            output_profile_result);
+      }
+      if (!status && !output_profile_result) {
+        SetError();
+      }
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenConvolveBackwardFilterWithAlgorithm(
+    const dnn::BatchDescriptor& input_descriptor,
+    const DeviceMemory<tensorflow::bfloat16>& input_data,
+    const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemory<tensorflow::bfloat16> backward_output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemory<tensorflow::bfloat16>* backward_filter_data,
+    ScratchAllocator* scratch_allocator,
+    const dnn::AlgorithmConfig& algorithm_config,
+    dnn::ProfileResult* output_profile_result) {
   VLOG_CALL(PARAM(input_descriptor), PARAM(input_data),
             PARAM(output_descriptor), PARAM(backward_output_data),
             PARAM(convolution_descriptor), PARAM(filter_descriptor),
@@ -5450,6 +5583,226 @@ Stream &Stream::ThenEnqueueOnBackgroundThread(
   return ThenDoHostCallback([stream_executor, bound_task]() {
     stream_executor->EnqueueOnBackgroundThread(bound_task);
   });
+}
+
+Stream& Stream::ThenFusedConvolutionBiasActivation(
+    const dnn::BatchDescriptor& conv_input_descriptor,
+    const DeviceMemory<float>& conv_input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const DeviceMemory<float>& filter_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::BatchDescriptor& bias_descriptor,
+    const DeviceMemory<float>& bias_data, dnn::ActivationMode activation_mode,
+    const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemory<float>* output_data) {
+  VLOG_CALL(PARAM(conv_input_descriptor), PARAM(conv_input_data),
+            PARAM(filter_descriptor), PARAM(filter_data),
+            PARAM(convolution_descriptor), PARAM(bias_descriptor),
+            PARAM(bias_data), PARAM(activation_mode), PARAM(output_descriptor),
+            PARAM(output_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedConvolutionBiasActivation(
+          this, conv_input_descriptor, conv_input_data, filter_descriptor,
+          filter_data, convolution_descriptor, bias_descriptor, bias_data,
+          activation_mode, output_descriptor, output_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
+Stream& Stream::ThenFusedBatchNormActivationInference(
+    const dnn::BatchDescriptor& x_descriptor, const DeviceMemory<float>& x_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data,
+    const DeviceMemory<float>& mean_data,
+    const DeviceMemory<float>& variance_data, double epsilon,
+    dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data) {
+  VLOG_CALL(PARAM(x_descriptor), PARAM(x_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(mean_data), PARAM(variance_data),
+            PARAM(epsilon), PARAM(activation_mode), PARAM(y_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationInference(
+          this, x_descriptor, x_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, mean_data, variance_data, epsilon,
+          activation_mode, y_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
+Stream& Stream::ThenFusedBatchNormActivationInference(
+    const dnn::BatchDescriptor& x_descriptor,
+    const DeviceMemory<Eigen::half>& x_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data,
+    const DeviceMemory<float>& mean_data,
+    const DeviceMemory<float>& variance_data, double epsilon,
+    dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half>* y_data) {
+  VLOG_CALL(PARAM(x_descriptor), PARAM(x_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(mean_data), PARAM(variance_data),
+            PARAM(epsilon), PARAM(activation_mode), PARAM(y_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationInference(
+          this, x_descriptor, x_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, mean_data, variance_data, epsilon,
+          activation_mode, y_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
+Stream& Stream::ThenFusedBatchNormActivationForward(
+    const dnn::BatchDescriptor& x_descriptor, const DeviceMemory<float>& x_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data, double epsilon,
+    dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data,
+    DeviceMemory<float>* batch_mean_data, DeviceMemory<float>* batch_var_data,
+    DeviceMemory<float>* saved_mean_data, DeviceMemory<float>* saved_var_data) {
+  VLOG_CALL(PARAM(x_descriptor), PARAM(x_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(epsilon), PARAM(activation_mode),
+            PARAM(y_data), PARAM(batch_mean_data), PARAM(batch_var_data),
+            PARAM(saved_mean_data), PARAM(saved_var_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationForward(
+          this, x_descriptor, x_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, epsilon, activation_mode, y_data,
+          batch_mean_data, batch_var_data, saved_mean_data, saved_var_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
+Stream& Stream::ThenFusedBatchNormActivationForward(
+    const dnn::BatchDescriptor& x_descriptor,
+    const DeviceMemory<Eigen::half>& x_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data, double epsilon,
+    dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half>* y_data,
+    DeviceMemory<float>* batch_mean_data, DeviceMemory<float>* batch_var_data,
+    DeviceMemory<float>* saved_mean_data, DeviceMemory<float>* saved_var_data) {
+  VLOG_CALL(PARAM(x_descriptor), PARAM(x_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(epsilon), PARAM(activation_mode),
+            PARAM(y_data), PARAM(batch_mean_data), PARAM(batch_var_data),
+            PARAM(saved_mean_data), PARAM(saved_var_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationForward(
+          this, x_descriptor, x_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, epsilon, activation_mode, y_data,
+          batch_mean_data, batch_var_data, saved_mean_data, saved_var_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
+Stream& Stream::ThenFusedBatchNormActivationBackward(
+    const dnn::BatchDescriptor& y_act_backprop_descriptor,
+    const DeviceMemory<float>& y_act_backprop_data,
+    const DeviceMemory<float>& y_act_data, dnn::ActivationMode activation_mode,
+    const DeviceMemory<float>& x_bn_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data,
+    const DeviceMemory<float>& saved_mean_data,
+    const DeviceMemory<float>& saved_var_data,
+    DeviceMemory<float>* x_bn_backprop_data,
+    DeviceMemory<float>* scale_backprop_data,
+    DeviceMemory<float>* offset_backprop_data) {
+  VLOG_CALL(PARAM(y_act_backprop_descriptor), PARAM(y_act_backprop_data),
+            PARAM(y_act_data), PARAM(activation_mode), PARAM(x_bn_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(saved_mean_data), PARAM(saved_var_data),
+            PARAM(x_bn_backprop_data), PARAM(scale_backprop_data),
+            PARAM(offset_backprop_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationBackward(
+          this, y_act_backprop_descriptor, y_act_backprop_data, y_act_data,
+          activation_mode, x_bn_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, saved_mean_data, saved_var_data,
+          x_bn_backprop_data, scale_backprop_data, offset_backprop_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
+}
+
+Stream& Stream::ThenFusedBatchNormActivationBackward(
+    const dnn::BatchDescriptor& y_act_backprop_descriptor,
+    const DeviceMemory<Eigen::half>& y_act_backprop_data,
+    const DeviceMemory<Eigen::half>& y_act_data,
+    dnn::ActivationMode activation_mode,
+    const DeviceMemory<Eigen::half>& x_bn_data,
+    const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+    const DeviceMemory<float>& scale_data,
+    const DeviceMemory<float>& offset_data,
+    const DeviceMemory<float>& saved_mean_data,
+    const DeviceMemory<float>& saved_var_data,
+    DeviceMemory<Eigen::half>* x_bn_backprop_data,
+    DeviceMemory<float>* scale_backprop_data,
+    DeviceMemory<float>* offset_backprop_data) {
+  VLOG_CALL(PARAM(y_act_backprop_descriptor), PARAM(y_act_backprop_data),
+            PARAM(y_act_data), PARAM(activation_mode), PARAM(x_bn_data),
+            PARAM(scale_offset_mean_variance_descriptor), PARAM(scale_data),
+            PARAM(offset_data), PARAM(saved_mean_data), PARAM(saved_var_data),
+            PARAM(x_bn_backprop_data), PARAM(scale_backprop_data),
+            PARAM(offset_backprop_data));
+
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoFusedBatchNormActivationBackward(
+          this, y_act_backprop_descriptor, y_act_backprop_data, y_act_data,
+          activation_mode, x_bn_data, scale_offset_mean_variance_descriptor,
+          scale_data, offset_data, saved_mean_data, saved_var_data,
+          x_bn_backprop_data, scale_backprop_data, offset_backprop_data,
+          /*output_profile_result=*/nullptr));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+
+  return *this;
 }
 
 port::Status Stream::BlockHostUntilDone() {

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <memory>
 
 #include "absl/synchronization/mutex.h"
+#include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/stream_executor/blas.h"
@@ -330,16 +331,28 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
-  Stream &ThenConvolveWithAlgorithm(
-      const dnn::BatchDescriptor &input_descriptor,
-      const DeviceMemory<Eigen::half> &input_data,
-      const dnn::FilterDescriptor &filter_descriptor,
-      const DeviceMemory<Eigen::half> &filter_data,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::BatchDescriptor &output_descriptor,
-      DeviceMemory<Eigen::half> *output, ScratchAllocator *scratch_allocator,
-      const dnn::AlgorithmConfig &algorithm_config,
-      dnn::ProfileResult *output_profile_result);
+  Stream& ThenConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<tensorflow::bfloat16>* output,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<Eigen::half>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<Eigen::half>* output, ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenConvolveWithAlgorithm(
       const dnn::BatchDescriptor &input_descriptor,
@@ -468,17 +481,29 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
-  Stream &ThenConvolveBackwardDataWithAlgorithm(
-      const dnn::FilterDescriptor &filter_descriptor,
-      const DeviceMemory<Eigen::half> &filter_data,
-      const dnn::BatchDescriptor &output_descriptor,
+  Stream& ThenConvolveBackwardDataWithAlgorithm(
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<tensorflow::bfloat16> backward_output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& input_descriptor,
+      DeviceMemory<tensorflow::bfloat16>* backward_input_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveBackwardDataWithAlgorithm(
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<Eigen::half>& filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<Eigen::half> backward_output_data,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::BatchDescriptor &input_descriptor,
-      DeviceMemory<Eigen::half> *backward_input_data,
-      ScratchAllocator *scratch_allocator,
-      const dnn::AlgorithmConfig &algorithm_config,
-      dnn::ProfileResult *output_profile_result);
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& input_descriptor,
+      DeviceMemory<Eigen::half>* backward_input_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenConvolveBackwardFilterWithAlgorithm(
       const dnn::BatchDescriptor &input_descriptor,
@@ -504,17 +529,29 @@ class Stream {
       const dnn::AlgorithmConfig &algorithm_config,
       dnn::ProfileResult *output_profile_result);
 
-  Stream &ThenConvolveBackwardFilterWithAlgorithm(
-      const dnn::BatchDescriptor &input_descriptor,
-      const DeviceMemory<Eigen::half> &input_data,
-      const dnn::BatchDescriptor &output_descriptor,
+  Stream& ThenConvolveBackwardFilterWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<tensorflow::bfloat16>& input_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<tensorflow::bfloat16> backward_output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemory<tensorflow::bfloat16>* backward_filter_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
+
+  Stream& ThenConvolveBackwardFilterWithAlgorithm(
+      const dnn::BatchDescriptor& input_descriptor,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::BatchDescriptor& output_descriptor,
       DeviceMemory<Eigen::half> backward_output_data,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::FilterDescriptor &filter_descriptor,
-      DeviceMemory<Eigen::half> *backward_filter_data,
-      ScratchAllocator *scratch_allocator,
-      const dnn::AlgorithmConfig &algorithm_config,
-      dnn::ProfileResult *output_profile_result);
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemory<Eigen::half>* backward_filter_data,
+      ScratchAllocator* scratch_allocator,
+      const dnn::AlgorithmConfig& algorithm_config,
+      dnn::ProfileResult* output_profile_result);
 
   Stream &ThenConvolveBackwardBias(const dnn::BatchDescriptor &input_descriptor,
                                    const DeviceMemory<double> &input_data,
@@ -1942,6 +1979,97 @@ class Stream {
                                input_data, output_desc,
                                dnn::ToDataType<OutElemT>(), output_data);
   }
+
+  // Routines to do fused operations
+
+  // Fused Convolution+Bias+Activation (float)
+  Stream& ThenFusedConvolutionBiasActivation(
+      const dnn::BatchDescriptor& conv_input_descriptor,
+      const DeviceMemory<float>& conv_input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const DeviceMemory<float>& filter_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      const dnn::BatchDescriptor& bias_descriptor,
+      const DeviceMemory<float>& bias_data, dnn::ActivationMode activation_mode,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemory<float>* output_data);
+
+  // Fused BatchNorm+Activation (inference) (float)
+  Stream& ThenFusedBatchNormActivationInference(
+      const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data);
+
+  // Fused BatchNorm+Activation (inference) (Eigen::half)
+  Stream& ThenFusedBatchNormActivationInference(
+      const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<Eigen::half>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& mean_data,
+      const DeviceMemory<float>& variance_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half>* y_data);
+
+  // Fused BatchNorm+Activation (training-fwd) (float)
+  Stream& ThenFusedBatchNormActivationForward(
+      const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<float>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<float>* y_data,
+      DeviceMemory<float>* batch_mean_data, DeviceMemory<float>* batch_var_data,
+      DeviceMemory<float>* saved_mean_data,
+      DeviceMemory<float>* saved_var_data);
+
+  // Fused BatchNorm+Activation (training-fwd) (Eigen::half)
+  Stream& ThenFusedBatchNormActivationForward(
+      const dnn::BatchDescriptor& x_descriptor,
+      const DeviceMemory<Eigen::half>& x_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data, double epsilon,
+      dnn::ActivationMode activation_mode, DeviceMemory<Eigen::half>* y_data,
+      DeviceMemory<float>* batch_mean_data, DeviceMemory<float>* batch_var_data,
+      DeviceMemory<float>* saved_mean_data,
+      DeviceMemory<float>* saved_var_data);
+
+  // Fused BatchNorm+Activation (training-bwd) (float)
+  Stream& ThenFusedBatchNormActivationBackward(
+      const dnn::BatchDescriptor& y_act_backprop_descriptor,
+      const DeviceMemory<float>& y_act_backprop_data,
+      const DeviceMemory<float>& y_act_data,
+      dnn::ActivationMode activation_mode, const DeviceMemory<float>& x_bn_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& saved_mean_data,
+      const DeviceMemory<float>& saved_var_data,
+      DeviceMemory<float>* x_bn_backprop_data,
+      DeviceMemory<float>* scale_backprop_data,
+      DeviceMemory<float>* offset_backprop_data);
+
+  // Fused BatchNorm+Activation (training-bwd) (Eigen::half)
+  Stream& ThenFusedBatchNormActivationBackward(
+      const dnn::BatchDescriptor& y_act_backprop_descriptor,
+      const DeviceMemory<Eigen::half>& y_act_backprop_data,
+      const DeviceMemory<Eigen::half>& y_act_data,
+      dnn::ActivationMode activation_mode,
+      const DeviceMemory<Eigen::half>& x_bn_data,
+      const dnn::BatchDescriptor& scale_offset_mean_variance_descriptor,
+      const DeviceMemory<float>& scale_data,
+      const DeviceMemory<float>& offset_data,
+      const DeviceMemory<float>& saved_mean_data,
+      const DeviceMemory<float>& saved_var_data,
+      DeviceMemory<Eigen::half>* x_bn_backprop_data,
+      DeviceMemory<float>* scale_backprop_data,
+      DeviceMemory<float>* offset_backprop_data);
 
   // (Synchronously) block the host code waiting for the operations
   // entrained on the stream (enqueued to this point in program


### PR DESCRIPTION
This PR is to port the ROCm blfoat16 support from the `develop-upstream` to the `master-rocm-enhanced` branch.

We need to have a few pre-reqs in place before we can take this PR
- [ ] identify a commit on the `upstream/master` branch for which all ROCm CI jobs (`rocm`, `rocm-cpp`, `rocm-xla`)  are passing, aka the ROCm CI qualified commit
- [ ] rebase the `master-rocm-enhanced` branch to the ROCm CI qualified commit
- [ ] Setup ROCm CI jobs to run on PRs filed on the `master-rocm-enhanced` branch

The purpose of filing this PR now is to assist with filtering out the changes in this PR, from the set of diffs in `develop-upstream` that we need to triage before we abandon that branch 