### PR TITLE
Revert to using MIOpen Find Mode

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -668,6 +668,7 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
       RunConvOptions options;
       options.profile_result = &profile_result;
       options.algo_override = alg;
+      options.scratch_size_override = miopen_alg.scratch_size();
       Status launch_status =
           RunGpuConv(instr, absl::MakeSpan(operand_buffers), result_buffer,
                      &scratch_allocator, stream, options);

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -117,11 +117,11 @@ std::vector<AlgorithmDesc> GetAlgorithms(CudnnConvKind kind,
   return algorithms;
 }
 
-StatusOr<std::vector<se::dnn::ProfileResult>> GetAlgorithms(
+StatusOr<std::vector<se::dnn::ProfileResult>> GetMIOpenAlgorithms(
     const HloCustomCallInstruction* conv,
     absl::Span<se::DeviceMemoryBase> operand_buffers,
     se::DeviceMemoryBase result_buffer, se::StreamExecutor* stream_exec,
-    se::Stream* stream) {
+    ScratchAllocator* scratch_allocator, se::Stream* stream) {
   std::vector<se::dnn::ProfileResult> algorithms;
 
   TF_ASSIGN_OR_RETURN(se::dnn::ConvolutionKind kind,
@@ -133,8 +133,9 @@ StatusOr<std::vector<se::dnn::ProfileResult>> GetAlgorithms(
                       GetGpuConvParams(conv, operand_buffers, result_buffer));
 
   bool succ = stream_exec->GetMIOpenConvolveAlgorithms(
-      kind, stream, dtype, params.input_descriptor, params.filter_descriptor,
-      params.conv_desc, params.output_descriptor, &algorithms);
+      kind, dtype, stream, params.input_descriptor, params.input_buf,
+      params.filter_descriptor, params.filter_buf, params.output_descriptor,
+      params.output_buf, params.conv_desc, scratch_allocator, &algorithms);
   DCHECK(succ);
 
   return algorithms;
@@ -634,9 +635,12 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
           ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(0))));
   initialize_buffer(result_buffer);
 
-  TF_ASSIGN_OR_RETURN(std::vector<se::dnn::ProfileResult> algorithms,
-                      GetAlgorithms(instr, absl::MakeSpan(operand_buffers),
-                                    result_buffer, stream_exec_, stream));
+  ScratchAllocator scratch_allocator(device_ordinal, allocator);
+
+  TF_ASSIGN_OR_RETURN(
+      std::vector<se::dnn::ProfileResult> algorithms,
+      GetMIOpenAlgorithms(instr, absl::MakeSpan(operand_buffers), result_buffer,
+                          stream_exec_, &scratch_allocator, stream));
 
   std::vector<AutotuneResult> profile_results;
 
@@ -659,7 +663,6 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
                        AlgorithmToString(alg)),
           2);
 
-      ScratchAllocator scratch_allocator(device_ordinal, allocator);
       se::dnn::ProfileResult profile_result;
       VLOG(3) << "Trying algorithm " << AlgorithmToString(alg) << " for "
               << instr->ToString();

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
@@ -225,6 +225,9 @@ Status RunGpuConvImpl(const GpuConvParams& params,
 
   if (options.algo_override.has_value()) {
     algorithm = AlgorithmConfig(*options.algo_override);
+    if (options.scratch_size_override.has_value()) {
+      algorithm.set_scratch_size(*options.scratch_size_override);
+    }
   }
 
   Status run_status = RunGpuConvInternalImpl<ElementType, BiasType, OutputType>(

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
@@ -35,6 +35,9 @@ struct RunConvOptions {
 
   // Use this algorithm, instead of the one from the instruction.
   absl::optional<se::dnn::AlgorithmDesc> algo_override;
+
+  // Use this scratch_bytes size, instead of the one from the instruction.
+  absl::optional<size_t> scratch_size_override;
 };
 
 // Implementation struct exposed for debugging and log analysis.

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -1142,7 +1142,9 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                       input_desc, bfloat16_input_ptr, output_desc,
                       bfloat16_out_backprop_ptr, conv_desc, filter_desc,
                       &bfloat16_filter_backprop_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm), &profile_result)
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
                   .ok();
         } else {
           miopen_launch_status =
@@ -1150,7 +1152,9 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                   ->ThenConvolveBackwardFilterWithAlgorithm(
                       input_desc, input_ptr, output_desc, out_backprop_ptr,
                       conv_desc, filter_desc, &filter_backprop_ptr,
-                      &scratch_allocator, AlgorithmConfig(profile_algorithm),
+                      &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
                       &profile_result)
                   .ok();
         }

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -1092,27 +1092,35 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       }
     }
 #elif TENSORFLOW_USE_ROCM
