### PR TITLE
[DO NOT MERGE] Porting ROCm githooks to the master-rocm-enhanced branch

### DIFF
--- a/tensorflow/tools/ci_build/hooks/post_push
+++ b/tensorflow/tools/ci_build/hooks/post_push
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "current image name: "$IMAGE_NAME
+
+GIT_COMMIT_HASH=`git rev-parse --short HEAD`
+NEW_IMAGE_NAME=$DOCKER_REPO":dev-"$GIT_COMMIT_HASH
+echo "new image name: "$NEW_IMAGE_NAME
+
+docker tag $IMAGE_NAME $NEW_IMAGE_NAME
+docker push $NEW_IMAGE_NAME

--- a/tensorflow/tools/ci_build/hooks/pre_build
+++ b/tensorflow/tools/ci_build/hooks/pre_build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if git diff --name-only HEAD^ HEAD | grep -q "ci_build"
+then
+  echo "Start a new build"
+else
+  echo "No dependency changes, abort build"
+  exit 1
+fi


### PR DESCRIPTION
This PR is to port the ROCm githooks from the `develop-upstream` to the `master-rocm-enhanced` branch.

We need to have a few pre-reqs in place before we can take this PR
- [ ] identify a commit on the `upstream/master` branch for which all ROCm CI jobs (`rocm`, `rocm-cpp`, `rocm-xla`)  are passing, aka the ROCm CI qualified commit
- [ ] rebase the `master-rocm-enhanced` branch to the ROCm CI qualified commit
- [ ] Setup ROCm CI jobs to run on PRs filed on the `master-rocm-enhanced` branch

The purpose of filing this PR now is to assist with filtering out the changes in this PR, from the set of diffs in `develop-upstream` that we need to triage before we abandon that branch 