### PR TITLE
[DO NOT MERGE] Porting ROCm scripts to master-rocm-enhanced branch

### DIFF
--- a/build_rocm
+++ b/build_rocm
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# prerequisites: install python
+# sudo apt-get install python-numpy python-dev python-pip python-wheel
+#
+# configure with python
+# PYTHON_BIN_PATH=/usr/bin/python ./configure
+#
+# press enter all the way
+#
+
+# Explicitly delete the old whl packages in the /tmp/tensorflow_pkg dir
+# Doing so comes in handy when the TF version number changes, because
+# it will cause the last line in this script (pip3 install ...) to fail.
+# Not deleting the old whl packages results in the last line installing
+# TF from the previous whl pakcage (if present) and not the current one
+# that was just built by this script. Since this error is not apparent, it
+# can lead to a lot of frustation and lost time trying to figure why the
+# changes made in the current build are not working!
+TF_PKG_LOC=/tmp/tensorflow_pkg
+rm -f $TF_PKG_LOC/tensorflow*.whl
+
+yes "" | ROCM_PATH=/opt/rocm-3.3.0 TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
+bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
+pip install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# prerequisites: install python3
+# sudo apt-get install python3-numpy python3-dev python3-pip python3-wheel
+#
+# configure with python3
+# PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+#
+# press enter all the way
+#
+
+# Explicitly delete the old whl packages in the /tmp/tensorflow_pkg dir
+# Doing so comes in handy when the TF version number changes, because
+# it will cause the last line in this script (pip3 install ...) to fail.
+# Not deleting the old whl packages results in the last line installing
+# TF from the previous whl pakcage (if present) and not the current one
+# that was just built by this script. Since this error is not apparent, it
+# can lead to a lot of frustation and lost time trying to figure why the
+# changes made in the current build are not working!
+TF_PKG_LOC=/tmp/tensorflow_pkg
+rm -f $TF_PKG_LOC/tensorflow*.whl
+
+yes "" | ROCM_PATH=/opt/rocm-3.3.0 TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
+pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/build_rocm_verbs
+++ b/build_rocm_verbs
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# prerequisites: install python
+# sudo apt-get install python-numpy python-dev python-pip python-wheel
+#
+# configure with python
+# PYTHON_BIN_PATH=/usr/bin/python ./configure
+#
+# press enter all the way
+#
+yes "" | ROCM_PATH=/opt/rocm-3.3.0 TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
+bazel build --config=opt --config=rocm --config=verbs --config=gdr //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
+pip install --upgrade /tmp/tensorflow_pkg/tensorflow-1.12.0rc0-cp27-cp27m-linux_x86_64.whl

--- a/build_rocm_xla_python3
+++ b/build_rocm_xla_python3
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# prerequisites: install python3
+# sudo apt-get install python3-numpy python3-dev python3-pip python3-wheel
+#
+# configure with python3
+# PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+#
+# press enter all the way
+#
+
+# Explicitly delete the old whl packages in the /tmp/tensorflow_pkg dir
+# Doing so comes in handy when the TF version number changes, because
+# it will cause the last line in this script (pip3 install ...) to fail.
+# Not deleting the old whl packages results in the last line installing
+# TF from the previous whl pakcage (if present) and not the current one
+# that was just built by this script. Since this error is not apparent, it
+# can lead to a lot of frustation and lost time trying to figure why the
+# changes made in the current build are not working!
+TF_PKG_LOC=/tmp/tensorflow_pkg
+rm -f $TF_PKG_LOC/tensorflow*.whl
+
+yes "" | ROCM_PATH=/opt/rocm-3.3.0 TF_NEED_ROCM=1 TF_ENABLE_XLA=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
+pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/configure.py
+++ b/configure.py
@@ -527,7 +527,7 @@ def set_cc_opt_flags(environ_cp):
   elif is_windows():
     default_cc_opt_flags = '/arch:AVX'
   else:
-    default_cc_opt_flags = '-march=native -Wno-sign-compare'
+    default_cc_opt_flags = '-march=haswell -Wno-sign-compare'
   question = ('Please specify optimization flags to use during compilation when'
               ' bazel option "--config=opt" is specified [Default is %s]: '
              ) % default_cc_opt_flags

--- a/tools/tf_env_collect.sh
+++ b/tools/tf_env_collect.sh
@@ -127,7 +127,7 @@ ${python_bin_path} /tmp/check_tf.py 2>&1  >> ${OUTPUT_FILE}
 LD_DEBUG=libs ${python_bin_path} -c "import tensorflow"  2>>${OUTPUT_FILE} > /tmp/loadedlibs
 
 {
-  grep libcudnn.so /tmp/loadedlibs
+  grep libMIOpen.so /tmp/loadedlibs
   echo
   echo '== env =========================================================='
   if [ -z ${LD_LIBRARY_PATH+x} ]; then
@@ -143,15 +143,14 @@ LD_DEBUG=libs ${python_bin_path} -c "import tensorflow"  2>>${OUTPUT_FILE} > /tm
   
   
   echo
-  echo '== nvidia-smi ==================================================='
-  nvidia-smi 2>&1
+  echo '== rocm-smi ==================================================='
+  "/opt/rocm/bin/rocm-smi" 2>&1
   
   echo
-  echo '== cuda libs  ==================================================='
+  echo '== rocm info ==================================================='
 } >> ${OUTPUT_FILE}
 
-find /usr/local -type f -name 'libcudart*'  2>/dev/null | grep cuda |  grep -v "\\.cache" >> ${OUTPUT_FILE}
-find /usr/local -type f -name 'libudnn*'  2>/dev/null | grep cuda |  grep -v "\\.cache" >> ${OUTPUT_FILE}
+"/opt/rocm/bin/rocminfo" >> ${OUTPUT_FILE}
 
 {
   echo


### PR DESCRIPTION
This PR is to port the ROCm scripts from the `develop-upstream` to the `master-rocm-enhanced` branch.

We need to have a few pre-reqs in place before we can take this PR
- [ ] identify a commit on the `upstream/master` branch for which all ROCm CI jobs (`rocm`, `rocm-cpp`, `rocm-xla`)  are passing, aka the ROCm CI qualified commit
- [ ] rebase the `master-rocm-enhanced` branch to the ROCm CI qualified commit
- [ ] Setup ROCm CI jobs to run on PRs filed on the `master-rocm-enhanced` branch

The purpose of filing this PR now is to assist with filtering out the changes in this PR, from the set of diffs in `develop-upstream` that we need to triage before we abandon that branch 