### PR TITLE
[DO NOT MERGE] Porting ROCm batch_gemm support to master-rocm-enhanced

### DIFF
--- a/tensorflow/core/api_def/python_api/api_def_BatchGemm.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_BatchGemm.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "BatchGemm"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3983,6 +3983,7 @@ cc_library(
         ":aggregate_ops",
         ":argmax_op",
         ":batch_matmul_op",
+        ":batch_gemm_op",
         ":betainc_op",
         ":bincount_op",
         ":bucketize_op",
@@ -4094,6 +4095,14 @@ tf_mkl_kernel_library(
         "mkl_matmul_ops_common.h",
     ],
     deps = MATH_DEPS + mkl_deps(),
+)
+
+tf_kernel_library(
+    name = "batch_gemm_op",
+    prefix = "batch_gemm_op",
+    deps = MATH_DEPS + [
+        ":batch_matmul_op"
+    ],
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/batch_gemm_op.cc
+++ b/tensorflow/core/kernels/batch_gemm_op.cc
@@ -1,0 +1,125 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/batch_matmul_op_impl.h"
+
+namespace tensorflow {
+
+template <typename Device, typename Scalar>
+class BatchGemmOp : public OpKernel {
+ public:
+  explicit BatchGemmOp(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("adj_x", &transpose_a_));
+    OP_REQUIRES_OK(context, context->GetAttr("adj_y", &transpose_b_));
+    OP_REQUIRES_OK(context, context->GetAttr("alpha", &alpha_));
+    OP_REQUIRES_OK(context, context->GetAttr("beta", &beta_));
+  }
+
+  ~BatchGemmOp() override {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor& in0 = ctx->input(0);
+    const Tensor& in1 = ctx->input(1);
+    const Tensor& in2 = ctx->input(2);
+
+    ValidateInputTensors(ctx, in0, in1);
+
+    MatMulBCast bcast(in0.shape().dim_sizes(), in1.shape().dim_sizes());
+    OP_REQUIRES(
+        ctx, bcast.IsValid(),
+        errors::InvalidArgument(
+            "In[0] and In[1] must have compatible batch dimensions: ",
+            in0.shape().DebugString(), " vs. ", in1.shape().DebugString()));
+
+    TensorShape out_shape = bcast.output_batch_shape();
+    auto batch_size = bcast.output_batch_size();
+    auto d0 = in0.dim_size(in0.dims() - 2);
+    auto d1 = in0.dim_size(in0.dims() - 1);
+    Tensor in0_reshaped;
+    OP_REQUIRES(
+        ctx,
+        in0_reshaped.CopyFrom(in0, TensorShape({bcast.x_batch_size(), d0, d1})),
+        errors::Internal("Failed to reshape In[0] from ",
+                         in0.shape().DebugString()));
+    auto d2 = in1.dim_size(in1.dims() - 2);
+    auto d3 = in1.dim_size(in1.dims() - 1);
+    Tensor in1_reshaped;
+    OP_REQUIRES(
+        ctx,
+        in1_reshaped.CopyFrom(in1, TensorShape({bcast.y_batch_size(), d2, d3})),
+        errors::Internal("Failed to reshape In[1] from ",
+                         in1.shape().DebugString()));
+    if (transpose_a_) std::swap(d0, d1);
+    if (transpose_b_) std::swap(d2, d3);
+    OP_REQUIRES(ctx, d1 == d2,
+                errors::InvalidArgument(
+                    "In[0] mismatch In[1] shape: ", d1, " vs. ", d2, ": ",
+                    in0.shape().DebugString(), " ", in1.shape().DebugString(),
+                    " ", transpose_a_, " ", transpose_b_));
+    out_shape.AddDim(d0);
+    out_shape.AddDim(d3);
+
+    Tensor out_reshaped;
+    OP_REQUIRES(ctx, out_reshaped.CopyFrom(in2, out_shape),
+                errors::Internal("Failed to reshape output from ",
+                                 in2.shape().DebugString(), " to ",
+                                 out_shape.DebugString()));
+    ctx->set_output(0, out_reshaped);
+
+    if (out_reshaped.NumElements() == 0) {
+      return;
+    }
+    if (in0.NumElements() == 0 || in1.NumElements() == 0) {
+      functor::SetZeroFunctor<Device, Scalar> f;
+      f(ctx->eigen_device<Device>(), out_reshaped.flat<Scalar>());
+      return;
+    }
+
+    LaunchBatchMatMul<Device, Scalar>::Launch(ctx, in0_reshaped, in1_reshaped,
+                                              transpose_a_, transpose_b_, bcast,
+                                              &out_reshaped, alpha_, beta_);
+  }
+
+ private:
+  void ValidateInputTensors(OpKernelContext* ctx, const Tensor& in0,
+                            const Tensor& in1) {
+    // Enable broadcasting support. Validity of broadcasting is checked in
+    // BaseBatchMatMulOp.
+    OP_REQUIRES(
+        ctx, in0.dims() >= 2,
+        errors::InvalidArgument("In[0] ndims must be >= 2: ", in0.dims()));
+    OP_REQUIRES(
+        ctx, in1.dims() >= 2,
+        errors::InvalidArgument("In[1] ndims must be >= 2: ", in1.dims()));
+  }
+
+  bool transpose_a_;
+  bool transpose_b_;
+  float alpha_;
+  float beta_;
+};
+
+#define REGISTER_BATCH_GEMM_GPU(TYPE)                                 \
+  REGISTER_KERNEL_BUILDER(                                            \
+      Name("BatchGemm").Device(DEVICE_GPU).TypeConstraint<TYPE>("T"), \
+      BatchGemmOp<GPUDevice, TYPE>);
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+TF_CALL_float(REGISTER_BATCH_GEMM_GPU);
+TF_CALL_double(REGISTER_BATCH_GEMM_GPU);
+TF_CALL_half(REGISTER_BATCH_GEMM_GPU);
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/math_grad.cc
+++ b/tensorflow/core/ops/math_grad.cc
@@ -915,6 +915,12 @@ REGISTER_OP_GRADIENT("BatchMatMulV2", BatchMatMulV2Grad);
 
 // REGISTER_OP_GRADIENT("SparseMatMul", SparseMatMulGrad);
 
+Status BatchGemmGrad(const AttrSlice& attrs, FunctionDef* g) {
+  return MatMulGradCommon("BatchGemm", "adj_x", "adj_y", attrs, g,
+                          true /* enable_broadcasting */);
+}
+REGISTER_OP_GRADIENT("BatchGemm", BatchGemmGrad);
+
 // Comparison ops.
 REGISTER_OP_NO_GRADIENT("Less");
 REGISTER_OP_NO_GRADIENT("LessEqual");

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -137,6 +137,19 @@ REGISTER_OP("BatchMatMulV2")
     .Attr("adj_y: bool = false")
     .SetShapeFn(shape_inference::BatchMatMulV2Shape);
 
+// Note: Reusing the BatchMatMulV2Shape inference function
+REGISTER_OP("BatchGemm")
+    .Input("a: T")
+    .Input("b: T")
+    .Input("c: T")
+    .Output("output: T")
+    .Attr("T: {half, float, double}")
+    .Attr("adj_x: bool = false")
+    .Attr("adj_y: bool = false")
+    .Attr("alpha: float = 1.0")
+    .Attr("beta: float = 0.0")
+    .SetShapeFn(shape_inference::BatchMatMulV2Shape);
+
 #ifdef INTEL_MKL
 REGISTER_OP("_MklBatchMatMul")
     .Input("x: T")

--- a/tensorflow/core/ops/ops.pbtxt
+++ b/tensorflow/core/ops/ops.pbtxt
@@ -3555,6 +3555,64 @@ op {
   }
 }
 op {
+  name: "BatchGemm"
+  input_arg {
+    name: "x"
+    type_attr: "T"
+  }
+  input_arg {
+    name: "y"
+    type_attr: "T"
+  }
+  input_arg {
+    name: "z"
+    type_attr: "T"
+  }
+  output_arg {
+    name: "output"
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_HALF
+        type: DT_FLOAT
+        type: DT_DOUBLE
+      }
+    }
+  }
+  attr {
+    name: "transpose_a"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
+  attr {
+    name: "transpose_b"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
+  attr {
+    name: "alpha"
+    type: "float"
+    default_value {
+      f: 1
+    }
+  }
+  attr {
+    name: "beta"
+    type: "float"
+    default_value {
+      f: 0
+    }
+  }
+}
+op {
   name: "BatchIFFT"
   input_arg {
     name: "input"

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -1636,6 +1636,21 @@ cuda_py_test(
 )
 
 cuda_py_test(
+    name = "batch_gemm_op_test",
+    size = "small",
+    srcs = ["batch_gemm_op_test.py"],
+    additional_deps = [
+        "//third_party/py/numpy",
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:framework_for_generated_wrappers",
+        "//tensorflow/python:math_ops",
+    ],
+    shard_count = 20,
+    xla_enable_strict_auto_jit = True,
+)
+
+cuda_py_test(
     name = "batchtospace_op_test",
     size = "small",
     srcs = ["batchtospace_op_test.py"],

--- a/tensorflow/python/kernel_tests/batch_gemm_op_test.py
+++ b/tensorflow/python/kernel_tests/batch_gemm_op_test.py
@@ -1,0 +1,193 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tensorflow.ops.tf.BatchGemm."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import random
+
+from tensorflow.python import tf2
+from tensorflow.python.client import session
+from tensorflow.python.compat import compat
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gradient_checker_v2
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import benchmark
+from tensorflow.python.platform import test
+
+def GetRandomNormalInput(shape, dtype):
+  # float16 has limited range so we reduce the variance of the scalars.
+  scale = 10.0 if dtype != np.float16 else 0.1
+  loc = -10.0 if dtype != np.float16 else 0.1
+  vals = np.array(np.random.normal(loc, scale, np.prod(shape)), dtype=dtype)
+  return vals.reshape(shape)
+
+
+class BatchGemmOpTest(test.TestCase):
+
+  # Uses numpy to compute batch_matmul(x, y, transpose_a, transpose_b).
+  def _npBatchGemm(self, x, y, transpose_a, transpose_b):
+    # output's shape depends on adj[0] and adj[1]
+    if transpose_a:
+      x = np.conjugate(np.swapaxes(x, -1, -2))
+    if transpose_b:
+      y = np.conjugate(np.swapaxes(y, -1, -2))
+    return np.matmul(x, y)
+
+  # Compares TensorFlow BatchGemm with NumPy's matmul.
+  def _compare(self, x_in, y_in, transpose_a, transpose_b, alpha, beta, static_shape):
+    x_t_shape = x_in.shape[:-2] + (x_in.shape[-1], x_in.shape[-2])
+    y_t_shape = y_in.shape[:-2] + (y_in.shape[-1], y_in.shape[-2])
+    x = x_in if not transpose_a else x_in.reshape(x_t_shape)
+    y = y_in if not transpose_b else y_in.reshape(y_t_shape)
+
+    tol = 0
+    if x.dtype == np.float32 or x.dtype == np.float16:
+      tol = 100 * np.finfo(x.dtype).eps
+    elif x.dtype == np.float64:
+      # float64 eps is around 10 ** (-14) which is way too small for accumulated differences
+      # Bumping it up to 10 ** (-7)
+      tol = 10 ** (-7)
+    with self.cached_session(use_gpu=True) as sess:
+      # Note: Testing with three dimensions only now
+      z_in = np.ones((x_in.shape[0], x_in.shape[1], y_in.shape[2])).astype(x.dtype)
+      if static_shape:
+        z0 = math_ops.batch_gemm(
+            x, y, z_in, transpose_a=transpose_a, transpose_b=transpose_b, alpha=alpha, beta=beta)
+        z0_val = self.evaluate(z0)
+      else:
+        x_ph = array_ops.placeholder(x.dtype)
+        y_ph = array_ops.placeholder(y.dtype)
+        z0 = math_ops.batch_gemm(
+            x, y, z_in, transpose_a=transpose_a, transpose_b=transpose_b, alpha=alpha, beta=beta)
+        z0_val = sess.run(z0, feed_dict={x_ph: x, y_ph: y})
+      z1 = alpha * self._npBatchGemm(x, y, transpose_a, transpose_b) + beta * z_in
+      self.assertAllClose(z0_val, z1, rtol=tol, atol=tol)
+
+  def _testNonEmpty(self, dtype, transpose_a, transpose_b, use_static_shape):
+
+    def CompareNonEmpty(self, a_shape, b_shape):
+      self._compare(
+          GetRandomNormalInput(a_shape, dtype),
+          GetRandomNormalInput(b_shape, dtype),
+          transpose_a,
+          transpose_b,
+          random.random(),
+          random.random(),
+          static_shape=use_static_shape)
+
+    CompareNonEmpty(self, [1, 2, 3], [1, 3, 5])
+    CompareNonEmpty(self, [1, 2, 3], [1, 3, 1])
+    CompareNonEmpty(self, [1, 1, 3], [1, 3, 5])
+    CompareNonEmpty(self, [1, 2, 3], [1, 3, 5])
+    CompareNonEmpty(self, [7, 1, 3], [7, 3, 5])
+    CompareNonEmpty(self, [7, 2, 3], [7, 3, 1])
+    CompareNonEmpty(self, [7, 2, 3], [7, 3, 5])
+    CompareNonEmpty(self, [10, 64, 75], [10, 75, 30])
+
+  def _testEmpty(self, dtype, transpose_a, transpose_b, use_static_shape):
+
+    def CompareEmpty(self, a_shape, b_shape):
+      self._compare(
+          np.zeros(a_shape).astype(dtype),
+          np.zeros(b_shape).astype(dtype),
+          transpose_a,
+          transpose_b,
+          random.random(),
+          random.random(),
+          static_shape=use_static_shape)
+
+    CompareEmpty(self, [0, 3, 2], [0, 2, 4])
+    CompareEmpty(self, [3, 0, 2], [3, 2, 5])
+    CompareEmpty(self, [3, 3, 2], [3, 2, 0])
+
+
+def _GetBatchGemmOpTest(dtype, transpose_a, transpose_b, use_static_shape):
+
+  def Test(self):
+    np.random.seed(42)
+    self._testNonEmpty(dtype, transpose_a, transpose_b, use_static_shape)
+    self._testEmpty(dtype, transpose_a, transpose_b, use_static_shape)
+
+  return Test
+
+class BatchGemmGradientTest(test.TestCase):
+
+  # loss = sum(batch_matmul(x, y)). Verify dl/dx and dl/dy via the
+  # gradient checker.
+  def _checkGrad(self, x_in, y_in, transpose_a, transpose_b, alpha, beta):
+    x_t_shape = x_in.shape[:-2] + (x_in.shape[-1], x_in.shape[-2])
+    y_t_shape = y_in.shape[:-2] + (y_in.shape[-1], y_in.shape[-2])
+    x = x_in if not transpose_a else x_in.reshape(x_t_shape)
+    y = y_in if not transpose_b else y_in.reshape(y_t_shape)
+    epsilon = np.finfo(x.dtype).eps
+    # Since our gradient is linear, a larger delta decreases the error.
+    delta = 10 * epsilon**(1.0 / 3.0)
+
+    z = np.ones((x_in.shape[0], x_in.shape[1], y_in.shape[2])).astype(x.dtype)
+
+    # Note: z is counted as a constant for batch_gemm operator therefore should
+    # not be fed into the loss function as an independent variable
+    def Loss(x, y):
+      return math_ops.reduce_sum(math_ops.batch_gemm(x, y, z, transpose_a, transpose_b, alpha, beta))
+
+    with self.cached_session(use_gpu=True):
+      ((x_jacob_t, y_jacob_t),
+       (x_jacob_n, y_jacob_n)) = gradient_checker_v2.compute_gradient(
+           Loss, [x, y], delta=delta)
+      tol = 10 * delta
+      self.assertAllClose(x_jacob_t, x_jacob_n, rtol=tol, atol=tol)
+      self.assertAllClose(y_jacob_t, y_jacob_n, rtol=tol, atol=tol)
+
+  def _compare(self, a_shape, b_shape, dtype, transpose_a, transpose_b):
+    np.random.seed(42)
+    x = GetRandomNormalInput(a_shape, dtype)
+    y = GetRandomNormalInput(b_shape, dtype)
+    self._checkGrad(x, y, transpose_a, transpose_b, random.random(), 0.0)
+
+
+def _GetBatchGemmGradientTest(dtype, transpose_a, transpose_b):
+
+  def Test(self):
+    def CheckGradients(self, a_shape, b_shape):
+      self._compare(a_shape, b_shape, dtype, transpose_a, transpose_b)
+
+    CheckGradients(self, [1, 2, 3], [1, 3, 5])
+    CheckGradients(self, [3, 4, 7], [3, 7, 10])
+
+  return Test
+
+if __name__ == "__main__":
+  dtypes_to_test = [np.float16, np.float32, np.float64]
+  for dtype_ in dtypes_to_test:
+    for transpose_a_ in False, True:
+      for transpose_b_ in False, True:
+        name = "%s_%s_%s" % (dtype_.__name__, transpose_a_, transpose_b_)
+        # TF2 does not support placeholders under eager so we skip it.
+        for use_static_shape_ in set([True, tf2.enabled()]):
+          setattr(
+              BatchGemmOpTest,
+              "testBatchGemmOp_" + name + "_{}".format(use_static_shape_),
+              _GetBatchGemmOpTest(dtype_, transpose_a_, transpose_b_,
+                                    use_static_shape_))
+        setattr(BatchGemmGradientTest, "testBatchGemmGradient_" + name,
+                _GetBatchGemmGradientTest(dtype_, transpose_a_, transpose_b_))
+
+  test.main()

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1723,6 +1723,12 @@ def _BatchMatMulV2(op, grad):
 
   return grad_x, grad_y
 
+@ops.RegisterGradient("BatchGemm")
+def _BatchGemm(op, grad):
+  """Returns the gradient of x and y given the gradient of alpha * x * y."""
+  alpha = op.get_attr("alpha")
+  return [math_ops.multiply(grad, alpha) for grad in _BatchMatMulV2(op, grad)] + [None]
+
 
 ops.NotDifferentiable("Range")
 ops.NotDifferentiable("LinSpace")

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3115,6 +3115,31 @@ def matmul(a,
           a, b, transpose_a=transpose_a, transpose_b=transpose_b, name=name)
 
 
+@tf_export("linalg.batch_gemm", "batch_gemm")
+@dispatch.add_dispatch_support
+def batch_gemm(a,
+           b,
+           c,
+           transpose_a=False,
+           transpose_b=False,
+           alpha=1.0,
+           beta=0.0,
+           name=None):
+  with ops.name_scope(name, "BatchGemm", [a, b]) as name:
+    if context.executing_eagerly():
+      if not isinstance(a, (ops.EagerTensor, _resource_variable_type)):
+        a = ops.convert_to_tensor(a, name="a")
+      if not isinstance(b, (ops.EagerTensor, _resource_variable_type)):
+        b = ops.convert_to_tensor(b, name="b")
+      if not isinstance(c, (ops.EagerTensor, _resource_variable_type)):
+        c = ops.convert_to_tensor(c, name="c")
+    else:
+      a = ops.convert_to_tensor(a, name="a")
+      b = ops.convert_to_tensor(b, name="b")
+      c = ops.convert_to_tensor(c, name="c")
+
+    return gen_math_ops.batch_gemm(a, b, c, adj_x=transpose_a, adj_y=transpose_b, alpha=alpha, beta=beta, name=name)
+
 @tf_export("linalg.matvec")
 def matvec(a,
            b,

--- a/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.linalg.pbtxt
@@ -97,6 +97,10 @@ tf_module {
     argspec: "args=[\'input\', \'num_lower\', \'num_upper\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "batch_gemm"
+    argspec: "args=[\'a\', \'b\', \'c\', \'transpose_a\', \'transpose_b\', \'alpha\', \'beta\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'1.0\', \'0.0\', \'None\'], "
+  }
+  member_method {
     name: "cholesky"
     argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -909,6 +909,10 @@ tf_module {
     argspec: "args=[\'params\', \'indices\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "batch_gemm"
+    argspec: "args=[\'a\', \'b\', \'c\', \'transpose_a\', \'transpose_b\', \'alpha\', \'beta\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'1.0\', \'0.0\', \'None\'], "
+  }
+  member_method {
     name: "batch_scatter_update"
     argspec: "args=[\'ref\', \'indices\', \'updates\', \'use_locking\', \'name\'], varargs=None, keywords=None, defaults=[\'True\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -345,6 +345,10 @@ tf_module {
     argspec: "args=[\'in_tensors\', \'captured_tensors\', \'f\', \'num_batch_threads\', \'max_batch_size\', \'batch_timeout_micros\', \'Tout\', \'max_enqueued_batches\', \'allowed_batch_sizes\', \'container\', \'shared_name\', \'batching_queue\', \'name\'], varargs=None, keywords=None, defaults=[\'10\', \'[]\', \'\', \'\', \'\', \'None\'], "
   }
   member_method {
+    name: "BatchGemm"
+    argspec: "args=[\'a\', \'b\', \'c\', \'adj_x\', \'adj_y\', \'alpha\', \'beta\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'1\', \'0\', \'None\'], "
+  }
+  member_method {
     name: "BatchIFFT"
     argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.linalg.pbtxt
@@ -97,6 +97,10 @@ tf_module {
     argspec: "args=[\'input\', \'num_lower\', \'num_upper\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "batch_gemm"
+    argspec: "args=[\'a\', \'b\', \'c\', \'transpose_a\', \'transpose_b\', \'alpha\', \'beta\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'1.0\', \'0.0\', \'None\'], "
+  }
+  member_method {
     name: "cholesky"
     argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -505,6 +505,10 @@ tf_module {
     argspec: "args=[\'x\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "batch_gemm"
+    argspec: "args=[\'a\', \'b\', \'c\', \'transpose_a\', \'transpose_b\', \'alpha\', \'beta\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'1.0\', \'0.0\', \'None\'], "
+  }
+  member_method {
     name: "batch_to_space"
     argspec: "args=[\'input\', \'block_shape\', \'crops\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -345,6 +345,10 @@ tf_module {
     argspec: "args=[\'in_tensors\', \'captured_tensors\', \'f\', \'num_batch_threads\', \'max_batch_size\', \'batch_timeout_micros\', \'Tout\', \'max_enqueued_batches\', \'allowed_batch_sizes\', \'container\', \'shared_name\', \'batching_queue\', \'name\'], varargs=None, keywords=None, defaults=[\'10\', \'[]\', \'\', \'\', \'\', \'None\'], "
   }
   member_method {
+    name: "BatchGemm"
+    argspec: "args=[\'a\', \'b\', \'c\', \'adj_x\', \'adj_y\', \'alpha\', \'beta\', \'name\'], varargs=None, keywords=None, defaults=[\'False\', \'False\', \'1\', \'0\', \'None\'], "
+  }
+  member_method {
     name: "BatchIFFT"
     argspec: "args=[\'input\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }


### PR DESCRIPTION
This PR is to port the ROCm batch_gemm support from the `develop-upstream` to the `master-rocm-enhanced` branch.

We need to have a few pre-reqs in place before we can take this PR
- [ ] identidy a commit on the `upstream/master` branch for which all ROCm CI jobs (`rocm`, `rocm-cpp`, `rocm-xla`)  are passing, aka the ROCm CI qualified commit
- [ ] rebase the `master-rocm-enhanced` branch to the ROCm CI qualified commit
- [ ] Setup ROCm CI jobs to run on PRs filed on the `master-rocm-enhanced` branch

The purpose of filing this PR now is to assist with filtering out the changes in this PR, from the set of diffs in `develop-upstream` that we need to triage before we abandon that branch 

/cc @deven-amd 