### PR TITLE
Wrapper header for rocprim and cub [2]

### DIFF
--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -34,14 +34,6 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 
-// Required for sorting Eigen::half
-namespace cub {
-template <>
-struct NumericTraits<Eigen::half>
-    : BaseTraits<FLOATING_POINT, true, false, unsigned short int, Eigen::half> {
-};
-}  // namespace cub
-
 namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;


### PR DESCRIPTION
This is a change that was accidentally left out of #815. Without it, TF does not build on CUDA because NumericTraits<Eigen::half> is defined twice.