### PR TITLE
[XLA] Removing ImplementedAsGemm() from ir_emission_utils

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -65,26 +65,6 @@ bool AreValidGemmShapes(const Shape& lhs_shape, const Shape& rhs_shape,
          !ShapeUtil::IsZeroElementArray(rhs_shape);
 }
 
-bool DotImplementedAsGemm(const HloInstruction& dot) {
-  CHECK_EQ(dot.opcode(), HloOpcode::kDot);
-  const Shape& lhs_shape = dot.operand(0)->shape();
-  const Shape& rhs_shape = dot.operand(1)->shape();
-  const DotDimensionNumbers& dim_numbers = dot.dot_dimension_numbers();
-
-  // If gemm can accept the operand shapes, use it rather than a custom
-  // kernel.
-  if (AreValidGemmShapes(lhs_shape, rhs_shape, dot.shape(),
-                         dim_numbers.lhs_batch_dimensions_size())) {
-    // The size of the reduction dimension should match. The shape inference
-    // guarantees this invariant, so the check here is for programming
-    // errors.
-    CHECK_EQ(lhs_shape.dimensions(dim_numbers.lhs_contracting_dimensions(0)),
-             rhs_shape.dimensions(dim_numbers.rhs_contracting_dimensions(0)));
-    return true;
-  }
-  return false;
-}
-
 // Given a shape and a group of contiguous dimensions in the shape, returns
 // a tuple of three values (major, middle, minor), where major is the size of
 // the dimensions more major then the given dimensions, minor is the size of
@@ -118,28 +98,6 @@ std::array<int64, 3> PartitionShapeByMiddleDimensions(
 
 }  // namespace
 
-bool ImplementedAsGemm(const HloInstruction& hlo) {
-  // For certain types of Dot, we can call pre-canned BLAS gemm.
-  if (hlo.opcode() == HloOpcode::kDot) {
-    return DotImplementedAsGemm(hlo);
-  }
-
-  if (hlo.IsOutputFusion() &&
-      (hlo.fused_expression_root()->opcode() == HloOpcode::kMultiply ||
-       hlo.fused_expression_root()->opcode() == HloOpcode::kAdd)) {
-    // Try to find the dot inside the output fusion node.
-    const HloInstruction* dot = hlo.fused_expression_root()->operand(0);
-    if (dot->opcode() != HloOpcode::kDot) {
-      dot = hlo.fused_expression_root()->operand(1);
-    }
-    if (dot->opcode() == HloOpcode::kDot) {
-      return DotImplementedAsGemm(*dot);
-    }
-  }
-
-  return false;
-}
-
 bool IsMatrixMultiplication(const HloInstruction& dot) {
   if (dot.opcode() != HloOpcode::kDot) {
     return false;
@@ -170,7 +128,7 @@ bool IsCublasGemm(const HloInstruction& hlo) {
 std::array<int64, 3> GetReductionTiling(
     const ReductionDimensions& reduction_dimensions) {
   if (reduction_dimensions.is_row_reduction) {
-    int64 tile_z = std::min(reduction_dimensions.dimensions[0], 8LL);
+    int64 tile_z = std::min(reduction_dimensions.dimensions[0], int64{8});
     if (reduction_dimensions.dimensions[1] == 1) {
       CHECK_EQ(reduction_dimensions.dimensions[0], 1);
       return {tile_z, 1, 16};
@@ -233,7 +191,7 @@ bool IsCustomCallToCusolver(const HloInstruction& hlo) {
 }
 
 bool ImplementedAsLibraryCall(const HloInstruction& hlo) {
-  return IsCublasGemm(hlo) || ImplementedAsGemm(hlo) || IsCustomCallToDnnBatchNorm(hlo) ||
+  return IsCublasGemm(hlo) || IsCustomCallToDnnBatchNorm(hlo) ||
          IsCustomCallToDnnConvolution(hlo);
 }
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.h
@@ -79,15 +79,6 @@ constexpr int64 kWarpSize = 32;
 // A call to cuBLAS general matrix multiplication API.
 extern const char* const kGemmCallTarget;
 
-// Returns true if `hlo` will be implemented as a call to BLAS gemm.
-//
-// Precondition: `hlo` is in an "unnested context", meaning, it lives within the
-// entry computation, within the either of a while loop's subcomputations,
-// within any of a conditional's subcomputations, etc., but *does not* live
-// within a reduce subcomputation, a map subcomputation, a fusion
-// subcomputation, etc.  It's OK if `hlo` *is* a fusion.
-bool ImplementedAsGemm(const HloInstruction& hlo);
-
 // A call to cuDNN for batch normalization is represented as CustomCall HLO with
 // a call target equal to one of these strings.
 //
@@ -200,7 +191,8 @@ struct ReductionDimensions {
 ReductionDimensions GetReductionKindAndContiguousComponents(
     const HloInstruction& reduce);
 
-// Get tiling per thread for the given reduction in dimensions [D, H, W].
+// Get tiling per thread for the given reduction in dimensions [D, H, W] per
+// thread.
 std::array<int64, 3> GetReductionTiling(
     const ReductionDimensions& reduction_dimensions);
 


### PR DESCRIPTION
ImplementedAsGemm has been removed from upstream in d4b6a19ee7c6b1b430ff50b52aa9d880808d54f2

/cc: @whchung @deven-amd 