+    DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
+                                          ctx);
+
     std::vector<ProfileResult> algorithms;
     if (TestMIOpenBFloat16Support<T>()) {
-      OP_REQUIRES(ctx,
-                  stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
-                      se::dnn::ToDataType<bfloat16>::value, input_desc,
-                      filter_desc, conv_desc, output_desc, &algorithms),
-                  errors::Unknown(
-                      "Failed to get convolution algorithm. This is probably "
-                      "because MIOpen failed to initialize, so try looking to "
-                      "see if a warning log message was printed above."));
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::BACKWARD_FILTER,
+              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
+              bfloat16_input_ptr, filter_desc, bfloat16_filter_backprop_ptr,
+              output_desc, bfloat16_out_backprop_ptr, conv_desc,
+              &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
     } else {
-      OP_REQUIRES(ctx,
-                  stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
-                      se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                      conv_desc, output_desc, &algorithms),
-                  errors::Unknown(
-                      "Failed to get convolution algorithm. This is probably "
-                      "because MIOpen failed to initialize, so try looking to "
-                      "see if a warning log message was printed above."));
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::BACKWARD_FILTER,
+              se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
+              filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
+              conv_desc, &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
     }
 
     std::vector<tensorflow::AutotuneResult> results;
@@ -1131,8 +1139,6 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
     } else {
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
-                                              ctx);
         ProfileResult profile_result;
         bool miopen_launch_status = true;
         if (TestMIOpenBFloat16Support<T>()) {

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -1309,7 +1309,9 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
                       filter_desc, bfloat16_filter_ptr, output_desc,
                       bfloat16_out_backprop_ptr, conv_desc, input_desc,
                       &bfloat16_in_backprop_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm), &profile_result)
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
                   .ok();
         } else {
           miopen_launch_status =
@@ -1317,7 +1319,9 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
                   ->ThenConvolveBackwardDataWithAlgorithm(
                       filter_desc, filter_ptr, output_desc, out_backprop_ptr,
                       conv_desc, input_desc, &in_backprop_ptr,
-                      &scratch_allocator, AlgorithmConfig(profile_algorithm),
+                      &scratch_allocator,
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
                       &profile_result)
                   .ok();
         }

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1446,7 +1446,9 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
                 ->ThenConvolveBackwardDataWithAlgorithm(
                     filter_desc, filter_ptr, output_desc, out_backprop_ptr,
                     conv_desc, input_desc, &in_backprop_ptr, &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm), &profile_result)
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
+                    &profile_result)
                 .ok();
         if (miopen_launch_status) {
           if (profile_result.is_valid()) {
@@ -1893,7 +1895,9 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
                     input_desc, input_ptr, output_desc, out_backprop_ptr,
                     conv_desc, filter_desc, &filter_backprop_ptr,
                     &scratch_allocator,
-                    AlgorithmConfig(profile_algorithm), &profile_result)
+                    AlgorithmConfig(profile_algorithm,
+                                    miopen_algorithm.scratch_size()),
+                    &profile_result)
                 .ok();
         if (cudnn_launch_status) {
           if (profile_result.is_valid()) {

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1386,8 +1386,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
           &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
+
       std::vector<tensorflow::AutotuneResult> results;
       for (auto profile_algorithm : algorithms) {
         // TODO(zhengxq): profile each algorithm multiple times to better
@@ -1424,15 +1423,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
             *result.mutable_run_time() = proto_utils::ToDurationProto(
                 absl::Milliseconds(profile_result.elapsed_time_in_ms()));
 
-            if (profile_result.elapsed_time_in_ms() <
-                best_result.elapsed_time_in_ms()) {
-              best_result = profile_result;
-            }
-            if (scratch_allocator.TotalByteSize() == 0 &&
-                profile_result.elapsed_time_in_ms() <
-                    best_result_no_scratch.elapsed_time_in_ms()) {
-              best_result_no_scratch = profile_result;
-            }
             // TODO(george): they don't do results at all??
             CheckRedzones(rz_scratch_allocator, &result);
             CheckRedzones(rz_allocator, &result);
@@ -1445,8 +1435,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
           se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
           se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
           output_desc, &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
       std::vector<tensorflow::AutotuneResult> results;
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
@@ -1470,16 +1458,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
             result.set_scratch_bytes(scratch_allocator.TotalByteSize());
             *result.mutable_run_time() = proto_utils::ToDurationProto(
                 absl::Milliseconds(profile_result.elapsed_time_in_ms()));
-
-            if (profile_result.elapsed_time_in_ms() <
-                best_result.elapsed_time_in_ms()) {
-              best_result = profile_result;
-            }
-            if (scratch_allocator.TotalByteSize() == 0 &&
-                profile_result.elapsed_time_in_ms() <
-                    best_result_no_scratch.elapsed_time_in_ms()) {
-              best_result_no_scratch = profile_result;
-            }
           }
         }
       }
@@ -1489,16 +1467,8 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
                              filter_ptr, out_backprop_ptr, input_desc,
                              filter_desc, output_desc, conv_desc,
                              stream->parent(), results);
-      OP_REQUIRES(context,
-                  best_result.is_valid() || best_result_no_scratch.is_valid(),
-                  errors::NotFound("No algorithm worked!"));
-      if (best_result.is_valid()) {
-        algorithm_config.set_algorithm(best_result.algorithm());
-      }
-      if (best_result_no_scratch.is_valid()) {
-        algorithm_config.set_algorithm_no_scratch(
-            best_result_no_scratch.algorithm());
-      }
+      OP_REQUIRES_OK(context,
+                     BestCudnnConvAlgorithm(results, &algorithm_config));
       AutoTuneConv3dBwdData::GetInstance()->Insert(conv_parameters,
                                                    algorithm_config);
     }
