### PR TITLE
[DO NOT MERGE] Porting ROCm Dropout support to master-rocm-enhanced

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Dropout.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Dropout.pbtxt
@@ -1,0 +1,6 @@
+op {
+  graph_op_name: "Dropout"
+  summary: "Regularizing tensor input by reset random elements to zero."
+  description: <<END
+END
+}

--- a/tensorflow/core/api_def/base_api/api_def_DropoutGrad.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DropoutGrad.pbtxt
@@ -1,0 +1,6 @@
+op {
+  graph_op_name: "DropoutGrad"
+  summary: "Computes gradients of the dropout function."
+  description: <<END
+END
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4723,6 +4723,7 @@ cc_library(
         ":depthwise_conv_grad_op",
         ":depthwise_conv_op",
         ":dilation_ops",
+        ":dropout_op",
         ":fused_batch_norm_op",
         ":in_topk_op",
         ":l2loss_op",
@@ -4783,6 +4784,14 @@ tf_kernel_library(
     ]) + if_rocm([
         "@local_config_rocm//rocm:rocprim",
     ]),
+)
+
+tf_kernel_library(
+    name = "dropout_op",
+    prefix = "dropout_op",
+    deps = NN_DEPS + [
+        ":conv_ops",
+    ],
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4791,6 +4791,7 @@ tf_kernel_library(
     prefix = "dropout_op",
     deps = NN_DEPS + [
         ":conv_ops",
+        ":random_op",
     ],
 )
 

--- a/tensorflow/core/kernels/dropout_op.cc
+++ b/tensorflow/core/kernels/dropout_op.cc
@@ -1,0 +1,275 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if TENSORFLOW_USE_ROCM
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/core/util/tensor_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename Device, typename T>
+class DropoutOp : public OpKernel {
+ public:
+  explicit DropoutOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  ~DropoutOp() override {}
+
+  void Compute(OpKernelContext* ctx) override {
+    auto* stream = ctx->op_device_context()->stream();
+
+    const Tensor& in0 = ctx->input(0);
+
+    const Tensor& in1 = ctx->input(1);
+    OP_REQUIRES(ctx, in0.dtype() == in1.dtype(),
+                errors::InvalidArgument(
+                    "Dropout rate must be same type as input tensor."));
+    OP_REQUIRES(
+        ctx, in1.dims() == 0,
+        errors::InvalidArgument("Dropout rate must be a scalar tensor."));
+    auto rate_src_ptr = AsDeviceMemory<T>(&in1.scalar<T>()(), sizeof(T));
+    T rate = 0;
+    stream->ThenMemcpy(&rate, rate_src_ptr, sizeof(T));
+
+    const Tensor& in2 = ctx->input(2);
+    auto noise_shape_src_ptr = AsDeviceMemory<int32>(
+        in2.flat<int32>().data(), in2.flat<int32>().size() * sizeof(int32));
+    std::vector<int32> noise_dim_size(in2.shape().num_elements(), 0);
+    stream->ThenMemcpy(noise_dim_size.data(), noise_shape_src_ptr,
+                       in2.flat<int32>().size() * sizeof(int32));
+    OP_REQUIRES(ctx, in0.dims() == noise_dim_size.size(),
+                errors::InvalidArgument("MIOpen only supports input dimensions "
+                                        "to match noise dimensions."));
+
+    const Tensor& in3 = ctx->input(3);
+    OP_REQUIRES(
+        ctx, in3.dims() == 0,
+        errors::InvalidArgument("Dropout seed must be a scalar tensor."));
+    auto seed_src_ptr =
+        AsDeviceMemory<int64>(&in3.scalar<int64>()(), sizeof(int64));
+    int64 seed = 0;
+    stream->ThenMemcpy(&seed, seed_src_ptr, sizeof(int64));
+
+    se::dnn::DropoutDescriptor dropout_desc;
+    dropout_desc.set_rate(rate);
+    dropout_desc.set_seed(seed);
+
+    // Allocate output, and exit early if possible
+    Tensor* output;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, in0.shape(), &output));
+    if (output->NumElements() == 0) return;
+
+    // Fill one to higher dimensions
+    gtl::InlinedVector<int64, 4> input_dim_sizes = in0.shape().dim_sizes();
+    size_t input_size_to_fill = 4 - input_dim_sizes.size();
+    for (size_t i = 0; i < input_size_to_fill; ++i) {
+      input_dim_sizes.insert(input_dim_sizes.begin(), 1);
+    }
+    const int64 in_batch = input_dim_sizes[0];
+    const int64 in_depths = input_dim_sizes[1];
+    const int64 in_rows = input_dim_sizes[2];
+    const int64 in_cols = input_dim_sizes[3];
+
+    // Interpret compute data layout to NCHW to be consistent with input tensor
+    se::dnn::BatchDescriptor input_desc;
+    input_desc.set_count(in_batch)
+        .set_feature_map_count(in_depths)
+        .set_height(in_rows)
+        .set_width(in_cols)
+        .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+    size_t noise_size_to_fill = 4 - noise_dim_size.size();
+    for (size_t i = 0; i < noise_size_to_fill; ++i) {
+      noise_dim_size.insert(noise_dim_size.begin(), 1);
+    }
+    const int64 noise_batch = noise_dim_size[0];
+    const int64 noise_depth = noise_dim_size[1];
+    const int64 noise_rows = noise_dim_size[2];
+    const int64 noise_cols = noise_dim_size[3];
+
+    se::dnn::BatchDescriptor noise_desc;
+    noise_desc.set_count(noise_batch)
+        .set_feature_map_count(noise_depth)
+        .set_height(noise_rows)
+        .set_width(noise_cols)
+        .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+    se::dnn::BatchDescriptor output_desc;
+    output_desc.CloneFrom(input_desc);
+
+    auto input_data =
+        AsDeviceMemory(in0.flat<T>().data(), in0.flat<T>().size());
+
+    auto output_data =
+        AsDeviceMemory(output->flat<T>().data(), output->flat<T>().size());
+
+    static int64 DropoutScratchSize = GetDnnWorkspaceLimit(
+        // default value is in bytes despite the name of the environment
+        // variable
+        "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB
+    );
+    DnnScratchAllocator scratch_allocator(DropoutScratchSize, ctx);
+
+    bool status = stream
+                      ->ThenDropoutForward(dropout_desc, noise_desc, input_desc,
+                                           input_data, output_desc,
+                                           &output_data, &scratch_allocator)
+                      .ok();
+    OP_REQUIRES(ctx, status,
+                errors::Internal("dnn DropoutForward launch failed"));
+  }
+};
+
+#define REGISTER_DROPOUT_GPU(TYPE)                                  \
+  REGISTER_KERNEL_BUILDER(                                          \
+      Name("Dropout").Device(DEVICE_GPU).TypeConstraint<TYPE>("T"), \
+      DropoutOp<GPUDevice, TYPE>);
+
+TF_CALL_float(REGISTER_DROPOUT_GPU);
+// TODO Enable when MIOpen supports the following data types
+//TF_CALL_double(REGISTER_DROPOUT_GPU);
+//TF_CALL_half(REGISTER_DROPOUT_GPU);
+
+template <typename Device, typename T>
+class DropoutGradOp : public OpKernel {
+ public:
+  explicit DropoutGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  ~DropoutGradOp() override {}
+
+  void Compute(OpKernelContext* ctx) override {
+    auto* stream = ctx->op_device_context()->stream();
+
+    const Tensor& in0 = ctx->input(0);
+
+    const Tensor& in1 = ctx->input(1);
+    OP_REQUIRES(ctx, in0.dtype() == in1.dtype(),
+                errors::InvalidArgument(
+                    "Dropout rate must be same type as input tensor."));
+    OP_REQUIRES(
+        ctx, in1.dims() == 0,
+        errors::InvalidArgument("Dropout rate must be a scalar tensor."));
+    auto rate_src_ptr = AsDeviceMemory<T>(&in1.scalar<T>()(), sizeof(T));
+    T rate = 0;
+    stream->ThenMemcpy(&rate, rate_src_ptr, sizeof(T));
+
+    const Tensor& in2 = ctx->input(2);
+    auto noise_shape_src_ptr = AsDeviceMemory<int32>(
+        in2.flat<int32>().data(), in2.flat<int32>().size() * sizeof(int32));
+    std::vector<int32> noise_dim_size(in2.shape().num_elements(), 0);
+    stream->ThenMemcpy(noise_dim_size.data(), noise_shape_src_ptr,
+                       in2.flat<int32>().size() * sizeof(int32));
+    OP_REQUIRES(ctx, in0.dims() == noise_dim_size.size(),
+                errors::InvalidArgument("MIOpen only supports input dimensions "
+                                        "to match noise dimensions."));
+
+    const Tensor& in3 = ctx->input(3);
+    OP_REQUIRES(
+        ctx, in3.dims() == 0,
+        errors::InvalidArgument("Dropout seed must be a scalar tensor."));
+    auto seed_src_ptr =
+        AsDeviceMemory<int64>(&in3.scalar<int64>()(), sizeof(int64));
+    int64 seed = 0;
+    stream->ThenMemcpy(&seed, seed_src_ptr, sizeof(int64));
+
+    se::dnn::DropoutDescriptor dropout_desc;
+    dropout_desc.set_rate(rate);
+    dropout_desc.set_seed(seed);
+
+    // Allocate output, and exit early if possible
+    Tensor* output;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, in0.shape(), &output));
+    if (output->NumElements() == 0) return;
+
+    // Fill one to higher dimensions
+    gtl::InlinedVector<int64, 4> input_dim_sizes = in0.shape().dim_sizes();
+    size_t input_size_to_fill = 4 - input_dim_sizes.size();
+    for (size_t i = 0; i < input_size_to_fill; ++i) {
+      input_dim_sizes.insert(input_dim_sizes.begin(), 1);
+    }
+    const int64 in_batch = input_dim_sizes[0];
+    const int64 in_depths = input_dim_sizes[1];
+    const int64 in_rows = input_dim_sizes[2];
+    const int64 in_cols = input_dim_sizes[3];
+
+    // Interpret compute data layout to NCHW to be consistent with input tensor
+    se::dnn::BatchDescriptor input_delta_desc;
+    input_delta_desc.set_count(in_batch)
+        .set_feature_map_count(in_depths)
+        .set_height(in_rows)
+        .set_width(in_cols)
+        .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+    size_t noise_size_to_fill = 4 - noise_dim_size.size();
+    for (size_t i = 0; i < noise_size_to_fill; ++i) {
+      noise_dim_size.insert(noise_dim_size.begin(), 1);
+    }
+    const int64 noise_batch = noise_dim_size[0];
+    const int64 noise_depth = noise_dim_size[1];
+    const int64 noise_rows = noise_dim_size[2];
+    const int64 noise_cols = noise_dim_size[3];
+
+    se::dnn::BatchDescriptor noise_desc;
+    noise_desc.set_count(noise_batch)
+        .set_feature_map_count(noise_depth)
+        .set_height(noise_rows)
+        .set_width(noise_cols)
+        .set_layout(se::dnn::DataLayout::kBatchDepthYX);
+
+    se::dnn::BatchDescriptor output_desc;
+    output_desc.CloneFrom(input_delta_desc);
+
+    auto input_delta =
+        AsDeviceMemory(in0.flat<T>().data(), in0.flat<T>().size());
+
+    auto output_data =
+        AsDeviceMemory(output->flat<T>().data(), output->flat<T>().size());
+
+    static int64 DropoutScratchSize = GetDnnWorkspaceLimit(
+        // default value is in bytes despite the name of the environment
+        // variable
+        "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB
+    );
+    DnnScratchAllocator scratch_allocator(DropoutScratchSize, ctx);
+
+    bool status =
+        stream
+            ->ThenDropoutBackward(dropout_desc, noise_desc, input_delta_desc,
+                                  input_delta, output_desc, &output_data,
+                                  &scratch_allocator)
+            .ok();
+    OP_REQUIRES(ctx, status,
+                errors::Internal("dnn DropoutBackward launch failed"));
+  }
+};
+
+#define REGISTER_DROPOUT_GRAD_GPU(TYPE)                                 \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("DropoutGrad").Device(DEVICE_GPU).TypeConstraint<TYPE>("T"), \
+      DropoutGradOp<GPUDevice, TYPE>);
+
+TF_CALL_float(REGISTER_DROPOUT_GRAD_GPU);
+// TODO Enable when MIOpen supports the following data types
+//TF_CALL_double(REGISTER_DROPOUT_GRAD_GPU);
+//TF_CALL_half(REGISTER_DROPOUT_GRAD_GPU);
+
+}  // namespace tensorflow
+#endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/dropout_op.cc
+++ b/tensorflow/core/kernels/dropout_op.cc
@@ -19,7 +19,9 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/conv_ops_gpu.h"
+#include "tensorflow/core/kernels/random_op.h"
 #include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/core/util/guarded_philox_random.h"
 #include "tensorflow/core/util/tensor_format.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
