### PR TITLE
Complete broadcast support in rocm_blas

### DIFF
--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -6,7 +6,7 @@ load(
     "stream_executor_friends",
 )
 load("//tensorflow:tensorflow.bzl", "tf_copts")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured", "rocm_copts")
 load("//tensorflow/core/platform:build_config_root.bzl", "if_static")
 
 package(
@@ -278,6 +278,16 @@ cc_library(
 )
 
 cc_library(
+        name = "rocm_helpers",
+        srcs = ["rocm_helpers.cu.cc"],
+        deps = 
+        ["@local_config_rocm//rocm:rocm_headers",
+        ],
+        copts = rocm_copts(),
+        alwayslink = True,
+    )
+
+cc_library(
     name = "all_runtime",
     copts = tf_copts(),
     visibility = ["//visibility:public"],
@@ -288,6 +298,7 @@ cc_library(
         ":rocrand_plugin",
         ":rocm_driver",
         ":rocm_platform",
+        ":rocm_helpers"
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/stream_executor/rocm/rocm_helpers.cu.cc
+++ b/tensorflow/stream_executor/rocm/rocm_helpers.cu.cc
@@ -1,0 +1,35 @@
+#include <hip/hip_runtime.h>
+#include <limits>
+namespace stream_executor {
+namespace gpu {
+
+__global__ void broadcast_fp32_kernel(float* dst, int dst_stride, int batches,
+                                      float* src, int size) {
+  dst += blockIdx.y * 4 * dst_stride;
+  float* dst2 = dst + dst_stride;
+  float* dst3 = dst + dst_stride*2;
+  float* dst4 = dst + dst_stride*3;
+  bool b2 = (blockIdx.y*4+1 < batches);
+  bool b3 = (blockIdx.y*4+2 < batches);
+  bool b4 = (blockIdx.y*4+3 < batches);
+  for (int i = threadIdx.x + blockIdx.x * 256; i < size; i += blockDim.x*gridDim.x) 
+  {
+  	dst[i] = src[i];
+  	if(b2)
+  		dst2[i] = src[i];
+  	if(b3)
+  		dst3[i] = src[i];
+  	if(b4)
+  		dst4[i] = src[i];
+  }
+}
+
+void broadcast_fp32(void* stream, float* dst, int dst_stride, int batches,
+                    float* src, int size) {
+  int x_blocks = (size+255)/256;
+  hipLaunchKernelGGL(broadcast_fp32_kernel, dim3(x_blocks, (batches+3)/4, 1), min(256, (int)size), 0,
+                     (hipStream_t)stream, dst, dst_stride, batches, src, size);
+}
+
+};  // namespace gpu
+};  // namespace stream_executor


### PR DESCRIPTION
This finishes the work started in #664 by merging broadcast copies (one source to multiple destinations) into single kernel calls.