@@ -1875,8 +1845,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
           conv_parameters.ShouldIncludeWinogradNonfusedAlgo<T>(
               stream->parent()),
           &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
+
+      std::vector<tensorflow::AutotuneResult> results;
       for (auto profile_algorithm : algorithms) {
         // TODO(zhengxq): profile each algorithm multiple times to better
         // accuracy.
@@ -1893,15 +1863,14 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
                 .ok();
         if (cudnn_launch_status) {
           if (profile_result.is_valid()) {
-            if (profile_result.elapsed_time_in_ms() <
-                best_result.elapsed_time_in_ms()) {
-              best_result = profile_result;
-            }
-            if (scratch_allocator.TotalByteSize() == 0 &&
-                profile_result.elapsed_time_in_ms() <
-                    best_result_no_scratch.elapsed_time_in_ms()) {
-              best_result_no_scratch = profile_result;
-            }
+            results.emplace_back();
+            auto& result = results.back();
+            result.mutable_conv()->set_algorithm(profile_algorithm.algo_id());
+            result.mutable_conv()->set_tensor_ops_enabled(
+                profile_algorithm.tensor_ops_enabled());
+            result.set_scratch_bytes(scratch_allocator.TotalByteSize());
+            *result.mutable_run_time() = proto_utils::ToDurationProto(
+                absl::Milliseconds(profile_result.elapsed_time_in_ms()));
           }
         }
       }
@@ -1911,50 +1880,42 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
           se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
           se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
           output_desc, &algorithms));
-      ProfileResult best_result;
-      ProfileResult best_result_no_scratch;
-      if (algorithms.size() == 1) {
-        best_result = algorithms[0];
-      } else {
-        for (auto miopen_algorithm : algorithms) {
-          auto profile_algorithm = miopen_algorithm.algorithm();
-          DnnScratchAllocator scratch_allocator(
-              ConvolveBackwardFilterScratchSize, context);
-          ProfileResult profile_result;
-          bool cudnn_launch_status =
-              stream
-                  ->ThenConvolveBackwardFilterWithAlgorithm(
-                      input_desc, input_ptr, output_desc, out_backprop_ptr,
-                      conv_desc, filter_desc, &filter_backprop_ptr,
-                      &scratch_allocator, AlgorithmConfig(profile_algorithm),
-                      &profile_result)
-                  .ok();
-          if (cudnn_launch_status) {
-            if (profile_result.is_valid()) {
-              if (profile_result.elapsed_time_in_ms() <
-                  best_result.elapsed_time_in_ms()) {
-                best_result = profile_result;
-              }
-              if (scratch_allocator.TotalByteSize() == 0 &&
-                  profile_result.elapsed_time_in_ms() <
-                      best_result_no_scratch.elapsed_time_in_ms()) {
-                best_result_no_scratch = profile_result;
-              }
-            }
+
+      std::vector<tensorflow::AutotuneResult> results;
+      for (auto miopen_algorithm : algorithms) {
+        auto profile_algorithm = miopen_algorithm.algorithm();
+        DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
+                                              context);
+        ProfileResult profile_result;
+        bool cudnn_launch_status =
+            stream
+                ->ThenConvolveBackwardFilterWithAlgorithm(
+                    input_desc, input_ptr, output_desc, out_backprop_ptr,
+                    conv_desc, filter_desc, &filter_backprop_ptr,
+                    &scratch_allocator,
+                    AlgorithmConfig(profile_algorithm), &profile_result)
+                .ok();
+        if (cudnn_launch_status) {
+          if (profile_result.is_valid()) {
+            results.emplace_back();
+            auto& result = results.back();
+            result.mutable_conv()->set_algorithm(profile_algorithm.algo_id());
+            result.mutable_conv()->set_tensor_ops_enabled(
+                profile_algorithm.tensor_ops_enabled());
+            result.set_scratch_bytes(scratch_allocator.TotalByteSize());
+            *result.mutable_run_time() = proto_utils::ToDurationProto(
+                absl::Milliseconds(profile_result.elapsed_time_in_ms()));
           }
         }
       }
 #endif
-      OP_REQUIRES(context,
-                  best_result.is_valid() || best_result_no_scratch.is_valid(),
-                  errors::NotFound("No algorithm worked!"));
-      if (best_result.is_valid()) {
-        algorithm_config.set_algorithm(best_result.algorithm());
-      }
-      if (best_result_no_scratch.is_valid()) {
-        algorithm_config.set_algorithm_no_scratch(
-            best_result_no_scratch.algorithm());
-      }
+      LogConvAutotuneResults(se::dnn::ConvolutionKind::BACKWARD_FILTER,
+                             se::dnn::ToDataType<T>::value, input_ptr,
+                             filter_backprop_ptr, out_backprop_ptr, input_desc,
+                             filter_desc, output_desc, conv_desc,
+                             stream->parent(), results);
+      OP_REQUIRES_OK(context,
+                     BestCudnnConvAlgorithm(results, &algorithm_config));
       AutoTuneConv3dBwdFilter::GetInstance()->Insert(conv_parameters,
                                                      algorithm_config);
     }

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1430,16 +1430,17 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         }
       }
 #elif TENSORFLOW_USE_ROCM