@@ -28,8 +30,13 @@ typedef Eigen::GpuDevice GPUDevice;
 
 template <typename Device, typename T>
 class DropoutOp : public OpKernel {
+ private:
+  GuardedPhiloxRandom generator_;
+
  public:
-  explicit DropoutOp(OpKernelConstruction* context) : OpKernel(context) {}
+  explicit DropoutOp(OpKernelConstruction* context) : OpKernel(context) {
+    generator_.Init(0, 0);
+  }
 
   ~DropoutOp() override {}
 
@@ -46,7 +53,7 @@ class DropoutOp : public OpKernel {
         ctx, in1.dims() == 0,
         errors::InvalidArgument("Dropout rate must be a scalar tensor."));
     auto rate_src_ptr = AsDeviceMemory<T>(&in1.scalar<T>()(), sizeof(T));
-    T rate = 0;
+    T rate;
     stream->ThenMemcpy(&rate, rate_src_ptr, sizeof(T));
 
     const Tensor& in2 = ctx->input(2);
@@ -67,10 +74,33 @@ class DropoutOp : public OpKernel {
         AsDeviceMemory<int64>(&in3.scalar<int64>()(), sizeof(int64));
     int64 seed = 0;
     stream->ThenMemcpy(&seed, seed_src_ptr, sizeof(int64));
+    generator_.ResetSeeds(seed, 0);
 
     se::dnn::DropoutDescriptor dropout_desc;
-    dropout_desc.set_rate(rate);
+    dropout_desc.set_rate(static_cast<float>(rate));
     dropout_desc.set_seed(seed);
+
+    // Build random uniform distribution
+    typedef random::UniformDistribution<random::PhiloxRandom, T> Distribution;
+    Distribution dist;
+
+    std::vector<T> random_nums(in0.shape().num_elements());
+    functor::FillPhiloxRandom<Eigen::ThreadPoolDevice, Distribution>()(
+        ctx, ctx->eigen_device<Eigen::ThreadPoolDevice>(),
+        // Multiplier 256 is the same as in FillPhiloxRandomTask; do not change
+        // it just here.
+        generator_.ReserveRandomOutputs(random_nums.size() * sizeof(T), 256),
+        random_nums.data(), random_nums.size(), dist);
+
+    Eigen::Tensor<T, 1> rate_tensor(random_nums.size());
+    rate_tensor.setConstant(rate);
+    Eigen::TensorMap<Eigen::Tensor<T, 1>> random_tensor(random_nums.data(),
+                                                        random_nums.size());
+    Eigen::Tensor<bool, 1> mask_tensor(random_nums.size());
+    mask_tensor = random_tensor >= rate_tensor;
+    std::vector<uint8> mask = std::vector<uint8>(
+        mask_tensor.data(), mask_tensor.data() + mask_tensor.size());
+    dropout_desc.set_mask(mask);
 
     // Allocate output, and exit early if possible
     Tensor* output;
@@ -144,14 +174,19 @@ class DropoutOp : public OpKernel {
       DropoutOp<GPUDevice, TYPE>);
 
 TF_CALL_float(REGISTER_DROPOUT_GPU);
+TF_CALL_half(REGISTER_DROPOUT_GPU);
 // TODO Enable when MIOpen supports the following data types
 //TF_CALL_double(REGISTER_DROPOUT_GPU);
-//TF_CALL_half(REGISTER_DROPOUT_GPU);
 
 template <typename Device, typename T>
 class DropoutGradOp : public OpKernel {
+ private:
+  GuardedPhiloxRandom generator_;
+
  public:
-  explicit DropoutGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+  explicit DropoutGradOp(OpKernelConstruction* context) : OpKernel(context) {
+    generator_.Init(0, 0);
+  }
 
   ~DropoutGradOp() override {}
 
@@ -168,7 +203,7 @@ class DropoutGradOp : public OpKernel {
         ctx, in1.dims() == 0,
         errors::InvalidArgument("Dropout rate must be a scalar tensor."));
     auto rate_src_ptr = AsDeviceMemory<T>(&in1.scalar<T>()(), sizeof(T));
-    T rate = 0;
+    T rate;
     stream->ThenMemcpy(&rate, rate_src_ptr, sizeof(T));
 
     const Tensor& in2 = ctx->input(2);
@@ -189,10 +224,33 @@ class DropoutGradOp : public OpKernel {
         AsDeviceMemory<int64>(&in3.scalar<int64>()(), sizeof(int64));
     int64 seed = 0;
     stream->ThenMemcpy(&seed, seed_src_ptr, sizeof(int64));
+    generator_.ResetSeeds(seed, 0);
 
     se::dnn::DropoutDescriptor dropout_desc;
-    dropout_desc.set_rate(rate);
+    dropout_desc.set_rate(static_cast<float>(rate));
     dropout_desc.set_seed(seed);
+
+    // Build random uniform distribution
+    typedef random::UniformDistribution<random::PhiloxRandom, T> Distribution;
+    Distribution dist;
+
+    std::vector<T> random_nums(in0.shape().num_elements());
+    functor::FillPhiloxRandom<Eigen::ThreadPoolDevice, Distribution>()(
+        ctx, ctx->eigen_device<Eigen::ThreadPoolDevice>(),
+        // Multiplier 256 is the same as in FillPhiloxRandomTask; do not change
+        // it just here.
+        generator_.ReserveRandomOutputs(random_nums.size() * sizeof(T), 256),
+        random_nums.data(), random_nums.size(), dist);
+
+    Eigen::Tensor<T, 1> rate_tensor(random_nums.size());
+    rate_tensor.setConstant(rate);
+    Eigen::TensorMap<Eigen::Tensor<T, 1>> random_tensor(random_nums.data(),
+                                                        random_nums.size());
+    Eigen::Tensor<bool, 1> mask_tensor(random_nums.size());
+    mask_tensor = random_tensor >= rate_tensor;
+    std::vector<uint8> mask = std::vector<uint8>(
+        mask_tensor.data(), mask_tensor.data() + mask_tensor.size());
+    dropout_desc.set_mask(mask);
 
     // Allocate output, and exit early if possible
     Tensor* output;
@@ -211,8 +269,8 @@ class DropoutGradOp : public OpKernel {
     const int64 in_cols = input_dim_sizes[3];
 
     // Interpret compute data layout to NCHW to be consistent with input tensor
-    se::dnn::BatchDescriptor input_delta_desc;
-    input_delta_desc.set_count(in_batch)
+    se::dnn::BatchDescriptor input_desc;
+    input_desc.set_count(in_batch)
         .set_feature_map_count(in_depths)
         .set_height(in_rows)
         .set_width(in_cols)
@@ -235,9 +293,9 @@ class DropoutGradOp : public OpKernel {
         .set_layout(se::dnn::DataLayout::kBatchDepthYX);
 
     se::dnn::BatchDescriptor output_desc;
-    output_desc.CloneFrom(input_delta_desc);
+    output_desc.CloneFrom(input_desc);
 
-    auto input_delta =
+    auto input_data =
         AsDeviceMemory(in0.flat<T>().data(), in0.flat<T>().size());
 
     auto output_data =
@@ -250,12 +308,11 @@ class DropoutGradOp : public OpKernel {
     );
     DnnScratchAllocator scratch_allocator(DropoutScratchSize, ctx);
 
-    bool status =
-        stream
-            ->ThenDropoutBackward(dropout_desc, noise_desc, input_delta_desc,
-                                  input_delta, output_desc, &output_data,
-                                  &scratch_allocator)
-            .ok();
+    bool status = stream
+                      ->ThenDropoutBackward(dropout_desc, noise_desc,
+                                            input_desc, input_data, output_desc,
+                                            &output_data, &scratch_allocator)
+                      .ok();
     OP_REQUIRES(ctx, status,
                 errors::Internal("dnn DropoutBackward launch failed"));
   }
@@ -267,9 +324,9 @@ class DropoutGradOp : public OpKernel {
       DropoutGradOp<GPUDevice, TYPE>);
 
 TF_CALL_float(REGISTER_DROPOUT_GRAD_GPU);
+TF_CALL_half(REGISTER_DROPOUT_GRAD_GPU);
 // TODO Enable when MIOpen supports the following data types
 //TF_CALL_double(REGISTER_DROPOUT_GRAD_GPU);
-//TF_CALL_half(REGISTER_DROPOUT_GRAD_GPU);
 
 }  // namespace tensorflow
 #endif  // TENSORFLOW_USE_ROCM

--- a/tensorflow/core/ops/nn_grad.cc
+++ b/tensorflow/core/ops/nn_grad.cc
@@ -137,6 +137,25 @@ Status CrossEntropyGrad(const AttrSlice& attrs, FunctionDef* g) {
 }
 REGISTER_OP_GRADIENT("CrossEntropy", CrossEntropyGrad);
 
+Status DropoutGrad(const AttrSlice& attrs, FunctionDef* g) {
+  // clang-format off
+  *g = FDH::Define(
+      // Arg defs
+      {"dy: T", "rate: T", "noise_shape: int32"},
+      // Ret val defs
+      {"dx: T"},
+      // Attr defs
+      {"T: {half, float, double}", "seed: int"},
+      // Nodes
+      {
+        {{"dx"}, "DropoutGrad", {"dy", "rate", "noise_shape", "seed"},
+         /*Attrs=*/{{"T", "$T"}}}
+      });
+  // clang-format on
+  return Status::OK();
+}
+REGISTER_OP_GRADIENT("Dropout", DropoutGrad);
+
 Status Conv2DGrad(const AttrSlice& attrs, FunctionDef* g) {
   // clang-format off
   *g = FDH::Define(

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -338,7 +338,7 @@ REGISTER_OP("Dropout")
     .Input("noise_shape: int32")
     .Input("seed: int64")
     .Output("output: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, half}")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("DropoutGrad")
@@ -347,7 +347,7 @@ REGISTER_OP("DropoutGrad")
     .Input("noise_shape: int32")
     .Input("seed: int64")
     .Output("backprops: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, half}")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 // --------------------------------------------------------------------------

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -332,6 +332,26 @@ REGISTER_OP("BiasAddV1")
     .SetShapeFn(shape_inference::BiasAddShape);
 // --------------------------------------------------------------------------
 
+REGISTER_OP("Dropout")
+    .Input("input: T")
+    .Input("rate: T")
+    .Input("noise_shape: int32")
+    .Input("seed: int64")
+    .Output("output: T")
+    .Attr("T: {float}")
+    .SetShapeFn(shape_inference::UnchangedShape);
+
+REGISTER_OP("DropoutGrad")
+    .Input("gradients: T")
+    .Input("rate: T")
+    .Input("noise_shape: int32")
+    .Input("seed: int64")
+    .Output("backprops: T")
+    .Attr("T: {float}")
+    .SetShapeFn(shape_inference::UnchangedShape);
+
+// --------------------------------------------------------------------------
+
 REGISTER_OP("Conv2D")
     .Input("input: T")
     .Input("filter: T")

--- a/tensorflow/core/util/guarded_philox_random.cc
+++ b/tensorflow/core/util/guarded_philox_random.cc
@@ -51,6 +51,11 @@ void GuardedPhiloxRandom::Init(random::PhiloxRandom::ResultType counter,
   initialized_ = true;
 }
 
+void GuardedPhiloxRandom::ResetSeeds(int64 seed, int64 seed2) {
+  mutex_lock lock(mu_);
+  generator_ = random::PhiloxRandom(seed, seed2);
+}
+
 random::PhiloxRandom GuardedPhiloxRandom::ReserveSamples128(int64 samples) {
   CHECK(initialized_);
   mutex_lock lock(mu_);

--- a/tensorflow/core/util/guarded_philox_random.h
+++ b/tensorflow/core/util/guarded_philox_random.h
@@ -52,6 +52,9 @@ class GuardedPhiloxRandom {
   void Init(random::PhiloxRandom::ResultType counter,
             random::PhiloxRandom::Key key);
 
+  // Used by dropout operator to reset seed to achieve same random state
+  void ResetSeeds(int64 seed, int64 seed2);
+
   // Reserve a certain number of 128-bit samples.
   // This function is thread safe.  The returned generator is valid for the
   // given number of samples, and can be used without a lock.

--- a/tensorflow/python/distribute/collective_all_reduce_strategy_test.py
+++ b/tensorflow/python/distribute/collective_all_reduce_strategy_test.py
@@ -215,7 +215,8 @@ class CollectiveAllReduceStrategyTestBase(
               activation=nn.relu), max_pool,
           l.Flatten(),
           l.Dense(1024, activation=nn.relu),
-          l.Dropout(0.4),
+          # ROCm dropout has GPU support only, disabling it now
+          #l.Dropout(0.4),
           l.Dense(10)
       ])
       image = random_ops.random_uniform([2, 28, 28])

--- a/tensorflow/python/keras/layers/core_test.py
+++ b/tensorflow/python/keras/layers/core_test.py
@@ -41,6 +41,8 @@ from tensorflow.python.platform import test
 class DropoutLayersTest(keras_parameterized.TestCase):
 
   def test_dropout(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     testing_utils.layer_test(
         keras.layers.Dropout, kwargs={'rate': 0.5}, input_shape=(3, 2))
 
@@ -55,12 +57,16 @@ class DropoutLayersTest(keras_parameterized.TestCase):
     self.assertEqual(True, dropout.supports_masking)
 
   def test_spatial_dropout_1d(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     testing_utils.layer_test(
         keras.layers.SpatialDropout1D,
         kwargs={'rate': 0.5},
         input_shape=(2, 3, 4))
 
   def test_spatial_dropout_2d(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     testing_utils.layer_test(
         keras.layers.SpatialDropout2D,
         kwargs={'rate': 0.5},
@@ -72,6 +78,8 @@ class DropoutLayersTest(keras_parameterized.TestCase):
         input_shape=(2, 3, 4, 5))
 
   def test_spatial_dropout_3d(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     testing_utils.layer_test(
         keras.layers.SpatialDropout3D,
         kwargs={'rate': 0.5},
@@ -83,6 +91,8 @@ class DropoutLayersTest(keras_parameterized.TestCase):
         input_shape=(2, 3, 4, 4, 5))
 
   def test_dropout_partial_noise_shape(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     inputs = keras.Input(shape=(5, 10))
     layer = keras.layers.Dropout(0.5, noise_shape=(None, 1, None))
     outputs = layer(inputs)

--- a/tensorflow/python/keras/legacy_tf_layers/core_test.py
+++ b/tensorflow/python/keras/legacy_tf_layers/core_test.py
@@ -421,6 +421,8 @@ class DropoutTest(test.TestCase, parameterized.TestCase):
 
   @combinations.generate(combinations.combine(mode=['graph', 'eager']))
   def testDynamicNoiseShape(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     inputs = array_ops.ones((5, 3, 2))
     noise_shape = [None, 1, None]
     dp = core_layers.Dropout(0.5, noise_shape=noise_shape, seed=1)
@@ -431,6 +433,8 @@ class DropoutTest(test.TestCase, parameterized.TestCase):
     self.assertAllClose(np_output[:, 0, :], np_output[:, 1, :])
 
   def testCustomNoiseShape(self):
+    if test.is_built_with_rocm:
+      self.skipTest('ROCm dropout donot support noise_shape different than input tensor shape.')
     inputs = array_ops.ones((5, 3, 2))
     noise_shape = [5, 1, 2]
     dp = core_layers.Dropout(0.5, noise_shape=noise_shape, seed=1)

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from tensorflow.python.eager import backprop
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+from tensorflow.python.platform import build_info
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import math_ops
@@ -1070,6 +1071,26 @@ def _L2LossGrad(op, grad):
   """
   return op.inputs[0] * grad
 
+def ConditionalRegister(dec, condition):
+  def decorator(func):
+    if condition:
+      return dec(func)
+    else:
+      return func
+  return decorator
+
+@ConditionalRegister(ops.RegisterGradient("Dropout"),build_info.is_rocm_build)
+def _DropoutGrad(op, grad):
+  dx = 0
+  if op.inputs[0].dtype is dtypes.float32:
+    dx =  gen_nn_ops.dropout_grad(
+          grad, op.inputs[1], op.inputs[2], op.inputs[3])
+  else:
+    keep_mask = (op.inputs[0] - op.outputs[0]) < 1e-5
+    keep_mask_val = math_ops.cast(keep_mask, op.inputs[0].dtype)
+    scale = tf.size(op.outputs[0]) / math_ops.reduce_sum(keep_mask_val)
+    dx = grad * scale * keep_mask_val
+  return [dx, None, None, None]
 
 @ops.RegisterGradient("TopK")
 @ops.RegisterGradient("TopKV2")

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -1083,12 +1083,12 @@ def ConditionalRegister(dec, condition):
 def _DropoutGrad(op, grad):
   dx = 0
   if op.inputs[0].dtype is dtypes.float32:
-    dx =  gen_nn_ops.dropout_grad(
+    dx = gen_nn_ops.dropout_grad(
           grad, op.inputs[1], op.inputs[2], op.inputs[3])
   else:
     keep_mask = (op.inputs[0] - op.outputs[0]) < 1e-5
     keep_mask_val = math_ops.cast(keep_mask, op.inputs[0].dtype)
-    scale = tf.size(op.outputs[0]) / math_ops.reduce_sum(keep_mask_val)
+    scale = math_ops.cast(array_ops.size(op.outputs[0]), op.inputs[0].dtype) / math_ops.reduce_sum(keep_mask_val)
     dx = grad * scale * keep_mask_val
   return [dx, None, None, None]
 

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -1071,27 +1071,6 @@ def _L2LossGrad(op, grad):
   """
   return op.inputs[0] * grad
 
-def ConditionalRegister(dec, condition):
-  def decorator(func):
-    if condition:
-      return dec(func)
-    else:
-      return func
-  return decorator
-
-@ConditionalRegister(ops.RegisterGradient("Dropout"),build_info.is_rocm_build)
-def _DropoutGrad(op, grad):
-  dx = 0
-  if op.inputs[0].dtype == dtypes.float32 or op.inputs[0].dtype == dtypes.float16:
-    dx = gen_nn_ops.dropout_grad(
-          grad, op.inputs[1], op.inputs[2], op.inputs[3])
-  else:
-    keep_mask = (op.inputs[0] - op.outputs[0]) < 1e-5
-    keep_mask_val = math_ops.cast(keep_mask, op.inputs[0].dtype)
-    scale = math_ops.cast(array_ops.size(op.outputs[0]), op.inputs[0].dtype) / math_ops.reduce_sum(keep_mask_val)
-    dx = grad * scale * keep_mask_val
-  return [dx, None, None, None]
-
 @ops.RegisterGradient("TopK")
 @ops.RegisterGradient("TopKV2")
 def _TopKGrad(op, grad, _):

--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -1082,7 +1082,7 @@ def ConditionalRegister(dec, condition):
 @ConditionalRegister(ops.RegisterGradient("Dropout"),build_info.is_rocm_build)
 def _DropoutGrad(op, grad):
   dx = 0
-  if op.inputs[0].dtype is dtypes.float32:
+  if op.inputs[0].dtype == dtypes.float32 or op.inputs[0].dtype == dtypes.float16:
     dx = gen_nn_ops.dropout_grad(
           grad, op.inputs[1], op.inputs[2], op.inputs[3])
   else:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4674,12 +4674,12 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
 
     noise_shape = _get_noise_shape(x, noise_shape)
 
-    if seed is None:
-        seed = 0
-
     # Should there be ROCm support, use it. Otherwise fallback to generic
     # implementation
-    if build_info.is_rocm_build and x.dtype is dtypes.float32:
+    if build_info.is_rocm_build and \
+       (x.dtype == dtypes.float32 or x.dtype == dtypes.float16):
+      if seed is None:
+        seed = 0
       return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
 
     # Sample a uniform distribution on [0.0, 1.0) and select values larger than

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4674,16 +4674,8 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
 
     noise_shape = _get_noise_shape(x, noise_shape)
 
-    # Should there be ROCm support, use it. Otherwise fallback to generic
-    # implementation
-    if build_info.is_rocm_build and \
-       (x.dtype == dtypes.float32 or x.dtype == dtypes.float16):
-      if seed is None:
-        seed = 0
-      return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
-
-    # Sample a uniform distribution on [0.0, 1.0) and select values larger than
-    # rate.
+    # Sample a uniform distribution on [0.0, 1.0) and select values larger
+    # than rate.
     #
     # NOTE: Random uniform can only generate 2^23 floats on [1.0, 2.0)
     # and subtract 1.0.

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -44,6 +44,8 @@ from tensorflow.python.ops import random_ops
 from tensorflow.python.ops.gen_nn_ops import *
 # pylint: enable=wildcard-import
 from tensorflow.python.platform import device_context
+from tensorflow.python.platform import build_info
+from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.compat import collections_abc
 from tensorflow.python.util.deprecation import deprecated_args
@@ -3279,7 +3281,7 @@ def softmax(logits, axis=None, name=None, dim=None):
       Tensor.
     RuntimeError: If a registered conversion function returns an invalid
       value.
-      
+
   """
   axis = deprecation.deprecated_argument_lookup("axis", axis, "dim", dim)
   if axis is None:
@@ -4671,8 +4673,20 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
       ret = gen_math_ops.real_div(x, gen_math_ops.sub(one_tensor, rate))
 
     noise_shape = _get_noise_shape(x, noise_shape)
-    # Sample a uniform distribution on [0.0, 1.0) and select values larger
-    # than rate.
+
+    if seed is None:
+        seed = 0
+
+    # Should there be ROCm support, use it. Otherwise fallback to generic
+    # implementation
+    if build_info.is_rocm_build and isinstance(seed, numbers.Real):
+      try:
+        return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
+      except:
+        pass
+
+    # Sample a uniform distribution on [0.0, 1.0) and select values larger than
+    # rate.
     #
     # NOTE: Random uniform can only generate 2^23 floats on [1.0, 2.0)
     # and subtract 1.0.

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4679,11 +4679,8 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
 
     # Should there be ROCm support, use it. Otherwise fallback to generic
     # implementation
-    if build_info.is_rocm_build and isinstance(seed, numbers.Real):
-      try:
-        return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
-      except:
-        pass
+    if build_info.is_rocm_build and x.dtype is dtypes.float32:
+      return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
 
     # Sample a uniform distribution on [0.0, 1.0) and select values larger than
     # rate.

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -358,36 +358,6 @@ class DropoutTest(test_lib.TestCase):
       print(rel_error)
       self.assertTrue(rel_error < 0.15)
 
-  @test_util.run_deprecated_v1
-  def testDropoutGradFloat16(self):
-    if not test_lib.is_built_with_rocm():
-      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
-
-    x_dim = 40
-    y_dim = 30
-    shape = [x_dim, y_dim]
-    rate = 0.1
-    with self.cached_session(use_gpu=True):
-      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float16)
-      value = nn_ops.dropout(t, rate=rate)
-      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
-      self.assertLess(err, 0.5)
-
-  @test_util.run_deprecated_v1
-  def testDropoutGradFloat32(self):
-    if not test_lib.is_built_with_rocm():
-      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
-
-    x_dim = 40
-    y_dim = 30
-    shape = [x_dim, y_dim]
-    rate = 0.1
-    with self.cached_session(use_gpu=True):
-      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float32)
-      value = nn_ops.dropout(t, rate=rate)
-      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
-      self.assertLess(err, 1e-2)
-
   def testShapedDropout(self):
     # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
     # that it is producing approximately the right number of ones over a large

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -340,12 +340,12 @@ class DropoutTest(test_lib.TestCase):
     x_dim = 40
     y_dim = 30
     shape = [x_dim, y_dim]
-    t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float32)
     rate = 0.1
-    value = nn_ops.dropout(t, rate=rate)
     with self.cached_session(use_gpu=True):
+      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float32)
+      value = nn_ops.dropout(t, rate=rate)
       err = gradient_checker.compute_gradient_error(t, shape, value, shape)
-      self.assertLess(err, 1e-4)
+      self.assertLess(err, 1e-2)
 
   def testShapedDropout(self):
     # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -306,6 +306,32 @@ class L2NormalizeTest(test_lib.TestCase):
 
 class DropoutTest(test_lib.TestCase):
 
+  def testDropoutFloat16(self):
+    # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
+    # that it is producing approximately the right number of ones over a large
+    # number of samples, based on the keep probability.
+    x_dim = 40
+    y_dim = 30
+    num_iter = 10
+    for keep_prob in [0.1, 0.5, 0.8]:
+      t = constant_op.constant(1.0, shape=[x_dim, y_dim], dtype=dtypes.float16)
+      dropout = nn_ops.dropout(t, rate=(1 - keep_prob))
+      final_count = 0
+      self.assertEqual([x_dim, y_dim], dropout.get_shape())
+      for _ in xrange(0, num_iter):
+        value = self.evaluate(dropout)
+        final_count += np.count_nonzero(value)
+        # Verifies that there are only two values: 0 and 1/keep_prob.
+        sorted_value = np.unique(np.sort(value))
+        self.assertEqual(0, sorted_value[0])
+        self.assertAllClose(1 / keep_prob, sorted_value[1], rtol=0.1, atol=0.1)
+
+      # Check that we are in the 15% error range
+      expected_count = x_dim * y_dim * keep_prob * num_iter
+      rel_error = math.fabs(final_count - expected_count) / expected_count
+      self.assertTrue(rel_error < 0.15)
+
+
   def testDropout(self):
     # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
     # that it is producing approximately the right number of ones over a large
@@ -331,6 +357,21 @@ class DropoutTest(test_lib.TestCase):
       rel_error = math.fabs(final_count - expected_count) / expected_count
       print(rel_error)
       self.assertTrue(rel_error < 0.15)
+
+  @test_util.run_deprecated_v1
+  def testDropoutGradFloat16(self):
+    if not test_lib.is_built_with_rocm():
+      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
+
+    x_dim = 40
+    y_dim = 30
+    shape = [x_dim, y_dim]
+    rate = 0.1
+    with self.cached_session(use_gpu=True):
+      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float16)
+      value = nn_ops.dropout(t, rate=rate)
+      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
+      self.assertLess(err, 0.5)
 
   @test_util.run_deprecated_v1
   def testDropoutGradFloat32(self):

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -332,11 +332,29 @@ class DropoutTest(test_lib.TestCase):
       print(rel_error)
       self.assertTrue(rel_error < 0.15)
 
+  @test_util.run_deprecated_v1
+  def testDropoutGradFloat32(self):
+    if not test_lib.is_built_with_rocm():
+      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
+
+    x_dim = 40
+    y_dim = 30
+    shape = [x_dim, y_dim]
+    t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float32)
+    rate = 0.1
+    value = nn_ops.dropout(t, rate=rate)
+    with self.cached_session(use_gpu=True):
+      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
+      self.assertLess(err, 1e-4)
+
   def testShapedDropout(self):
     # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
     # that it is producing approximately the right number of ones over a large
     # number of samples, based on the keep probability. This time with shaped
     # noise.
+    if test_lib.is_built_with_rocm():
+      self.skipTest("MIOpen does not support noise_shape with a different dimension")
+
     x_dim = 40 * 30
     y_dim = 3
     num_iter = 10
@@ -361,6 +379,9 @@ class DropoutTest(test_lib.TestCase):
 
   def testShapedDropoutCorrelation(self):
     # Runs a shaped dropout and tests that the correlations are correct.
+    if test_lib.is_built_with_rocm():
+       self.skipTest("MIOpen does not support noise_shape with a different dimension")
+
     x_dim = 40
     y_dim = 30
     num_iter = 10
@@ -417,6 +438,9 @@ class DropoutTest(test_lib.TestCase):
     self.assertEqual(x.get_shape(), dropout_x.get_shape())
 
   def testPartialShapedDropout(self):
+    if test_lib.is_built_with_rocm():
+       self.skipTest("MIOpen does not support noise_shape with a different dimension")
+
     x_dim = 40 * 30
     y_dim = 3
     num_iter = 10
@@ -480,6 +504,9 @@ class DropoutTest(test_lib.TestCase):
 
   @test_util.run_deprecated_v1
   def testShapedDropoutShapeError(self):
+    if test_lib.is_built_with_rocm():
+       self.skipTest("MIOpen does not support noise_shape with a different dimension")
+
     # Runs shaped dropout and verifies an error is thrown on misshapen noise.
     x_dim = 40
     y_dim = 30

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -654,13 +654,19 @@ class DropoutDescriptor {
     rate_ = value;
     return *this;
   }
+  DropoutDescriptor& set_mask(const std::vector<uint8>& mask) {
+    mask_ = mask;
+    return *this;
+  }
 
   unsigned long long seed() const { return seed_; }
   float rate() const { return rate_; }
+  std::vector<uint8> mask() const { return mask_; }
 
  private:
   unsigned long long seed_;
   float rate_;
+  std::vector<uint8> mask_;
 };
 
 // A patch of values in the input can be pooled via either a max or an average
@@ -1663,18 +1669,6 @@ class DnnSupport {
       Stream* stream, const dnn::DropoutDescriptor& dropout_params,
       const dnn::BatchDescriptor& noise_dimensions,
       const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<double>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<double>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutForward not implemented for double.";
-    return false;
-  }
-
-  virtual bool DoDropoutForward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
       const DeviceMemory<float>& input_data,
       const dnn::BatchDescriptor& output_dimensions,
       DeviceMemory<float>* output_data,
@@ -1691,30 +1685,7 @@ class DnnSupport {
       const dnn::BatchDescriptor& output_dimensions,
       DeviceMemory<Eigen::half>* output_data,
       ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutForward not implemented for Eigen::half.";
-    return false;
-  }
-
-  virtual bool DoDropoutForward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<int8>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<int8>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutForward not implemented for int8.";
-    return false;
-  }
-  virtual bool DoDropoutBackward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<double>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<double>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutBackward not implemented for double.";
+    LOG(FATAL) << "DoDropoutForward not implemented for half.";
     return false;
   }
 
@@ -1738,19 +1709,7 @@ class DnnSupport {
       const dnn::BatchDescriptor& output_dimensions,
       DeviceMemory<Eigen::half>* output_data,
       ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutBackward not implemented for Eigen::half.";
-    return false;
-  }
-
-  virtual bool DoDropoutBackward(
-      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
-      const dnn::BatchDescriptor& noise_dimensions,
-      const dnn::BatchDescriptor& input_dimensions,
-      const DeviceMemory<int8>& input_data,
-      const dnn::BatchDescriptor& output_dimensions,
-      DeviceMemory<int8>* output_data,
-      ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(FATAL) << "DoDropoutBackward not implemented for int8.";
+    LOG(FATAL) << "DoDropoutBackward not implemented for half.";
     return false;
   }
 

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -642,6 +642,27 @@ class ConvolutionDescriptor {
   // int64 upscale_input_y;
 };
 
+class DropoutDescriptor {
+ public:
+  DropoutDescriptor(){};
+
+  DropoutDescriptor& set_seed(unsigned long long value) {
+    seed_ = value;
+    return *this;
+  }
+  DropoutDescriptor& set_rate(float value) {
+    rate_ = value;
+    return *this;
+  }
+
+  unsigned long long seed() const { return seed_; }
+  float rate() const { return rate_; }
+
+ private:
+  unsigned long long seed_;
+  float rate_;
+};
+
 // A patch of values in the input can be pooled via either a max or an average
 // operation.
 // Specify int64 so there's no padding in PoolingDescriptor.
@@ -1637,6 +1658,101 @@ class DnnSupport {
                          const DeviceMemory<float>& biases,
                          const dnn::BatchDescriptor& dimensions,
                          DeviceMemory<float>* output_data) = 0;
+
+  virtual bool DoDropoutForward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<double>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<double>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutForward not implemented for double.";
+    return false;
+  }
+
+  virtual bool DoDropoutForward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<float>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<float>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutForward not implemented for float.";
+    return false;
+  }
+
+  virtual bool DoDropoutForward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<Eigen::half>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutForward not implemented for Eigen::half.";
+    return false;
+  }
+
+  virtual bool DoDropoutForward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<int8>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<int8>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutForward not implemented for int8.";
+    return false;
+  }
+  virtual bool DoDropoutBackward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<double>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<double>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutBackward not implemented for double.";
+    return false;
+  }
+
+  virtual bool DoDropoutBackward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<float>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<float>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutBackward not implemented for float.";
+    return false;
+  }
+
+  virtual bool DoDropoutBackward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<Eigen::half>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutBackward not implemented for Eigen::half.";
+    return false;
+  }
+
+  virtual bool DoDropoutBackward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<int8>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<int8>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(FATAL) << "DoDropoutBackward not implemented for int8.";
+    return false;
+  }
 
   // Performs a forward pooling operation on input_data, writing to
   // output_data. See PoolingDescriptor for how to configure the

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -63,6 +63,7 @@ namespace stream_executor {
 using dnn::AlgorithmDesc;
 using dnn::BatchDescriptor;
 using dnn::ConvolutionDescriptor;
+using dnn::DropoutDescriptor;
 using dnn::FilterDescriptor;
 using dnn::NormalizeDescriptor;
 using dnn::PoolingDescriptor;
@@ -269,6 +270,8 @@ namespace wrap {
   __macro(miopenCreateConvolutionDescriptor)                         \
   __macro(miopenCreatePoolingDescriptor)                             \
   __macro(miopenDestroyPoolingDescriptor)                            \
+  __macro(miopenCreateDropoutDescriptor)			     \
+  __macro(miopenDestroyDropoutDescriptor)			     \
   __macro(miopenCreateLRNDescriptor)                                 \
   __macro(miopenDestroyLRNDescriptor)                                \
   __macro(miopenDestroyConvolutionDescriptor)                        \
@@ -292,6 +295,10 @@ namespace wrap {
   __macro(miopenPoolingForward)                                      \
   __macro(miopenPoolingGetWorkSpaceSize)                             \
   __macro(miopenPoolingBackward)                                     \
+  __macro(miopenDropoutForward)					     \
+  __macro(miopenDropoutBackward)				     \
+  __macro(miopenDropoutGetStatesSize)				     \
+  __macro(miopenSetDropoutDescriptor)				     \
   __macro(miopenLRNForward)                                          \
   __macro(miopenLRNBackward)                                         \
   __macro(miopenOpTensor)                                            \
@@ -815,6 +822,64 @@ class ScopedConvolutionDescriptor {
   miopenConvolutionDescriptor_t handle_;  // Owned.
 
   SE_DISALLOW_COPY_AND_ASSIGN(ScopedConvolutionDescriptor);
+};
+
+class ScopedDropoutDescriptor {
+ public:
+  ScopedDropoutDescriptor(miopenHandle_t miopen_handle,
+                          const DropoutDescriptor& dropout_descriptor,
+                          ScratchAllocator* state_allocator)
+      : handle_(nullptr) {
+    auto status = wrap::miopenCreateDropoutDescriptor(&handle_);
+    if (status != miopenStatusSuccess) {
+      LOG(FATAL) << "could not create miopen dropout descriptor: "
+                 << ToString(status);
+    }
+
+    DeviceMemory<uint8> state_memory;
+    if (state_allocator) {
+      size_t state_sizes_in_bytes = 0;
+      status = wrap::miopenDropoutGetStatesSize(miopen_handle,
+                                                &state_sizes_in_bytes);
+      if (status != miopenStatusSuccess) {
+        LOG(FATAL) << "could not query miopen dropout state size: "
+                   << ToString(status);
+      }
+      auto allocated = state_allocator->AllocateBytes(state_sizes_in_bytes);
+      if (!allocated.ok() ||
+          (state_memory = allocated.ValueOrDie()) == nullptr) {
+        LOG(ERROR) << "Failed to allocate dropout workspace";
+        return;
+      }
+    }
+
+    // Note that we hard code rng_mode now because there is only one node
+    // available, and this option is not part of user API. In the future we may
+    // consider exposing this as a field in DropoutDescriptor
+    status = wrap::miopenSetDropoutDescriptor(
+        handle_, miopen_handle, dropout_descriptor.rate(),
+        state_memory.opaque(), state_memory.size(), dropout_descriptor.seed(),
+        /*use_mask=*/false, /*state_evo=*/false,
+        /*rng_mode=*/miopenRNGType_t::MIOPEN_RNG_PSEUDO_XORWOW);
+    if (status != miopenStatusSuccess) {
+      LOG(FATAL) << "could not set miopen dropout descriptor: "
+                 << ToString(status);
+    }
+  }
+
+  miopenDropoutDescriptor_t handle() const { return handle_; }
+
+  ~ScopedDropoutDescriptor() {
+    auto status = wrap::miopenDestroyDropoutDescriptor(handle_);
+    if (status != miopenStatusSuccess) {
+      LOG(ERROR) << "could not destroy miopen dropout descriptor: "
+                 << ToString(status);
+    }
+  }
+
+ private:
+  miopenDropoutDescriptor_t handle_;  // Owned.
+  SE_DISALLOW_COPY_AND_ASSIGN(ScopedDropoutDescriptor);
 };
 
 // Turns a PoolingDescriptor structure into a miopen pooling descriptor handle
@@ -4001,6 +4066,121 @@ bool MIOpenSupport::DoActivate(Stream* stream,
                                uint64 options) {
   LOG(ERROR) << "miopen does not support activation yet";
   return false;
+}
+
+bool MIOpenSupport::DoDropoutForward(
+    Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_dimensions,
+    const DeviceMemory<float>& input_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<float>* output_data, ScratchAllocator* workspace_allocator) {
+  auto miopen = miopen_->GetHandle(parent_, stream);
+  const ScopedTensorDescriptor src_desc{input_dimensions, miopenFloat};
+  const ScopedTensorDescriptor dest_desc{output_dimensions, miopenFloat};
+  const ScopedTensorDescriptor noise_desc{noise_dimensions, miopenFloat};
+  const ScopedDropoutDescriptor dropout_desc{miopen.handle(), dropout_params,
+                                             workspace_allocator};
+
+  auto status = wrap::miopenDropoutForward(
+      miopen.handle(), dropout_desc.handle(), noise_desc.handle(),
+      src_desc.handle(), input_data.opaque(), dest_desc.handle(),
+      output_data->opaque(), nullptr, 0);
+  if (status != miopenStatusSuccess) {
+    LOG(ERROR) << "failed to enqueue forward dropout on stream: "
+               << ToString(status);
+    return false;
+  }
+  return true;
+}
+
+bool MIOpenSupport::DoDropoutForward(
+    Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_dimensions,
+    const DeviceMemory<Eigen::half>& input_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<Eigen::half>* output_data,
+    ScratchAllocator* workspace_allocator) {
+  auto miopen = miopen_->GetHandle(parent_, stream);
+  const ScopedTensorDescriptor src_desc{input_dimensions, miopenHalf};
+  const ScopedTensorDescriptor dest_desc{output_dimensions, miopenHalf};
+  const ScopedTensorDescriptor noise_desc{noise_dimensions, miopenHalf};
+  const ScopedDropoutDescriptor dropout_desc{miopen.handle(), dropout_params,
+                                             workspace_allocator};
+
+  auto status = wrap::miopenDropoutForward(
+      miopen.handle(), dropout_desc.handle(), noise_desc.handle(),
+      src_desc.handle(), input_data.opaque(), dest_desc.handle(),
+      output_data->opaque(), nullptr, 0);
+  if (status != miopenStatusSuccess) {
+    LOG(ERROR) << "failed to enqueue forward dropout on stream: "
+               << ToString(status);
+    return false;
+  }
+  return true;
+}
+
+bool MIOpenSupport::DoDropoutBackward(
+    Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_diff_dimensions,
+    const DeviceMemory<float>& input_diff_data,
+    const dnn::BatchDescriptor& output_diff_dimensions,
+    DeviceMemory<float>* output_diff_data,
+    ScratchAllocator* workspace_allocator) {
+  auto miopen = miopen_->GetHandle(parent_, stream);
+  const ScopedTensorDescriptor input_diff_desc{input_diff_dimensions,
+                                               miopenFloat};
+  const ScopedTensorDescriptor output_diff_desc{output_diff_dimensions,
+                                                miopenFloat};
+  const ScopedTensorDescriptor noise_desc{noise_dimensions, miopenFloat};
+  const ScopedDropoutDescriptor dropout_desc{miopen.handle(), dropout_params,
+                                             workspace_allocator};
+
+  auto status = wrap::miopenDropoutBackward(
+      miopen.handle(), dropout_desc.handle(), noise_desc.handle(),
+      /*dyDesc*/ input_diff_desc.handle(), /*dy*/ input_diff_data.opaque(),
+      /*dxDesc*/ output_diff_desc.handle(), /*dx*/ output_diff_data->opaque(),
+      nullptr, 0);
+
+  if (status != miopenStatusSuccess) {
+    LOG(ERROR) << "failed to enqueue backward dropout on stream: "
+               << ToString(status);
+    return false;
+  }
+  return true;
+}
+
+bool MIOpenSupport::DoDropoutBackward(
+    Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_diff_dimensions,
+    const DeviceMemory<Eigen::half>& input_diff_data,
+    const dnn::BatchDescriptor& output_diff_dimensions,
+    DeviceMemory<Eigen::half>* output_diff_data,
+    ScratchAllocator* workspace_allocator) {
+  auto miopen = miopen_->GetHandle(parent_, stream);
+  const ScopedTensorDescriptor input_diff_desc{input_diff_dimensions,
+                                               miopenHalf};
+  const ScopedTensorDescriptor output_diff_desc{output_diff_dimensions,
+                                                miopenHalf};
+  const ScopedTensorDescriptor noise_desc{noise_dimensions, miopenFloat};
+  const ScopedDropoutDescriptor dropout_desc{miopen.handle(), dropout_params,
+                                             workspace_allocator};
+
+  auto status = wrap::miopenDropoutBackward(
+      miopen.handle(), dropout_desc.handle(), noise_desc.handle(),
+      /*dyDesc*/ input_diff_desc.handle(), /*dy*/ input_diff_data.opaque(),
+      /*dxDesc*/ output_diff_desc.handle(), /*dx*/ output_diff_data->opaque(),
+      nullptr, 0);
+
+  if (status != miopenStatusSuccess) {
+    LOG(ERROR) << "failed to enqueue backward dropout on stream: "
+               << ToString(status);
+    return false;
+  }
+  return true;
 }
 
 bool MIOpenSupport::DoPoolForward(

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -434,18 +434,6 @@ class MIOpenSupport : public dnn::DnnSupport {
                   const DeviceMemory<float>& input_data,
                   DeviceMemory<float>* output_data, uint64 options) override;
 
-  bool DoDropoutForward(Stream* stream,
-                        const dnn::DropoutDescriptor& dropout_params,
-                        const dnn::BatchDescriptor& noise_dimensions,
-                        const dnn::BatchDescriptor& input_dimensions,
-                        const DeviceMemory<double>& input_data,
-                        const dnn::BatchDescriptor& output_dimensions,
-                        DeviceMemory<double>* output_data,
-                        ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(ERROR) << "miopen does not support dropout for dobule type yet";
-    return false;
-  }
-
   bool DoDropoutForward(
       Stream* stream, const dnn::DropoutDescriptor& dropout_params,
       const dnn::BatchDescriptor& noise_dimensions,
@@ -464,35 +452,23 @@ class MIOpenSupport : public dnn::DnnSupport {
       DeviceMemory<Eigen::half>* output_data,
       ScratchAllocator* workspace_allocator = nullptr) override;
 
-  bool DoDropoutBackward(Stream* stream,
-                         const dnn::DropoutDescriptor& dropout_params,
-                         const dnn::BatchDescriptor& noise_dimensions,
-                         const dnn::BatchDescriptor& input_diff_dimensions,
-                         const DeviceMemory<double>& input_diff_data,
-                         const dnn::BatchDescriptor& output_diff_dimensions,
-                         DeviceMemory<double>* output_data,
-                         ScratchAllocator* workspace_allocator = nullptr) {
-    LOG(ERROR) << "miopen does not support dropout for dobule type yet";
-    return false;
-  }
+  bool DoDropoutBackward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_diff_dimensions,
+      const DeviceMemory<float>& input_diff_data,
+      const dnn::BatchDescriptor& output_diff_dimensions,
+      DeviceMemory<float>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) override;
 
-  bool DoDropoutBackward(Stream* stream,
-                         const dnn::DropoutDescriptor& dropout_params,
-                         const dnn::BatchDescriptor& noise_dimensions,
-                         const dnn::BatchDescriptor& input_diff_dimensions,
-                         const DeviceMemory<float>& input_diff_data,
-                         const dnn::BatchDescriptor& output_diff_dimensions,
-                         DeviceMemory<float>* output_data,
-                         ScratchAllocator* workspace_allocator) override;
-
-  bool DoDropoutBackward(Stream* stream,
-                         const dnn::DropoutDescriptor& dropout_params,
-                         const dnn::BatchDescriptor& noise_dimensions,
-                         const dnn::BatchDescriptor& input_diff_dimensions,
-                         const DeviceMemory<Eigen::half>& input_diff_data,
-                         const dnn::BatchDescriptor& output_diff_dimensions,
-                         DeviceMemory<Eigen::half>* output_data,
-                         ScratchAllocator* workspace_allocator) override;
+  bool DoDropoutBackward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_diff_dimensions,
+      const DeviceMemory<Eigen::half>& input_diff_data,
+      const dnn::BatchDescriptor& output_diff_dimensions,
+      DeviceMemory<Eigen::half>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) override;
 
   bool DoPoolForward(Stream* stream,
                      const dnn::PoolingDescriptor& pooling_dimensions,

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -434,6 +434,66 @@ class MIOpenSupport : public dnn::DnnSupport {
                   const DeviceMemory<float>& input_data,
                   DeviceMemory<float>* output_data, uint64 options) override;
 
+  bool DoDropoutForward(Stream* stream,
+                        const dnn::DropoutDescriptor& dropout_params,
+                        const dnn::BatchDescriptor& noise_dimensions,
+                        const dnn::BatchDescriptor& input_dimensions,
+                        const DeviceMemory<double>& input_data,
+                        const dnn::BatchDescriptor& output_dimensions,
+                        DeviceMemory<double>* output_data,
+                        ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(ERROR) << "miopen does not support dropout for dobule type yet";
+    return false;
+  }
+
+  bool DoDropoutForward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<float>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<float>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) override;
+
+  bool DoDropoutForward(
+      Stream* stream, const dnn::DropoutDescriptor& dropout_params,
+      const dnn::BatchDescriptor& noise_dimensions,
+      const dnn::BatchDescriptor& input_dimensions,
+      const DeviceMemory<Eigen::half>& input_data,
+      const dnn::BatchDescriptor& output_dimensions,
+      DeviceMemory<Eigen::half>* output_data,
+      ScratchAllocator* workspace_allocator = nullptr) override;
+
+  bool DoDropoutBackward(Stream* stream,
+                         const dnn::DropoutDescriptor& dropout_params,
+                         const dnn::BatchDescriptor& noise_dimensions,
+                         const dnn::BatchDescriptor& input_diff_dimensions,
+                         const DeviceMemory<double>& input_diff_data,
+                         const dnn::BatchDescriptor& output_diff_dimensions,
+                         DeviceMemory<double>* output_data,
+                         ScratchAllocator* workspace_allocator = nullptr) {
+    LOG(ERROR) << "miopen does not support dropout for dobule type yet";
+    return false;
+  }
+
+  bool DoDropoutBackward(Stream* stream,
+                         const dnn::DropoutDescriptor& dropout_params,
+                         const dnn::BatchDescriptor& noise_dimensions,
+                         const dnn::BatchDescriptor& input_diff_dimensions,
+                         const DeviceMemory<float>& input_diff_data,
+                         const dnn::BatchDescriptor& output_diff_dimensions,
+                         DeviceMemory<float>* output_data,
+                         ScratchAllocator* workspace_allocator) override;
+
+  bool DoDropoutBackward(Stream* stream,
+                         const dnn::DropoutDescriptor& dropout_params,
+                         const dnn::BatchDescriptor& noise_dimensions,
+                         const dnn::BatchDescriptor& input_diff_dimensions,
+                         const DeviceMemory<Eigen::half>& input_diff_data,
+                         const dnn::BatchDescriptor& output_diff_dimensions,
+                         DeviceMemory<Eigen::half>* output_data,
+                         ScratchAllocator* workspace_allocator) override;
+
   bool DoPoolForward(Stream* stream,
                      const dnn::PoolingDescriptor& pooling_dimensions,
                      const dnn::BatchDescriptor& input_dimensions,

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -1379,6 +1379,163 @@ Stream &Stream::ThenPoolForward(
   return *this;
 }
 
+Stream& Stream::ThenDropoutForward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_dimensions,
+    const DeviceMemory<double>& input_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<double>* output_data, ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutForward(
+          this, dropout_params, noise_dimensions, input_dimensions, input_data,
+          output_dimensions, output_data, workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenDropoutForward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_dimensions,
+    const DeviceMemory<float>& input_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<float>* output_data, ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutForward(
+          this, dropout_params, noise_dimensions, input_dimensions, input_data,
+          output_dimensions, output_data, workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenDropoutForward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_dimensions,
+    const DeviceMemory<Eigen::half>& input_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<Eigen::half>* output_data,
+    ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutForward(
+          this, dropout_params, noise_dimensions, input_dimensions, input_data,
+          output_dimensions, output_data, workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenDropoutForward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_dimensions,
+    const DeviceMemory<int8>& input_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<int8>* output_data, ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutForward(
+          this, dropout_params, noise_dimensions, input_dimensions, input_data,
+          output_dimensions, output_data, workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenDropoutBackward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_diff_dimensions,
+    const DeviceMemory<double>& input_diff_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<double>* output_data, ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
+                                        input_diff_dimensions, input_diff_data,
+                                        output_dimensions, output_data,
+                                        workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenDropoutBackward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_diff_dimensions,
+    const DeviceMemory<float>& input_diff_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<float>* output_data, ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
+                                        input_diff_dimensions, input_diff_data,
+                                        output_dimensions, output_data,
+                                        workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+Stream& Stream::ThenDropoutBackward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_diff_dimensions,
+    const DeviceMemory<Eigen::half>& input_diff_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<Eigen::half>* output_data,
+    ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
+                                        input_diff_dimensions, input_diff_data,
+                                        output_dimensions, output_data,
+                                        workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
+Stream& Stream::ThenDropoutBackward(
+    const dnn::DropoutDescriptor& dropout_params,
+    const dnn::BatchDescriptor& noise_dimensions,
+    const dnn::BatchDescriptor& input_diff_dimensions,
+    const DeviceMemory<int8>& input_diff_data,
+    const dnn::BatchDescriptor& output_dimensions,
+    DeviceMemory<int8>* output_data, ScratchAllocator* workspace_allocator) {
+  if (ok()) {
+    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
+      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
+                                        input_diff_dimensions, input_diff_data,
+                                        output_dimensions, output_data,
+                                        workspace_allocator));
+    } else {
+      SetErrorAndLogNoDnnSupport();
+    }
+  }
+  return *this;
+}
+
 Stream &Stream::ThenPoolForward(
     const dnn::PoolingDescriptor &pooling_dimensions,
     const dnn::BatchDescriptor &input_dimensions,

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -1383,25 +1383,6 @@ Stream& Stream::ThenDropoutForward(
     const dnn::DropoutDescriptor& dropout_params,
     const dnn::BatchDescriptor& noise_dimensions,
     const dnn::BatchDescriptor& input_dimensions,
-    const DeviceMemory<double>& input_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<double>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutForward(
-          this, dropout_params, noise_dimensions, input_dimensions, input_data,
-          output_dimensions, output_data, workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
-Stream& Stream::ThenDropoutForward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_dimensions,
     const DeviceMemory<float>& input_data,
     const dnn::BatchDescriptor& output_dimensions,
     DeviceMemory<float>* output_data, ScratchAllocator* workspace_allocator) {
@@ -1437,45 +1418,6 @@ Stream& Stream::ThenDropoutForward(
   return *this;
 }
 
-Stream& Stream::ThenDropoutForward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_dimensions,
-    const DeviceMemory<int8>& input_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<int8>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutForward(
-          this, dropout_params, noise_dimensions, input_dimensions, input_data,
-          output_dimensions, output_data, workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
-Stream& Stream::ThenDropoutBackward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_diff_dimensions,
-    const DeviceMemory<double>& input_diff_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<double>* output_data, ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
-                                        input_diff_dimensions, input_diff_data,
-                                        output_dimensions, output_data,
-                                        workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
 Stream& Stream::ThenDropoutBackward(
     const dnn::DropoutDescriptor& dropout_params,
     const dnn::BatchDescriptor& noise_dimensions,
@@ -1495,6 +1437,7 @@ Stream& Stream::ThenDropoutBackward(
   }
   return *this;
 }
+
 Stream& Stream::ThenDropoutBackward(
     const dnn::DropoutDescriptor& dropout_params,
     const dnn::BatchDescriptor& noise_dimensions,
@@ -1503,26 +1446,6 @@ Stream& Stream::ThenDropoutBackward(
     const dnn::BatchDescriptor& output_dimensions,
     DeviceMemory<Eigen::half>* output_data,
     ScratchAllocator* workspace_allocator) {
-  if (ok()) {
-    if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
-      CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,
-                                        input_diff_dimensions, input_diff_data,
-                                        output_dimensions, output_data,
-                                        workspace_allocator));
-    } else {
-      SetErrorAndLogNoDnnSupport();
-    }
-  }
-  return *this;
-}
-
-Stream& Stream::ThenDropoutBackward(
-    const dnn::DropoutDescriptor& dropout_params,
-    const dnn::BatchDescriptor& noise_dimensions,
-    const dnn::BatchDescriptor& input_diff_dimensions,
-    const DeviceMemory<int8>& input_diff_data,
-    const dnn::BatchDescriptor& output_dimensions,
-    DeviceMemory<int8>* output_data, ScratchAllocator* workspace_allocator) {
   if (ok()) {
     if (dnn::DnnSupport* dnn = parent_->AsDnn()) {
       CheckError(dnn->DoDropoutBackward(this, dropout_params, noise_dimensions,

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -557,6 +557,70 @@ class Stream {
                       const dnn::BatchDescriptor &dimensions,
                       DeviceMemory<float> *output_data);
 
+  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
+                             const dnn::BatchDescriptor& noise_dimensions,
+                             const dnn::BatchDescriptor& input_dimensions,
+                             const DeviceMemory<double>& input_data,
+                             const dnn::BatchDescriptor& output_dimensions,
+                             DeviceMemory<double>* output_data,
+                             ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
+                             const dnn::BatchDescriptor& noise_dimensions,
+                             const dnn::BatchDescriptor& input_dimensions,
+                             const DeviceMemory<float>& input_data,
+                             const dnn::BatchDescriptor& output_dimensions,
+                             DeviceMemory<float>* output_data,
+                             ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
+                             const dnn::BatchDescriptor& noise_dimensions,
+                             const dnn::BatchDescriptor& input_dimensions,
+                             const DeviceMemory<Eigen::half>& input_data,
+                             const dnn::BatchDescriptor& output_dimensions,
+                             DeviceMemory<Eigen::half>* output_data,
+                             ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
+                             const dnn::BatchDescriptor& noise_dimensions,
+                             const dnn::BatchDescriptor& input_dimensions,
+                             const DeviceMemory<int8>& input_data,
+                             const dnn::BatchDescriptor& output_dimensions,
+                             DeviceMemory<int8>* output_data,
+                             ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
+                              const dnn::BatchDescriptor& noise_dimensions,
+                              const dnn::BatchDescriptor& input_diff_dimensions,
+                              const DeviceMemory<double>& input_diff_data,
+                              const dnn::BatchDescriptor& output_dimensions,
+                              DeviceMemory<double>* output_data,
+                              ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
+                              const dnn::BatchDescriptor& noise_dimensions,
+                              const dnn::BatchDescriptor& input_diff_dimensions,
+                              const DeviceMemory<float>& input_diff_data,
+                              const dnn::BatchDescriptor& output_dimensions,
+                              DeviceMemory<float>* output_data,
+                              ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
+                              const dnn::BatchDescriptor& noise_dimensions,
+                              const dnn::BatchDescriptor& input_diff_dimensions,
+                              const DeviceMemory<Eigen::half>& input_diff_data,
+                              const dnn::BatchDescriptor& output_dimensions,
+                              DeviceMemory<Eigen::half>* output_data,
+                              ScratchAllocator* workspace_allocator = nullptr);
+
+  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
+                              const dnn::BatchDescriptor& noise_dimensions,
+                              const dnn::BatchDescriptor& input_diff_dimensions,
+                              const DeviceMemory<int8>& input_diff_data,
+                              const dnn::BatchDescriptor& output_dimensions,
+                              DeviceMemory<int8>* output_data,
+                              ScratchAllocator* workspace_allocator = nullptr);
+
   Stream &ThenPoolForward(const dnn::PoolingDescriptor &pooling_dimensions,
                           const dnn::BatchDescriptor &input_dimensions,
                           const DeviceMemory<double> &input_data,

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -560,14 +560,6 @@ class Stream {
   Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
                              const dnn::BatchDescriptor& noise_dimensions,
                              const dnn::BatchDescriptor& input_dimensions,
-                             const DeviceMemory<double>& input_data,
-                             const dnn::BatchDescriptor& output_dimensions,
-                             DeviceMemory<double>* output_data,
-                             ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
-                             const dnn::BatchDescriptor& noise_dimensions,
-                             const dnn::BatchDescriptor& input_dimensions,
                              const DeviceMemory<float>& input_data,
                              const dnn::BatchDescriptor& output_dimensions,
                              DeviceMemory<float>* output_data,
@@ -580,22 +572,6 @@ class Stream {
                              const dnn::BatchDescriptor& output_dimensions,
                              DeviceMemory<Eigen::half>* output_data,
                              ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutForward(const dnn::DropoutDescriptor& dropout_params,
-                             const dnn::BatchDescriptor& noise_dimensions,
-                             const dnn::BatchDescriptor& input_dimensions,
-                             const DeviceMemory<int8>& input_data,
-                             const dnn::BatchDescriptor& output_dimensions,
-                             DeviceMemory<int8>* output_data,
-                             ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
-                              const dnn::BatchDescriptor& noise_dimensions,
-                              const dnn::BatchDescriptor& input_diff_dimensions,
-                              const DeviceMemory<double>& input_diff_data,
-                              const dnn::BatchDescriptor& output_dimensions,
-                              DeviceMemory<double>* output_data,
-                              ScratchAllocator* workspace_allocator = nullptr);
 
   Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
                               const dnn::BatchDescriptor& noise_dimensions,
@@ -611,14 +587,6 @@ class Stream {
                               const DeviceMemory<Eigen::half>& input_diff_data,
                               const dnn::BatchDescriptor& output_dimensions,
                               DeviceMemory<Eigen::half>* output_data,
-                              ScratchAllocator* workspace_allocator = nullptr);
-
-  Stream& ThenDropoutBackward(const dnn::DropoutDescriptor& dropout_params,
-                              const dnn::BatchDescriptor& noise_dimensions,
-                              const dnn::BatchDescriptor& input_diff_dimensions,
-                              const DeviceMemory<int8>& input_diff_data,
-                              const dnn::BatchDescriptor& output_dimensions,
-                              DeviceMemory<int8>* output_data,
                               ScratchAllocator* workspace_allocator = nullptr);
 
   Stream &ThenPoolForward(const dnn::PoolingDescriptor &pooling_dimensions,

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -1173,6 +1173,14 @@ tf_module {
     argspec: "args=[\'x\', \'y\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "dropout"
+    argspec: "args=[\'input\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "dropout_grad"
+    argspec: "args=[\'gradients\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "dynamic_partition"
     argspec: "args=[\'data\', \'partitions\', \'num_partitions\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -1181,6 +1181,14 @@ tf_module {
     argspec: "args=[\'images\', \'boxes\', \'colors\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "Dropout"
+    argspec: "args=[\'input\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "DropoutGrad"
+    argspec: "args=[\'gradients\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "DummyIterationCounter"
     argspec: "args=[\'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -597,6 +597,14 @@ tf_module {
     argspec: "args=[\'x\', \'y\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "dropout"
+    argspec: "args=[\'input\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "dropout_grad"
+    argspec: "args=[\'gradients\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "dynamic_partition"
     argspec: "args=[\'data\', \'partitions\', \'num_partitions\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -1181,6 +1181,14 @@ tf_module {
     argspec: "args=[\'images\', \'boxes\', \'colors\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "Dropout"
+    argspec: "args=[\'input\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "DropoutGrad"
+    argspec: "args=[\'gradients\', \'rate\', \'noise_shape\', \'seed\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "DummyIterationCounter"
     argspec: "args=[\'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
This PR is to port the ROCm Dropout support from the `develop-upstream` to the `master-rocm-enhanced` branch.

We need to have a few pre-reqs in place before we can take this PR
- [ ] identidy a commit on the `upstream/master` branch for which all ROCm CI jobs (`rocm`, `rocm-cpp`, `rocm-xla`)  are passing, aka the ROCm CI qualified commit
- [ ] rebase the `master-rocm-enhanced` branch to the ROCm CI qualified commit
- [ ] Setup ROCm CI jobs to run on PRs filed on the `master-rocm-enhanced` branch

The purpose of filing this PR now is to assist with filtering out the changes in this PR, from the set of diffs in `develop-upstream` that we need to triage before we abandon that branch 

/cc @deven-amd 