### PR TITLE
Disable dropout backend

### DIFF
--- a/tensorflow/python/ops/nn_grad.py
+++ b/tensorflow/python/ops/nn_grad.py
@@ -1068,27 +1068,6 @@ def _L2LossGrad(op, grad):
   """
   return op.inputs[0] * grad
 
-def ConditionalRegister(dec, condition):
-  def decorator(func):
-    if condition:
-      return dec(func)
-    else:
-      return func
-  return decorator
-
-@ConditionalRegister(ops.RegisterGradient("Dropout"),build_info.is_rocm_build)
-def _DropoutGrad(op, grad):
-  dx = 0
-  if op.inputs[0].dtype == dtypes.float32 or op.inputs[0].dtype == dtypes.float16:
-    dx = gen_nn_ops.dropout_grad(
-          grad, op.inputs[1], op.inputs[2], op.inputs[3])
-  else:
-    keep_mask = (op.inputs[0] - op.outputs[0]) < 1e-5
-    keep_mask_val = math_ops.cast(keep_mask, op.inputs[0].dtype)
-    scale = math_ops.cast(array_ops.size(op.outputs[0]), op.inputs[0].dtype) / math_ops.reduce_sum(keep_mask_val)
-    dx = grad * scale * keep_mask_val
-  return [dx, None, None, None]
-
 @ops.RegisterGradient("TopK")
 @ops.RegisterGradient("TopKV2")
 def _TopKGrad(op, grad, _):

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4434,14 +4434,6 @@ def dropout_v2(x, rate, noise_shape=None, seed=None, name=None):
 
     noise_shape = _get_noise_shape(x, noise_shape)
 
-    # Should there be ROCm support, use it. Otherwise fallback to generic
-    # implementation
-    if build_info.is_rocm_build and \
-       (x.dtype == dtypes.float32 or x.dtype == dtypes.float16):
-      if seed is None:
-        seed = 0
-      return gen_nn_ops.dropout(x,rate,noise_shape=noise_shape,seed=seed)
-
     # Sample a uniform distribution on [0.0, 1.0) and select values larger
     # than rate.
     #

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -358,36 +358,6 @@ class DropoutTest(test_lib.TestCase):
       print(rel_error)
       self.assertTrue(rel_error < 0.15)
 
-  @test_util.run_deprecated_v1
-  def testDropoutGradFloat16(self):
-    if not test_lib.is_built_with_rocm():
-      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
-
-    x_dim = 40
-    y_dim = 30
-    shape = [x_dim, y_dim]
-    rate = 0.1
-    with self.cached_session(use_gpu=True):
-      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float16)
-      value = nn_ops.dropout(t, rate=rate)
-      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
-      self.assertLess(err, 0.5)
-
-  @test_util.run_deprecated_v1
-  def testDropoutGradFloat32(self):
-    if not test_lib.is_built_with_rocm():
-      self.skipTest("Dropout gradient kernels are enabled only in ROCm platform")
-
-    x_dim = 40
-    y_dim = 30
-    shape = [x_dim, y_dim]
-    rate = 0.1
-    with self.cached_session(use_gpu=True):
-      t = constant_op.constant(1.0, shape=shape, dtype=dtypes.float32)
-      value = nn_ops.dropout(t, rate=rate)
-      err = gradient_checker.compute_gradient_error(t, shape, value, shape)
-      self.assertLess(err, 1e-2)
-
   def testShapedDropout(self):
     # Runs dropout with 0-1 tensor 10 times, sum the number of ones and validate
     # that it is producing approximately the right number of ones over a large


### PR DESCRIPTION
This disables the dropout backend in case `develop-upstream` is used for profiling in the migration period.