+      DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize,
+                                            context);
       std::vector<ProfileResult> algorithms;
       CHECK(stream->parent()->GetMIOpenConvolveAlgorithms(
-          se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
-          se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
-          output_desc, &algorithms));
+          se::dnn::ConvolutionKind::BACKWARD_DATA,
+          se::dnn::ToDataType<T>::value, stream, input_desc, in_backprop_ptr,
+          filter_desc, filter_ptr, output_desc, out_backprop_ptr, conv_desc,
+          &scratch_allocator, &algorithms));
       std::vector<tensorflow::AutotuneResult> results;
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize,
-                                              context);
         ProfileResult profile_result;
         bool miopen_launch_status =
             stream
@@ -1877,17 +1878,18 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
         }
       }
 #elif TENSORFLOW_USE_ROCM
+      DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
+                                            context);
       std::vector<ProfileResult> algorithms;
       CHECK(stream->parent()->GetMIOpenConvolveAlgorithms(
-          se::dnn::ConvolutionKind::BACKWARD_FILTER, stream,
-          se::dnn::ToDataType<T>::value, input_desc, filter_desc, conv_desc,
-          output_desc, &algorithms));
+          se::dnn::ConvolutionKind::BACKWARD_FILTER,
+          se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
+          filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
+          conv_desc, &scratch_allocator, &algorithms));
 
       std::vector<tensorflow::AutotuneResult> results;
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
-                                              context);
         ProfileResult profile_result;
         bool cudnn_launch_status =
             stream

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1150,7 +1150,9 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
                       input_desc, bfloat16_input_ptr, filter_desc,
                       bfloat16_filter_ptr, conv_desc, output_desc,
                       &bfloat16_output_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm), &profile_result)
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
                   .ok();
         } else {
           miopen_launch_status =
@@ -1158,7 +1160,9 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
                   ->ThenConvolveWithAlgorithm(
                       input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
                       output_desc, &output_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm), &profile_result)
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
                   .ok();
         }
         if (miopen_launch_status && profile_result.is_valid()) {

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1100,23 +1100,28 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     }
 
 #elif TENSORFLOW_USE_ROCM
+    DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
+
     std::vector<ProfileResult> algorithms;
     if (TestMIOpenBFloat16Support<T>()) {
-      OP_REQUIRES(ctx,
-                  stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::FORWARD, stream,
-                      se::dnn::ToDataType<bfloat16>::value, input_desc,
-                      filter_desc, conv_desc, output_desc, &algorithms),
-                  errors::Unknown(
-                      "Failed to get convolution algorithm. This is probably "
-                      "because MIOpen failed to initialize, so try looking to "
-                      "see if a warning log message was printed above."));
+      OP_REQUIRES(
+          ctx,
+          stream->parent()->GetMIOpenConvolveAlgorithms(
+              se::dnn::ConvolutionKind::FORWARD,
+              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
+              bfloat16_input_ptr, filter_desc, bfloat16_filter_ptr, output_desc,
+              bfloat16_output_ptr, conv_desc, &scratch_allocator, &algorithms),
+          errors::Unknown(
+              "Failed to get convolution algorithm. This is probably "
+              "because MIOpen failed to initialize, so try looking to "
+              "see if a warning log message was printed above."));
     } else {
       OP_REQUIRES(ctx,
                   stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::FORWARD, stream,
-                      se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                      conv_desc, output_desc, &algorithms),
+                      se::dnn::ConvolutionKind::FORWARD,
+                      se::dnn::ToDataType<T>::value, stream, input_desc,
+                      input_ptr, filter_desc, filter_ptr, output_desc,
+                      output_ptr, conv_desc, &scratch_allocator, &algorithms),
                   errors::Unknown(
                       "Failed to get convolution algorithm. This is probably "
                       "because MIOpen failed to initialize, so try looking to "
@@ -1140,7 +1145,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     } else {
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
-        DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
         ProfileResult profile_result;
         bool miopen_launch_status = false;
         if (TestMIOpenBFloat16Support<T>()) {

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -544,7 +544,9 @@ struct LaunchConvOp<GPUDevice, T> {
                   ->ThenConvolveWithAlgorithm(
                       input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
                       output_desc, &output_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm), &profile_result)
+                      AlgorithmConfig(profile_algorithm,
+                                      miopen_algorithm.scratch_size()),
+                      &profile_result)
                   .ok();
           if (miopen_launch_status) {
             if (profile_result.is_valid()) {

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -511,12 +511,15 @@ struct LaunchConvOp<GPUDevice, T> {
         }
       }
 #elif TENSORFLOW_USE_ROCM
+      DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
+
       std::vector<ProfileResult> algorithms;
       OP_REQUIRES(ctx,
                   stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::FORWARD, stream,
-                      se::dnn::ToDataType<T>::value, input_desc, filter_desc,
-                      conv_desc, output_desc, &algorithms),
+                      se::dnn::ConvolutionKind::FORWARD,
+                      se::dnn::ToDataType<T>::value, stream, input_desc,
+                      input_ptr, filter_desc, filter_ptr, output_desc,
+                      output_ptr, conv_desc, &scratch_allocator, &algorithms),
                   errors::Unknown(
                       "Failed to get convolution algorithm. This is probably "
                       "because MIOpen failed to initialize, so try looking to "
@@ -537,7 +540,6 @@ struct LaunchConvOp<GPUDevice, T> {
       } else {
         for (auto miopen_algorithm : algorithms) {
           auto profile_algorithm = miopen_algorithm.algorithm();
-          DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
           ProfileResult profile_result;
           bool miopen_launch_status =
               stream

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -238,6 +238,7 @@ Status BestCudnnConvAlgorithm(absl::Span<const AutotuneResult> results,
 
   algo->set_algorithm({best_result->conv().algorithm(),
                        best_result->conv().tensor_ops_enabled()});
+  algo->set_scratch_size(best_result->scratch_bytes());
   if (best_result_no_scratch != filtered_results.end() &&
       best_result_no_scratch->scratch_bytes() == 0) {
     algo->set_algorithm_no_scratch(

--- a/tensorflow/python/debug/lib/check_numerics_callback_test.py
+++ b/tensorflow/python/debug/lib/check_numerics_callback_test.py
@@ -41,6 +41,7 @@ from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import googletest
+from tensorflow.python.platform import test as test_lib
 
 
 class LimitStringLengthTest(test_util.TensorFlowTestCase):
@@ -513,6 +514,13 @@ class CheckNumericsCallbackTest(test_util.TensorFlowTestCase):
   @test_util.run_in_graph_and_eager_modes
   def testMobileNetV2Fit(self):
     """Test training Keras MobileNetV2 application works w/ check numerics."""
+
+    if test_lib.is_built_with_rocm():
+      # This test passes with MIOpen Find Mode (which is the default)
+      # This bug is being tracked via MLOpen Issue #2379, re-enable this
+      # test once the fix for that issue is available in a ROCm release
+      self.skipTest("MIOpen bug results in test failure")
+
     check_numerics_callback.enable_check_numerics()
     model = mobilenet_v2.MobileNetV2(alpha=0.1, weights=None)
 

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -42,12 +42,15 @@ bool DnnSupport::GetConvolveAlgorithms(
 }
 
 bool DnnSupport::GetMIOpenConvolveAlgorithms(
-    dnn::ConvolutionKind /*kind*/, Stream* /*stream*/,
-    dnn::DataType /*element_type*/,
-    const dnn::BatchDescriptor& /*input_descriptor*/,
+    dnn::ConvolutionKind /*kind*/, dnn::DataType /*element_type*/,
+    Stream* /*stream*/, const dnn::BatchDescriptor& /*input_descriptor*/,
+    DeviceMemoryBase input_data,
     const dnn::FilterDescriptor& /*filter_descriptor*/,
-    const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
+    DeviceMemoryBase filter_data,
     const dnn::BatchDescriptor& /*output_descriptor*/,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
+    ScratchAllocator* scratch_allocator,
     std::vector<ProfileResult>* /*out_algorithms*/) {
   return false;
 }

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1385,11 +1385,14 @@ class DnnSupport {
       std::vector<AlgorithmDesc>* out_algorithms);
 
   virtual bool GetMIOpenConvolveAlgorithms(
-      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
-      const dnn::BatchDescriptor& input_descriptor,
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
       const dnn::FilterDescriptor& filter_descriptor,
-      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
       std::vector<ProfileResult>* out_algorithms);
 
   // Returns a list of supported rnn algorithms.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -604,13 +604,11 @@ MIOpenSupport::MIOpenSupport(GpuExecutor* parent) : parent_(parent) {
   tensorflow::ReadBoolFromEnvVar("TF_ROCM_RETURN_BEST_ALGO_ONLY", false,
                                  &return_best_algo_only_);
 
-  // by default, use Immediate Mode APIs for convolution
-  use_immediate_mode_ = true;
-  // swich to Find Mode if env var TF_ROCM_USE_FIND_MODE is set
-  bool use_find_mode = false;
-  tensorflow::ReadBoolFromEnvVar("TF_ROCM_USE_FIND_MODE", false,
-                                 &use_find_mode);
-  use_immediate_mode_ = !use_find_mode;
+  // by default, use Find Mode APIs for convolution
+  use_immediate_mode_ = false;
+  // swich to Find Mode if env var TF_ROCM_USE_IMMEDIATE_MODE is set
+  tensorflow::ReadBoolFromEnvVar("TF_ROCM_USE_IMMEDIATE_MODE", false,
+                                 &use_immediate_mode_);
 }
 
 port::Status MIOpenSupport::Init() {

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -54,7 +54,7 @@ NarrowT CheckedNarrowing(const WideT& wide) {
   return narrow;
 }
 
-const int kImmediateModeVlogLevel = 3;
+const int kConvDebugVlogLevel = 3;
 
 }  // namespace
 
@@ -546,7 +546,15 @@ class MIOpenAccess {
   miopenHandle_t handle_ GUARDED_BY(mutex_);  // Owned.
 };
 
-MIOpenSupport::MIOpenSupport(GpuExecutor* parent) : parent_(parent) {}
+MIOpenSupport::MIOpenSupport(GpuExecutor* parent) : parent_(parent) {
+  // by default, the Get*Algorithm API will return the list of all applicable
+  // algorithms
+  return_best_algo_only_ = false;
+  // but if the env var TF_ROCM_RETURN_BEST_ALGO_ONLY is set, only the best
+  // (i.e. most efficient) algorithm will be returned
+  tensorflow::ReadBoolFromEnvVar("TF_ROCM_RETURN_BEST_ALGO_ONLY", false,
+                                 &return_best_algo_only_);
+}
 
 port::Status MIOpenSupport::Init() {
   ScopedActivateExecutorContext context(parent_);
@@ -3140,18 +3148,14 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
     }
   }
 
-  VLOG(kImmediateModeVlogLevel)
+  VLOG(kConvDebugVlogLevel)
       << "Number of conv solutions max: " << maxSolutionCount;
 
-  // if the env var TF_ROCM_MIMIC_FIND_MODE is set, determine the best solution
-  // as per the "runtime" information for each solution (returned by the prior
-  // call to the *GetSolution api), and then return only the best solution
-  // The idea here is to mimic the old "find" mode, in which we relied upon
-  // the miopen api to determine the best solution, and use that solution
-  // without doing any further measurement in the TF layer
-  bool mimic_find_mode = false;
-  tensorflow::ReadBoolFromEnvVar("TF_ROCM_MIMIC_FIND_MODE", false,
-                                 &mimic_find_mode);
+  if (return_best_algo_only_) {
+    VLOG(kConvDebugVlogLevel) << "TF_ROCM_RETURN_BEST_ALGO_ONLY is set, "
+                              << "setting maxSolutionCount to 1";
+    maxSolutionCount = 1;
+  }
 
   size_t solutionCount = 0;
   std::unique_ptr<miopenConvSolution_t[]> solutions(
@@ -3170,61 +3174,30 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         return false;
       }
 
-      VLOG(kImmediateModeVlogLevel)
+      VLOG(kConvDebugVlogLevel)
           << "Number of conv solutions actual: " << solutionCount;
 
-      if (mimic_find_mode) {
-        miopenConvSolution_t best_solution = solutions[0];
+      for (int i = 0; i < solutionCount; i++) {
+        miopenConvSolution_t solution = solutions[i];
 
-        for (int i = 1; i < solutionCount; i++) {
-          miopenConvSolution_t solution = solutions[i];
-          if (solution.time < best_solution.time) {
-            best_solution = solution;
-          }
-        }
-
-        VLOG(kImmediateModeVlogLevel)
-            << "Best Solution (id, algo) = " << best_solution.solution_id
-            << ", " << ToString(best_solution.algorithm);
+        VLOG(kConvDebugVlogLevel)
+            << "solution " << i << " (time, mem, id, algo) =  " << solution.time
+            << ", " << solution.workspace_size << ", " << solution.solution_id
+            << ", " << ToString(solution.algorithm);
 
         status = wrap::miopenConvolutionForwardCompileSolution(
             miopen.handle(), filter.handle(), input_nd.handle(), conv.handle(),
-            output_nd.handle(), best_solution.solution_id);
+            output_nd.handle(), solution.solution_id);
 
         if (status != miopenStatusSuccess) {
-          LOG(FATAL) << "call to miopenConvolutionForwardCompileSolution "
-                        "failed: "
-                     << ToString(status);
+          LOG(FATAL)
+              << "call to miopenConvolutionForwardCompileSolution failed: "
+              << ToString(status);
           return false;
         }
 
         out_algorithms->emplace_back(
-            GetProfileResultFromConvSolution(best_solution));
-
-      } else {
-        for (int i = 0; i < solutionCount; i++) {
-          miopenConvSolution_t solution = solutions[i];
-
-          VLOG(kImmediateModeVlogLevel)
-              << "solution " << i
-              << " (time, mem, id, algo) =  " << solution.time << ", "
-              << solution.workspace_size << ", " << solution.solution_id << ", "
-              << ToString(solution.algorithm);
-
-          status = wrap::miopenConvolutionForwardCompileSolution(
-              miopen.handle(), filter.handle(), input_nd.handle(),
-              conv.handle(), output_nd.handle(), solution.solution_id);
-
-          if (status != miopenStatusSuccess) {
-            LOG(FATAL)
-                << "call to miopenConvolutionForwardCompileSolution failed: "
-                << ToString(status);
-            return false;
-          }
-
-          out_algorithms->emplace_back(
-              GetProfileResultFromConvSolution(solution));
-        }
+            GetProfileResultFromConvSolution(solution));
       }
       break;
     }
@@ -3240,62 +3213,30 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         return false;
       }
 
-      VLOG(kImmediateModeVlogLevel)
+      VLOG(kConvDebugVlogLevel)
           << "Number of conv solutions actual: " << solutionCount;
 
-      if (mimic_find_mode) {
-        miopenConvSolution_t best_solution = solutions[0];
+      for (int i = 0; i < solutionCount; i++) {
+        miopenConvSolution_t solution = solutions[i];
 
-        for (int i = 1; i < solutionCount; i++) {
-          miopenConvSolution_t solution = solutions[i];
-          if (solution.time < best_solution.time) {
-            best_solution = solution;
-          }
-        }
-
-        VLOG(kImmediateModeVlogLevel)
-            << "Best Solution (id, algo) = " << best_solution.solution_id
-            << ", " << ToString(best_solution.algorithm);
+        VLOG(kConvDebugVlogLevel)
+            << "solution " << i << " (time, mem, id, algo) =  " << solution.time
+            << ", " << solution.workspace_size << ", " << solution.solution_id
+            << ", " << ToString(solution.algorithm);
 
         status = wrap::miopenConvolutionBackwardDataCompileSolution(
             miopen.handle(), output_nd.handle(), filter.handle(), conv.handle(),
-            input_nd.handle(), best_solution.solution_id);
+            input_nd.handle(), solution.solution_id);
 
         if (status != miopenStatusSuccess) {
-          LOG(FATAL) << "call to miopenConvolutionBackwardDataCompileSolution "
+          LOG(FATAL) << " call to miopenConvolutionBackwardDataCompileSolution "
                         "failed: "
                      << ToString(status);
           return false;
         }
 
         out_algorithms->emplace_back(
-            GetProfileResultFromConvSolution(best_solution));
-
-      } else {
-        for (int i = 0; i < solutionCount; i++) {
-          miopenConvSolution_t solution = solutions[i];
-
-          VLOG(kImmediateModeVlogLevel)
-              << "solution " << i
-              << " (time, mem, id, algo) =  " << solution.time << ", "
-              << solution.workspace_size << ", " << solution.solution_id << ", "
-              << ToString(solution.algorithm);
-
-          status = wrap::miopenConvolutionBackwardDataCompileSolution(
-              miopen.handle(), output_nd.handle(), filter.handle(),
-              conv.handle(), input_nd.handle(), solution.solution_id);
-
-          if (status != miopenStatusSuccess) {
-            LOG(FATAL)
-                << " call to miopenConvolutionBackwardDataCompileSolution "
-                   "failed: "
-                << ToString(status);
-            return false;
-          }
-
-          out_algorithms->emplace_back(
-              GetProfileResultFromConvSolution(solution));
-        }
+            GetProfileResultFromConvSolution(solution));
       }
       break;
     }
@@ -3310,26 +3251,20 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         return false;
       }
 
-      VLOG(kImmediateModeVlogLevel)
+      VLOG(kConvDebugVlogLevel)
           << "Number of conv solutions actual: " << solutionCount;
 
-      if (mimic_find_mode) {
-        miopenConvSolution_t best_solution = solutions[0];
+      for (int i = 0; i < solutionCount; i++) {
+        miopenConvSolution_t solution = solutions[i];
 
-        for (int i = 1; i < solutionCount; i++) {
-          miopenConvSolution_t solution = solutions[i];
-          if (solution.time < best_solution.time) {
-            best_solution = solution;
-          }
-        }
-
-        VLOG(kImmediateModeVlogLevel)
-            << "Best Solution (id, algo) = " << best_solution.solution_id
-            << ", " << ToString(best_solution.algorithm);
+        VLOG(kConvDebugVlogLevel)
+            << "solution " << i << " (time, mem, id, algo) =  " << solution.time
+            << ", " << solution.workspace_size << ", " << solution.solution_id
+            << ", " << ToString(solution.algorithm);
 
         status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
             miopen.handle(), output_nd.handle(), input_nd.handle(),
-            conv.handle(), filter.handle(), best_solution.solution_id);
+            conv.handle(), filter.handle(), solution.solution_id);
 
         if (status != miopenStatusSuccess) {
           LOG(FATAL)
@@ -3340,33 +3275,7 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithms(
         }
 
         out_algorithms->emplace_back(
-            GetProfileResultFromConvSolution(best_solution));
-
-      } else {
-        for (int i = 0; i < solutionCount; i++) {
-          miopenConvSolution_t solution = solutions[i];
-
-          VLOG(kImmediateModeVlogLevel)
-              << "solution " << i
-              << " (time, mem, id, algo) =  " << solution.time << ", "
-              << solution.workspace_size << ", " << solution.solution_id << ", "
-              << ToString(solution.algorithm);
-
-          status = wrap::miopenConvolutionBackwardWeightsCompileSolution(
-              miopen.handle(), output_nd.handle(), input_nd.handle(),
-              conv.handle(), filter.handle(), solution.solution_id);
-
-          if (status != miopenStatusSuccess) {
-            LOG(FATAL)
-                << "call to miopenConvolutionBackwardWeightsCompileSolution "
-                   "failed: "
-                << ToString(status);
-            return false;
-          }
-
-          out_algorithms->emplace_back(
-              GetProfileResultFromConvSolution(solution));
-        }
+            GetProfileResultFromConvSolution(solution));
       }
       break;
     }

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -675,6 +675,10 @@ class MIOpenSupport : public dnn::DnnSupport {
  private:
   GpuExecutor* parent_;  // Parent executor object. Not owned.
 
+  // Flag to indicate whether Get*Algorithm routines should only return
+  // the best algorithm (as opposed to a list of all applicable ones)
+  bool return_best_algo_only_;
+
   // Provide access to the MIOpen handle.
   std::unique_ptr<class MIOpenAccess> miopen_;
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -196,11 +196,14 @@ class MIOpenSupport : public dnn::DnnSupport {
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 
   bool GetMIOpenConvolveAlgorithms(
-      dnn::ConvolutionKind kind, Stream* stream, dnn::DataType element_type,
-      const dnn::BatchDescriptor& input_descriptor,
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
       const dnn::FilterDescriptor& filter_descriptor,
-      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
       std::vector<dnn::ProfileResult>* out_algorithms) override;
 
   bool GetRnnAlgorithms(
@@ -679,6 +682,9 @@ class MIOpenSupport : public dnn::DnnSupport {
   // the best algorithm (as opposed to a list of all applicable ones)
   bool return_best_algo_only_;
 
+  // Flag to indicate whether to use Immediate (or Find) mode for Convolutions
+  bool use_immediate_mode_;
+
   // Provide access to the MIOpen handle.
   std::unique_ptr<class MIOpenAccess> miopen_;
 
@@ -826,6 +832,28 @@ class MIOpenSupport : public dnn::DnnSupport {
       const dnn::AlgorithmConfig& algorithm_config,
       ScratchAllocator* scratch_allocator, dnn::AlgorithmDesc* algorithm_desc,
       DeviceMemory<uint8>* scratch_memory) override;
+
+  bool GetMIOpenConvolveAlgorithmsImmediateMode(
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
+      std::vector<dnn::ProfileResult>* out_algorithms);
+
+  bool GetMIOpenConvolveAlgorithmsFindMode(
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
+      std::vector<dnn::ProfileResult>* out_algorithms);
 
   SE_DISALLOW_COPY_AND_ASSIGN(MIOpenSupport);
 };

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -291,19 +291,22 @@ bool StreamExecutor::GetConvolveAlgorithms(
 }
 
 bool StreamExecutor::GetMIOpenConvolveAlgorithms(
-    dnn::ConvolutionKind kind, Stream *stream, dnn::DataType element_type,
-    const dnn::BatchDescriptor &input_descriptor,
-    const dnn::FilterDescriptor &filter_descriptor,
-    const dnn::ConvolutionDescriptor &convolution_descriptor,
-    const dnn::BatchDescriptor &output_descriptor,
-    std::vector<dnn::ProfileResult> *out_algorithms) {
+    dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    ScratchAllocator* scratch_allocator,
+    std::vector<dnn::ProfileResult>* out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();
   if (!dnn_support) {
     return false;
   }
   return dnn_support->GetMIOpenConvolveAlgorithms(
-      kind, stream, element_type, input_descriptor, filter_descriptor,
-      convolution_descriptor, output_descriptor, out_algorithms);
+      kind, element_type, stream, input_descriptor, input_data,
+      filter_descriptor, filter_data, output_descriptor, output_data,
+      convolution_descriptor, scratch_allocator, out_algorithms);
 }
 
 bool StreamExecutor::GetRnnAlgorithms(

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -375,12 +375,15 @@ class StreamExecutor {
   // Returns the list of supported algorithms for the forward convolution
   // operation.
   bool GetMIOpenConvolveAlgorithms(
-      dnn::ConvolutionKind kind, Stream *stream, dnn::DataType element_type,
-      const dnn::BatchDescriptor &input_descriptor,
-      const dnn::FilterDescriptor &filter_descriptor,
-      const dnn::ConvolutionDescriptor &convolution_descriptor,
-      const dnn::BatchDescriptor &output_descriptor,
-      std::vector<dnn::ProfileResult> *out_algorithms);
+      dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      ScratchAllocator* scratch_allocator,
+      std::vector<dnn::ProfileResult>* out_algorithms);
 
   // Returns the list of supported algorithms for rnn operation.
   bool GetRnnAlgorithms(std::vector<dnn::AlgorithmDesc> *out_algorithms);


### PR DESCRIPTION
This PR is to revert TF to using the MIOpen Find Mode APIs for doing convolution.

After this PR, TF code will have the ability to call either Find Mode APIs or Immediate Mode APIs for doing convolution. 
* The default behaviour will be to use the Find Mode APIs. 
* Setting the env var `TF_ROCM_USE_IMMEDIATE_MODE=1` will result in the TF using Immediate Mode APIs instead.

-----------------------------------

@whchung @jerryyin @ekuznetsov139 @sunway513 @jeffdaily @parallelo please review

Currently this PR still has Immediate Mode as the default. Once I get a clean CI run with Immediate Mode as the default, I will push out a commit that flips the default Find Mode.

Reviewing this PR on a per commit basis will be easier :)

-----------------------------------

update : ROCm CI tests came back clean in Immediate Mode. Pushed out a commit to change the default to Find Mode.

Expect tests that do convolution to run a **lot** slower :(
