### PR TITLE
Fused multiply add ops

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -6657,6 +6657,7 @@ filegroup(
         "cwise_op_floor.cc",
         "cwise_op_floor_div.cc",
         "cwise_op_floor_mod.cc",
+        "cwise_op_fma.cc",
         "cwise_op_greater.cc",
         "cwise_op_greater_equal.cc",
         "cwise_op_invert.cc",

--- a/tensorflow/core/kernels/cwise_op_fma.cc
+++ b/tensorflow/core/kernels/cwise_op_fma.cc
@@ -1,0 +1,417 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/cwise_op_fma.h"
+
+#include <vector>
+
+#include "tensorflow/core/kernels/cwise_ops_common.h"
+namespace tensorflow {
+
+//#define FMA_TRACE
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+template <FMAType Type, typename T>
+T fma_op(T m1, T m2) {
+  if (Type == FMAType_Add)
+    return m1 + m2;
+  else if (Type == FMAType_Sub)
+    return m1 - m2;
+  else
+    return m2 - m1;
+}
+
+template <typename Device, typename T, FMAType Type>
+void LaunchFusedMulAddOp<Device, T, Type>::operator()(
+    const Device& device, T* out, const T* x1, const T* y1, const T* x2,
+    uint64 elements, bool broadcast_x1, bool broadcast_y1, bool broadcast_x2) {
+  for (uint64 i = 0; i < elements; i++) {
+    out[i] = fma_op<Type>(x1[broadcast_x1 ? 0 : i] * y1[broadcast_y1 ? 0 : i],
+                          x2[broadcast_x2 ? 0 : i]);
+  }
+}
+
+template <typename Device, typename T, FMAType Type>
+void LaunchFusedMulAdd2Op<Device, T, Type>::operator()(
+    const Device& device, T* out, const T* x1, const T* y1, const T* x2,
+    const T* y2, uint64 elements, bool broadcast_x1, bool broadcast_y1,
+    bool broadcast_x2, bool broadcast_y2) {
+  for (uint64 i = 0; i < elements; i++) {
+    out[i] = fma_op<Type>(x1[broadcast_x1 ? 0 : i] * y1[broadcast_y1 ? 0 : i],
+                          x2[broadcast_x2 ? 0 : i] * y2[broadcast_y2 ? 0 : i]);
+  }
+}
+
+template <typename Device, typename T, FMAType Type>
+void FallbackLaunchFusedMulAddOp<Device, T, Type>::operator()(
+    const Device& device, T* out, const T* x1, const T* y1, const T* x2,
+    int64 dims[6], uint8 broadcast_masks[6]) {
+#ifdef FMA_TRACE
+  printf("FallbackLaunchFusedMulAddOpCPU %p %p %p %p\n", out, x1, y1, x2);
+#endif
+  int64 strides[3][5];
+  for (int i = 0; i < 3; i++) {
+    int64 s = 1;
+    for (int j = 0; j < 5; j++) {
+      int b = broadcast_masks[j] & (1 << i);
+      int b_next = broadcast_masks[j + 1] & (1 << i);
+      s *= b ? dims[j] : 1;
+      strides[i][j] = s * ((b_next - b) >> i);
+    }
+  };
+  for (uint64 t = 0; t < dims[5]; t++) {
+    for (uint64 u = 0; u < dims[4]; u++) {
+      for (uint64 v = 0; v < dims[3]; v++) {
+        for (uint64 z = 0; z < dims[2]; z++) {
+          for (uint64 y = 0; y < dims[1]; y++) {
+            for (uint64 x = 0; x < dims[0]; x++) {
+              *out = fma_op<Type>((*x1) * (*y1), (*x2));
+              out++;
+              if (broadcast_masks[0] & 1) x1++;
+              if (broadcast_masks[0] & 2) y1++;
+              if (broadcast_masks[0] & 4) x2++;
+            }
+            x1 += strides[0][0];
+            y1 += strides[1][0];
+            x2 += strides[2][0];
+          }
+          x1 += strides[0][1];
+          y1 += strides[1][1];
+          x2 += strides[2][1];
+        }
+        x1 += strides[0][2];
+        y1 += strides[1][2];
+        x2 += strides[2][2];
+      }
+      x1 += strides[0][3];
+      y1 += strides[1][3];
+      x2 += strides[2][3];
+    }
+    x1 += strides[0][4];
+    y1 += strides[1][4];
+    x2 += strides[2][4];
+  }
+}
+
+template <typename Device, typename T, FMAType Type>
+void FallbackLaunchFusedMulAdd2Op<Device, T, Type>::operator()(
+    const Device& device, T* out, const T* x1, const T* y1, const T* x2,
+    const T* y2, int64 dims[6], uint8 broadcast_masks[6]) {
+  int64 strides[4][4];
+  for (int i = 0; i < 4; i++) {
+    int64 s = 1;
+    for (int j = 0; j < 4; j++) {
+      int b = broadcast_masks[j] & (1 << i);
+      int b_next = broadcast_masks[j + 1] & (1 << i);
+      s *= b ? dims[j] : 1;
+      strides[i][j] = s * ((b_next - b) >> i);
+    }
+  };
+  for (uint64 u = 0; u < dims[4]; u++) {
+    for (uint64 v = 0; v < dims[3]; v++) {
+      for (uint64 z = 0; z < dims[2]; z++) {
+        for (uint64 y = 0; y < dims[1]; y++) {
+          for (uint64 x = 0; x < dims[0]; x++) {
+            *out = fma_op<Type>((*x1) * (*y1), (*x2) * (*y2));
+            out++;
+            if (broadcast_masks[0] & 1) x1++;
+            if (broadcast_masks[0] & 2) y1++;
+            if (broadcast_masks[0] & 4) x2++;
+            if (broadcast_masks[0] & 8) y2++;
+          }
+          x1 += strides[0][0];
+          y1 += strides[1][0];
+          x2 += strides[2][0];
+          y2 += strides[3][0];
+        }
+        x1 += strides[0][1];
+        y1 += strides[1][1];
+        x2 += strides[2][1];
+        y2 += strides[3][1];
+      }
+      x1 += strides[0][2];
+      y1 += strides[1][2];
+      x2 += strides[2][2];
+      y2 += strides[3][2];
+    }
+    x1 += strides[0][3];
+    y1 += strides[1][3];
+    x2 += strides[2][3];
+    y2 += strides[3][3];
+  }
+}
+
+template <typename Device, int N>
+class FusedMulAddBase {
+ public:
+  // Analyze the incoming shapes for compatibility, calculate
+  // the output shape and the necessary broadcasts.
+  bool DoShapeAnalysis(OpKernelContext* ctx, const Tensor** inputs,
+                       bool& pure_broadcast,
+                       std::vector<uint8>& broadcast_masks,
+                       std::vector<int64>& out_dims, TensorShape& out_shape,
+                       int64& out_elements) {
+    int64 in_elements[N];
+    int in_ranks[N];
+    int rank = 0;
+    bool scalars[N];
+
+    for (int i = 0; i < N; i++) {
+      in_elements[i] = inputs[i]->NumElements();
+      in_ranks[i] = inputs[i]->dims();
+      scalars[i] = (in_ranks[i] == 0);
+      rank = (rank > in_ranks[i]) ? rank : in_ranks[i];
+#ifdef FMA_TRACE
+      printf("Input %d: %d dimensions, %d elements\n", i, in_ranks[i],
+             in_elements[i]);
+      for (int j = 0; j < in_ranks[i]; j++)
+        printf("%d ", inputs[i]->shape().dim_size(j));
+      printf("\n");
+#endif
+    }
+    broadcast_masks.resize(rank);
+    out_dims.resize(rank);
+
+    for (int i = 0; i < rank; i++) {
+      int64 xds[N];
+      int64 max_dim = 0;
+      int ii = rank - i - 1;
+      bool null_shape = false;
+      // find the largest dimension of all inputs at this index
+      for (int j = 0; j < N; j++) {
+        xds[j] = (scalars[j] || ii >= in_ranks[j])
+                     ? 1
+                     : inputs[j]->shape().dim_size(in_ranks[j] - ii - 1);
+        max_dim = (max_dim > xds[j]) ? max_dim : xds[j];
+      }
+
+      for (int j = 0; j < N; j++) {
+        // make sure dimensions are compatible
+        if (!(xds[j] == 0 || xds[j] == 1 || xds[j] == max_dim)) return false;
+        if (xds[j] == 0) null_shape = true;
+        broadcast_masks[rank - i - 1] |= (xds[j] != 1 ? 1 : 0) << j;
+      }
+      if (null_shape) max_dim = 0;
+      out_shape.AddDim(max_dim);
+      out_dims[rank - i - 1] = max_dim;
+    }
+    out_elements = out_shape.num_elements();
+    pure_broadcast = true;
+    if (out_elements <= 1) return true;
+
+    for (int i = 0; i < N; i++)
+      if (in_elements[i] != 1 && in_elements[i] != out_elements)
+        pure_broadcast = false;
+    if (pure_broadcast) {
+      broadcast_masks[0] = 0;
+      for (int i = 0; i < N; i++)
+        if (in_elements[i] != 1) broadcast_masks[0] |= 1 << i;
+#ifdef FMA_TRACE
+      printf("%d elements, pure broadcast\n", out_elements);
+#endif
+      return true;
+    }
+#ifdef FMA_TRACE
+    printf("%d elements, broadcast %s\n", out_elements,
+           pure_broadcast ? "true" : "false");
+    for (int i = 0; i < rank; i++)
+      printf("out_dim[%d] = %d mask %d\n", i, out_dims[i],
+             (int)broadcast_masks[i]);
+#endif
+    // folding dimensions from the highest down
+    // [50,10,10]x[50,10,10]x[50,1,1] -> [50,100]x[50,100]x[50,1]
+    bool folded = false;
+
+    while (rank > 1 && out_dims.back() == 1) {
+      out_dims.pop_back();
+      broadcast_masks.pop_back();
+      rank--;
+    }
+
+    for (int i = rank - 1; i > 0; i--) {
+      if (out_dims[i] == 1 || broadcast_masks[i] == broadcast_masks[i - 1]) {
+        folded = true;
+        out_dims[i - 1] *= out_dims[i];
+        for (int j = i; j < rank - 1; j++) {
+          out_dims[j] = out_dims[j + 1];
+          broadcast_masks[j] = broadcast_masks[j + 1];
+        }
+        out_dims.pop_back();
+        broadcast_masks.pop_back();
+        rank--;
+      }
+    }
+#ifdef FMA_TRACE
+    if (folded) {
+      printf("After folding:\n");
+      for (int i = 0; i < rank; i++)
+        printf("out_dim[%d] = %d mask %d\n", i, out_dims[i],
+               (int)broadcast_masks[i]);
+    }
+#endif
+    return (rank <= 6);
+  }
+};
+
+template <typename Device, typename T, FMAType Type>
+class FusedMulAddOp : public OpKernel, public FusedMulAddBase<Device, 3> {
+ public:
+  explicit FusedMulAddOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor* inputs[3];
+    // printf("FusedMulAddOp\n");
+    OP_REQUIRES_OK(ctx, ctx->input("x1", &inputs[0]));
+    OP_REQUIRES_OK(ctx, ctx->input("y1", &inputs[1]));
+    OP_REQUIRES_OK(ctx, ctx->input("x2", &inputs[2]));
+    bool pure_broadcast = true;
+
+    std::vector<uint8> broadcast_masks;
+    std::vector<int64> out_dims;
+    //    uint8 broadcast_masks[6]={0,0,0,0,0,0};
+    //    int64 out_dims[6]={1,1,1,1,1,1};
+    TensorShape out_shape;
+    int64 out_elements = 0;
+    bool ok = FusedMulAddBase<Device, 3>::DoShapeAnalysis(
+        ctx, inputs, pure_broadcast, broadcast_masks, out_dims, out_shape,
+        out_elements);
+    OP_REQUIRES(
+        ctx, ok,
+        errors::InvalidArgument("FusedMulAdd with incompatible shapes"));
+    OP_REQUIRES(
+        ctx, pure_broadcast || broadcast_masks.size() <= 6,
+        errors::InvalidArgument("FusedMulAdd with ", broadcast_masks.size(),
+                                " broadcast ranks not supported"));
+    while (broadcast_masks.size() < 6) {
+      broadcast_masks.push_back(0);
+      out_dims.push_back(1);
+    }
+    // pure_broadcast=false;
+    Tensor* output = nullptr;
+    // todo: an OP_REQUIRES to check that all dims fit in 32 bit
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, out_shape, &output));
+    if (out_elements == 0) return;
+    if (pure_broadcast)
+      LaunchFusedMulAddOp<Device, T, Type>()(
+          ctx->eigen_device<Device>(), output->flat<T>().data(),
+          inputs[0]->flat<T>().data(), inputs[1]->flat<T>().data(),
+          inputs[2]->flat<T>().data(), out_elements, !(broadcast_masks[0] & 1),
+          !(broadcast_masks[0] & 2), !(broadcast_masks[0] & 4));
+    else
+      FallbackLaunchFusedMulAddOp<Device, T, Type>()(
+          ctx->eigen_device<Device>(), output->flat<T>().data(),
+          inputs[0]->flat<T>().data(), inputs[1]->flat<T>().data(),
+          inputs[2]->flat<T>().data(), &out_dims[0], &broadcast_masks[0]);
+  }
+};
+
+template <typename Device, typename T, FMAType Type>
+class FusedMulAdd2Op : public OpKernel, public FusedMulAddBase<Device, 4> {
+ public:
+  explicit FusedMulAdd2Op(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* ctx) override {
+    const Tensor* inputs[4];
+    OP_REQUIRES_OK(ctx, ctx->input("x1", &inputs[0]));
+    OP_REQUIRES_OK(ctx, ctx->input("y1", &inputs[1]));
+    OP_REQUIRES_OK(ctx, ctx->input("x2", &inputs[2]));
+    OP_REQUIRES_OK(ctx, ctx->input("y2", &inputs[3]));
+    bool pure_broadcast = true;
+    std::vector<uint8> broadcast_masks;
+    std::vector<int64> out_dims;
+    TensorShape out_shape;
+    int64 out_elements = 0;
+    bool ok = FusedMulAddBase<Device, 4>::DoShapeAnalysis(
+        ctx, inputs, pure_broadcast, broadcast_masks, out_dims, out_shape,
+        out_elements);
+#ifdef TRACE_FMA
+    fflush(stdout);
+#endif
+    OP_REQUIRES(
+        ctx, ok,
+        errors::InvalidArgument("FusedMulAdd2 with incompatible shapes"));
+    OP_REQUIRES(
+        ctx, pure_broadcast || broadcast_masks.size() <= 6,
+        errors::InvalidArgument("FusedMulAdd with ", broadcast_masks.size(),
+                                " broadcast ranks not supported"));
+    while (broadcast_masks.size() < 6) {
+      broadcast_masks.push_back(0);
+      out_dims.push_back(1);
+    }
+    // pure_broadcast=false;
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(ctx, ctx->allocate_output(0, out_shape, &output));
+    if (out_elements == 0) return;
+    if (pure_broadcast)
+      LaunchFusedMulAdd2Op<Device, T, Type>()(
+          ctx->eigen_device<Device>(), output->flat<T>().data(),
+          inputs[0]->flat<T>().data(), inputs[1]->flat<T>().data(),
+          inputs[2]->flat<T>().data(), inputs[3]->flat<T>().data(),
+          out_elements, !(broadcast_masks[0] & 1), !(broadcast_masks[0] & 2),
+          !(broadcast_masks[0] & 4), !(broadcast_masks[0] & 8));
+    else
+      FallbackLaunchFusedMulAdd2Op<Device, T, Type>()(
+          ctx->eigen_device<Device>(), output->flat<T>().data(),
+          inputs[0]->flat<T>().data(), inputs[1]->flat<T>().data(),
+          inputs[2]->flat<T>().data(), inputs[3]->flat<T>().data(),
+          &out_dims[0], &broadcast_masks[0]);
+  }
+};
+
+#define REGISTER_CPU_KERNEL(type)                                           \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulAdd").Device(DEVICE_CPU).TypeConstraint<type>("T"),    \
+      FusedMulAddOp<CPUDevice, type, FMAType_Add>);                         \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulAdd2").Device(DEVICE_CPU).TypeConstraint<type>("T"),   \
+      FusedMulAdd2Op<CPUDevice, type, FMAType_Add>);                        \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulSub").Device(DEVICE_CPU).TypeConstraint<type>("T"),    \
+      FusedMulAddOp<CPUDevice, type, FMAType_Sub>);                         \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulSubRev").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
+      FusedMulAddOp<CPUDevice, type, FMAType_SubRev>);                      \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulSub2").Device(DEVICE_CPU).TypeConstraint<type>("T"),   \
+      FusedMulAdd2Op<CPUDevice, type, FMAType_Sub>);
+
+REGISTER_CPU_KERNEL(Eigen::half);
+REGISTER_CPU_KERNEL(float);
+REGISTER_CPU_KERNEL(double);
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#define REGISTER_GPU_KERNEL(type)                                           \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulAdd").Device(DEVICE_GPU).TypeConstraint<type>("T"),    \
+      FusedMulAddOp<GPUDevice, type, FMAType_Add>);                         \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulAdd2").Device(DEVICE_GPU).TypeConstraint<type>("T"),   \
+      FusedMulAdd2Op<GPUDevice, type, FMAType_Add>);                        \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulSub").Device(DEVICE_GPU).TypeConstraint<type>("T"),    \
+      FusedMulAddOp<GPUDevice, type, FMAType_Sub>);                         \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulSubRev").Device(DEVICE_GPU).TypeConstraint<type>("T"), \
+      FusedMulAddOp<GPUDevice, type, FMAType_SubRev>);                      \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_FusedMulSub2").Device(DEVICE_GPU).TypeConstraint<type>("T"),   \
+      FusedMulAdd2Op<GPUDevice, type, FMAType_Sub>);
+
+REGISTER_GPU_KERNEL(Eigen::half);
+REGISTER_GPU_KERNEL(float);
+REGISTER_GPU_KERNEL(double);
+#endif
+};  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_fma.h
+++ b/tensorflow/core/kernels/cwise_op_fma.h
@@ -1,0 +1,108 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_CWISE_OP_FMA_H_
+#define TENSORFLOW_CORE_KERNELS_CWISE_OP_FMA_H_
+
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/platform/types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+enum FMAType { FMAType_Add, FMAType_Sub, FMAType_SubRev };
+
+template <typename Device, typename T, FMAType Type>
+class LaunchFusedMulAddOp {
+ public:
+  void operator()(const Device& device, T* out, const T* x1, const T* y1,
+                  const T* x2, uint64 elements, bool broadcast_x1,
+                  bool broadcast_y1, bool broadcast_x2);
+};
+
+template <typename Device, typename T, FMAType Type>
+class LaunchFusedMulAdd2Op {
+ public:
+  void operator()(const Device& device, T* out, const T* x1, const T* y1,
+                  const T* x2, const T* y2, uint64 elements, bool broadcast_x1,
+                  bool broadcast_y1, bool broadcast_x2, bool broadcast_y2);
+};
+
+template <typename Device, typename T, FMAType Type>
+class FallbackLaunchFusedMulAddOp {
+ public:
+  void operator()(const Device& device, T* out, const T* x1, const T* y1,
+                  const T* x2, int64 dims[6], uint8 broadcast_masks[6]);
+};
+
+template <typename Device, typename T, FMAType Type>
+class FallbackLaunchFusedMulAdd2Op {
+ public:
+  void operator()(const Device& device, T* out, const T* x1, const T* y1,
+                  const T* x2, const T* y2, int64 dims[6],
+                  uint8 broadcast_masks[6]);
+};
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+typedef Eigen::GpuDevice GPUDevice;
+
+template <typename T, FMAType Type>
+class LaunchFusedMulAddOp<GPUDevice, T, Type> {
+ public:
+  typedef void exec_fun(const GPUDevice& device, T* out, const T* x1,
+                        const T* y1, const T* x2, uint64 elements);
+
+  template <int N>
+  static void execute(const GPUDevice& device, T* out, const T* x1, const T* y1,
+                      const T* x2, uint64 elements);
+
+  void operator()(const GPUDevice& device, T* out, const T* x1, const T* y1,
+                  const T* x2, uint64 elements, bool broadcast_x1,
+                  bool broadcast_y1, bool broadcast_x2);
+};
+
+template <typename T, FMAType Type>
+class LaunchFusedMulAdd2Op<GPUDevice, T, Type> {
+ public:
+  typedef void exec_fun(const GPUDevice& device, T* out, const T* x1,
+                        const T* y1, const T* x2, const T* y2, uint64 elements);
+  template <int N>
+  static void execute(const GPUDevice& device, T* out, const T* x1, const T* y1,
+                      const T* x2, const T* y2, uint64 elements);
+  void operator()(const GPUDevice& device, T* out, const T* x1, const T* y1,
+                  const T* x2, const T* y2, uint64 elements, bool broadcast_x1,
+                  bool broadcast_y1, bool broadcast_x2, bool broadcast_y2);
+};
+
+template <typename T, FMAType Type>
+class FallbackLaunchFusedMulAddOp<GPUDevice, T, Type> {
+ public:
+  void operator()(const GPUDevice& device, T* out, const T* x1, const T* y1,
+                  const T* x2, int64 dims[6], uint8 broadcast_masks[6]);
+};
+
+template <typename T, FMAType Type>
+class FallbackLaunchFusedMulAdd2Op<GPUDevice, T, Type> {
+ public:
+  void operator()(const GPUDevice& device, T* out, const T* x1, const T* y1,
+                  const T* x2, const T* y2, int64 dims[6],
+                  uint8 broadcast_masks[6]);
+};
+#endif
+
+};  // namespace tensorflow
+
+#endif

--- a/tensorflow/core/kernels/cwise_op_gpu_fma.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_fma.cu.cc
@@ -1,0 +1,459 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if TENSORFLOW_USE_ROCM || \
+    (GOOGLE_CUDA && (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)))
+
+//#if TENSORFLOW_USE_ROCM
+
+#include "tensorflow/core/kernels/cwise_op_fma.h"
+#include "tensorflow/core/kernels/cwise_ops_gpu_common.cu.h"
+#include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+
+#if TENSORFLOW_USE_ROCM
+#include "rocm/include/hip/hip_fp16.h"
+#else
+#include "third_party/gpus/cuda/include/cuda_fp16.hpp"
+#endif
+
+namespace tensorflow {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+template <FMAType Type, typename T>
+__device__ T fma_op(T m1, T m2) {
+  if (Type == FMAType_Add)
+    return m1 + m2;
+  else if (Type == FMAType_Sub)
+    return m1 - m2;
+  else
+    return m2 - m1;
+}
+
+template <class T>
+__device__ T load_broadcast(const T* x) {
+  return *x;
+}
+
+template <>
+__device__ __half2 load_broadcast(const __half2* x) {
+  return __half2half2(*(const __half*)x);
+}
+
+//
+// Fast pathway: each tensor is either full-size or 1-element.
+//
+
+template <typename T, int N, FMAType Type>
+__global__ void CwiseFusedMulAddKernel(GpuLaunchConfig cfg, T* out, const T* x1,
+                                       const T* y1, const T* x2) {
+  constexpr bool broadcast_x1 = (N & 1);
+  constexpr bool broadcast_y1 = (N & 2);
+  constexpr bool broadcast_x2 = (N & 4);
+  T cx1 = load_broadcast(x1);
+  T cx2 = load_broadcast(x2);
+  T cy1 = load_broadcast(y1);
+  GPU_1D_KERNEL_LOOP(i, cfg.virtual_thread_count) {
+    out[i] = fma_op<Type>(
+        (broadcast_x1 ? cx1 : x1[i]) * (broadcast_y1 ? cy1 : y1[i]),
+        broadcast_x2 ? cx2 : x2[i]);
+  }
+}
+
+template <typename T, int N, FMAType Type>
+__global__ void CwiseFusedMulAdd2Kernel(GpuLaunchConfig cfg, T* out,
+                                        const T* x1, const T* y1, const T* x2,
+                                        const T* y2) {
+  constexpr bool broadcast_x1 = (N & 1);
+  constexpr bool broadcast_y1 = (N & 2);
+  constexpr bool broadcast_x2 = (N & 4);
+  constexpr bool broadcast_y2 = (N & 8);
+  GPU_1D_KERNEL_LOOP(i, cfg.virtual_thread_count) {
+    out[i] = fma_op<Type>(x1[broadcast_x1 ? 0 : i] * y1[broadcast_y1 ? 0 : i],
+                          x2[broadcast_x2 ? 0 : i] * y2[broadcast_y2 ? 0 : i]);
+  }
+}
+
+template <typename T, FMAType Type>
+template <int N>
+void LaunchFusedMulAddOp<GPUDevice, T, Type>::execute(const GPUDevice& device,
+                                                      T* out, const T* x1,
+                                                      const T* y1, const T* x2,
+                                                      uint64 elements) {
+  if (std::is_same<T, Eigen::half>::value && !(elements & 1)) {
+    auto config = GetGpuLaunchConfig(elements / 2, device);
+    TF_CHECK_OK(GpuLaunchKernel(
+        CwiseFusedMulAddKernel<__half2, N, Type>, config.block_count,
+        config.thread_per_block, 0, device.stream(), config, (__half2*)out,
+        (const __half2*)x1, (const __half2*)y1, (const __half2*)x2));
+  } else {
+    auto config = GetGpuLaunchConfig(elements, device);
+    TF_CHECK_OK(GpuLaunchKernel(CwiseFusedMulAddKernel<T, N, Type>,
+                                config.block_count, config.thread_per_block, 0,
+                                device.stream(), config, out, x1, y1, x2));
+  }
+}
+
+template <typename T, FMAType Type>
+void LaunchFusedMulAddOp<GPUDevice, T, Type>::operator()(
+    const GPUDevice& device, T* out, const T* x1, const T* y1, const T* x2,
+    uint64 elements, bool broadcast_x1, bool broadcast_y1, bool broadcast_x2) {
+  int index =
+      (broadcast_x1 ? 1 : 0) + (broadcast_y1 ? 2 : 0) + (broadcast_x2 ? 4 : 0);
+  exec_fun* execs[8] = {&execute<0>, &execute<1>, &execute<2>, &execute<3>,
+                        &execute<4>, &execute<5>, &execute<6>, &execute<7>};
+  execs[index](device, out, x1, y1, x2, elements);
+}
+
+template <typename T, FMAType Type>
+template <int N>
+void LaunchFusedMulAdd2Op<GPUDevice, T, Type>::execute(const GPUDevice& device,
+                                                       T* out, const T* x1,
+                                                       const T* y1, const T* x2,
+                                                       const T* y2,
+                                                       uint64 elements) {
+  auto config = GetGpuLaunchConfig(elements, device);
+  TF_CHECK_OK(GpuLaunchKernel(CwiseFusedMulAdd2Kernel<T, N, Type>,
+                              config.block_count, config.thread_per_block, 0,
+                              device.stream(), config, out, x1, y1, x2, y2));
+}
+
+template <typename T, FMAType Type>
+void LaunchFusedMulAdd2Op<GPUDevice, T, Type>::operator()(
+    const GPUDevice& device, T* out, const T* x1, const T* y1, const T* x2,
+    const T* y2, uint64 elements, bool broadcast_x1, bool broadcast_y1,
+    bool broadcast_x2, bool broadcast_y2) {
+  int index = (broadcast_x1 ? 1 : 0) + (broadcast_y1 ? 2 : 0) +
+              (broadcast_x2 ? 4 : 0) + (broadcast_y2 ? 8 : 0);
+  exec_fun* execs[16] = {
+      &execute<0>,  &execute<1>,  &execute<2>,  &execute<3>,
+      &execute<4>,  &execute<5>,  &execute<6>,  &execute<7>,
+      &execute<8>,  &execute<9>,  &execute<10>, &execute<11>,
+      &execute<12>, &execute<13>, &execute<14>, &execute<15>,
+  };
+  execs[index](device, out, x1, y1, x2, y2, elements);
+}
+
+//
+// Fallback pathway: we need to broadcast some tensors along some dimensions
+// but not others. Necessary because, at the time grappler does the fusion,
+// we don't have full input shapes.
+//
+template <typename T, FMAType type, int N>
+struct Fallback_FMA_Arg {
+  T* out;
+  const T* ptrs[N - 1];
+  // uint64 has high overhead
+  int32 shifts[N][5];
+  int32 dims[6];
+  // uint32 broadcast_mask;
+  uint32 x_mask[N - 1];
+  __device__ void shift(int dim, int delta) {
+    out += shifts[0][dim - 1] * delta;
+    for (int i = 0; i < N - 1; i++) ptrs[i] += shifts[i + 1][dim - 1] * delta;
+  }
+  void construct(const int64 dims[6], const uint8 broadcast_masks[6]);
+
+  // todo: __half2 optimizations
+  __device__ void x_loop(int start, int x_step) {
+    for (int x = start; x < dims[0]; x += x_step) {
+      T m1 = ptrs[0][x & x_mask[0]] * ptrs[1][x & x_mask[1]];
+      T m2 = ptrs[2][x & x_mask[2]];
+      if (N == 5) m2 *= ptrs[3][x & x_mask[3]];
+      out[x] = fma_op<type>(m1, m2);
+    }
+  }
+
+  __device__ void x_loop_2(int start, int span) {
+    int x_cnt = 0;
+    for (int x = start; x_cnt < span && x < dims[0]; x += blockDim.x) {
+      T m1 = ptrs[0][x & x_mask[0]] * ptrs[1][x & x_mask[1]];
+      T m2 = ptrs[2][x & x_mask[2]];
+      if (N == 5) m2 *= ptrs[3][x & x_mask[3]];
+      out[x] = fma_op<type>(m1, m2);
+      x_cnt++;
+    }
+  }
+};
+
+template <typename T, FMAType type, int N>
+void Fallback_FMA_Arg<T, type, N>::construct(const int64 _dims[6],
+                                             const uint8 broadcast_masks[6]) {
+  for (int y = 0; y < 6; y++) dims[y] = (int32)_dims[y];
+  for (int y = 0; y < N; y++) {
+    int b0, b1, b2;
+    if (y == 0)
+      b0 = b1 = b2 = 1;
+    else {
+      b0 = broadcast_masks[0] & (1 << (y - 1));
+      b1 = broadcast_masks[1] & (1 << (y - 1));
+      b2 = broadcast_masks[2] & (1 << (y - 1));
+    }
+    int stride = (b0 ? _dims[0] : 1) * (b1 ? _dims[1] : 1);
+    shifts[y][1] = b2 ? stride : 0;
+    for (int x = 1; x < 4; x++) {
+      int b = (y == 0) ? 1 : (broadcast_masks[x + 1] & (1 << (y - 1)));
+      int bn = (y == 0) ? 1 : (broadcast_masks[x + 2] & (1 << (y - 1)));
+      if (b) stride *= _dims[x + 1];
+      shifts[y][x + 1] = bn ? stride : 0;
+    }
+  }
+
+  for (int y = 0; y < N - 1; y++)
+    x_mask[y] = (broadcast_masks[0] & (1 << y)) ? -1 : 0;
+  // broadcast_mask = broadcast_masks[0];
+
+  shifts[0][0] = dims[0];
+  for (int i = 1; i < N; i++)
+    shifts[i][0] = (broadcast_masks[1] & (1 << (i - 1)))
+                       ? ((broadcast_masks[0] & (1 << (i - 1))) ? dims[0] : 1)
+                       : 0;
+}
+
+// "Fallback fallback" case
+template <typename T, FMAType Type, int N>
+__global__ void FallbackLaunchFusedMulAddKernel6D(
+    Fallback_FMA_Arg<T, Type, N> arg) {
+  arg.shift(4, blockIdx.z);
+  arg.shift(3, blockIdx.y);
+  int32 z = threadIdx.z + blockIdx.x * blockDim.z;
+  if (z >= arg.dims[2]) return;
+  arg.shift(2, z);
+  arg.shift(1, threadIdx.y);
+  for (int32_t t = 0; t < arg.dims[5]; t++) {
+    int y_count = 0;
+    for (int32 y = threadIdx.y; y < arg.dims[1]; y += blockDim.y) {
+      arg.x_loop(threadIdx.x, blockDim.x);
+      arg.shift(1, blockDim.y);
+      y_count++;
+    }
+    arg.shift(1, -blockDim.y * y_count);
+    arg.shift(5, 1);
+  }
+}
+
+struct FallbackFMAGrid {
+  // TODO: enforce repeats_x,y < 65536
+  uint16 tdims[4];
+  uint32 gdims[2];
+};
+
+template <typename T, FMAType Type, int N, int loops>
+__global__ void FallbackLaunchFusedMulAddKernel4D(
+    Fallback_FMA_Arg<T, Type, N> arg, FallbackFMAGrid grid) {
+  int tid0 = threadIdx.x;
+  int tid1 = threadIdx.y;
+  int tid2 = threadIdx.z % grid.tdims[0];
+  int tid3 = threadIdx.z / grid.tdims[0];
+  int gid0 = blockIdx.x;
+  int gid1 = blockIdx.y;
+  int gid2 = blockIdx.z % grid.gdims[0];
+  int gid3 = blockIdx.z / grid.gdims[0];
+
+  int32 px = blockDim.x;
+  int32 py = blockDim.y;
+  int32 pz = grid.tdims[0];
+  int32 pt = grid.tdims[1];
+
+  int32 repeats_x = grid.tdims[2];
+  int32 repeats_y = grid.tdims[3];
+  int32 x0 = tid0 + gid0 * px * repeats_x;
+  int32 y0 = tid1 + gid1 * py * repeats_y;
+  int32 z0 = tid2 + gid2 * pz;
+  int32 t0 = tid3 + gid3 * pt;
+  pz *= grid.gdims[0];
+  pt *= grid.gdims[1];
+  if (x0 >= arg.dims[0]) return;
+  if (y0 >= arg.dims[1]) return;
+  if (z0 >= arg.dims[2]) return;
+  if (t0 >= arg.dims[3]) return;
+  arg.shift(3, t0);
+  arg.shift(2, z0);
+  arg.shift(1, y0);
+  if (loops == 1) {
+    arg.x_loop_2(x0, repeats_x);
+  } else if (loops == 2) {
+    int y_cnt = 0;
+    for (int32 y = y0; y < arg.dims[1] && y_cnt < repeats_y; y += py) {
+      arg.x_loop_2(x0, repeats_x);
+      arg.shift(1, py);
+      y_cnt++;
+    }
+  } else {
+    for (int32 t = t0; t < arg.dims[3]; t += pt) {
+      int z_cnt = 0;
+      for (int32 z = z0; z < arg.dims[2]; z += pz) {
+        int y_cnt = 0;
+        for (int32 y = y0; y < arg.dims[1] && y_cnt < repeats_y; y += py) {
+          arg.x_loop_2(x0, repeats_x);
+          arg.shift(1, py);
+          y_cnt++;
+        }
+        arg.shift(1, -py * y_cnt);
+        arg.shift(2, pz);
+        z_cnt++;
+      }
+      arg.shift(2, -pz * z_cnt);
+      arg.shift(3, pt);
+    }
+  }
+}
+
+template <typename T, FMAType Type, int N>
+__global__ void FallbackLaunchFusedMulAddKernel2D(
+    Fallback_FMA_Arg<T, Type, N> arg) {
+  arg.shift(1, blockIdx.x);
+  arg.x_loop(threadIdx.x, blockDim.x);
+}
+
+template <typename T, FMAType type, int N>
+void Fallback_FMA_execute(const GPUDevice& device, int64 dims[6],
+                          Fallback_FMA_Arg<T, type, N>& arg) {
+  const uint64 kThreads = 256;
+  if (dims[2] == 1 && dims[3] == 1 && dims[4] == 1 && dims[5] == 1) {
+    TF_CHECK_OK(GpuLaunchKernel(
+        FallbackLaunchFusedMulAddKernel2D<T, type, N>, dim3(dims[1], 1, 1),
+        dim3(dims[0] > 256 ? 256 : dims[0], 1, 1), 0, device.stream(), arg));
+  } else if (dims[4] == 1 && dims[5] == 1) {
+    FallbackFMAGrid grid_conf;
+    dim3 block, grid;
+    int64 min_blocks = 0, min_repeats = 0;
+
+    (void)ReadInt64FromEnvVar("TF_FMA_MIN_BLOCKS", 0, &min_blocks);
+    (void)ReadInt64FromEnvVar("TF_FMA_MIN_REPEATS", 16, &min_repeats);
+
+    int repeats = 1;
+    uint32 true_grid[2][4];
+    int axis_repeats[4] = {1, 1, 1, 1};
+    uint32 threads = 256, blocks = 1;
+    bool y_loop = false, z_loop = false, t_loop = false;
+    // We have 4 dimensions to loop over, but only 3 thread dimensions
+    // Therefore, we squeeze dims[2] and dims[3] into threadIdx.z
+    for (int i = 0; i < 4; i++) {
+      true_grid[0][i] = min(threads, dims[i]);
+      true_grid[1][i] = (dims[i] + true_grid[0][i] - 1) / true_grid[0][i];
+      threads /= true_grid[0][i];
+      blocks *= true_grid[1][i];
+    }
+
+    // It is more efficient for each thread to process >1 location
+    if (min_blocks != 0 || min_repeats != 0) {
+      for (int i = 0; i < 4; i++) {
+        int factor =
+            (min_blocks != 0) ? (blocks / min_blocks) : (min_repeats / repeats);
+        if (factor <= 1) break;
+        auto& g = true_grid[1][i];
+        uint32 og = g;
+        g = (g + factor - 1) / factor;
+        if (g == 0) g = 1;
+        if (g != og) {
+          if (i == 1) y_loop = true;
+          if (i == 2) z_loop = true;
+          if (i == 3) t_loop = true;
+        }
+        axis_repeats[i] = (og + g - 1) / g;
+        repeats *= axis_repeats[i];
+        blocks /= og;
+        blocks *= g;
+      }
+    }
+
+    block.x = true_grid[0][0];
+    block.y = true_grid[0][1];
+    block.z = true_grid[0][2] * true_grid[0][3];
+    grid.x = true_grid[1][0];
+    grid.y = true_grid[1][1];
+    grid.z = true_grid[1][2] * true_grid[1][3];
+    grid_conf.tdims[0] = true_grid[0][2];
+    grid_conf.tdims[1] = true_grid[0][3];
+    grid_conf.gdims[0] = true_grid[1][2];
+    grid_conf.gdims[1] = true_grid[1][3];
+    grid_conf.tdims[2] = axis_repeats[0];
+    grid_conf.tdims[3] = axis_repeats[1];
+    TF_CHECK_OK(GpuLaunchKernel(
+        (z_loop || t_loop)
+            ? FallbackLaunchFusedMulAddKernel4D<T, type, N, 4>
+            : (y_loop ? FallbackLaunchFusedMulAddKernel4D<T, type, N, 2>
+                      : FallbackLaunchFusedMulAddKernel4D<T, type, N, 1>),
+        grid, block, 0, device.stream(), arg, grid_conf));
+  } else {
+    int block_x = min(kThreads, dims[0]);
+    int block_y = min(kThreads / block_x, dims[1]);
+    int block_z = min(kThreads / (block_x * block_y), dims[2]);
+    int grid_x = (dims[2] + block_z - 1) / block_z;
+    int grid_y = dims[3];
+    int grid_z = dims[4];
+    TF_CHECK_OK(GpuLaunchKernel(FallbackLaunchFusedMulAddKernel6D<T, type, N>,
+                                dim3(grid_x, grid_y, grid_z),
+                                dim3(block_x, block_y, block_z), 0,
+                                device.stream(), arg));
+  }
+}
+
+template <typename T, FMAType Type>
+void FallbackLaunchFusedMulAddOp<GPUDevice, T, Type>::operator()(
+    const GPUDevice& device, T* out, const T* x1, const T* y1, const T* x2,
+    int64 dims[6], uint8 broadcast_masks[6]) {
+  Fallback_FMA_Arg<T, Type, 4> arg;
+  arg.out = out;
+  arg.ptrs[0] = x1;
+  arg.ptrs[1] = y1;
+  arg.ptrs[2] = x2;
+  arg.construct(dims, broadcast_masks);
+  Fallback_FMA_execute(device, dims, arg);
+}
+
+template <typename T, FMAType Type>
+void FallbackLaunchFusedMulAdd2Op<GPUDevice, T, Type>::operator()(
+    const GPUDevice& device, T* out, const T* x1, const T* y1, const T* x2,
+    const T* y2, int64 dims[6], uint8 broadcast_masks[6]) {
+  Fallback_FMA_Arg<T, Type, 5> arg;
+  arg.out = out;
+  arg.ptrs[0] = x1;
+  arg.ptrs[1] = y1;
+  arg.ptrs[2] = x2;
+  arg.ptrs[3] = y2;
+  arg.construct(dims, broadcast_masks);
+  Fallback_FMA_execute(device, dims, arg);
+}
+
+#define INSTANTIATE_FMA(X, S)                                                 \
+  template void LaunchFusedMulAddOp<GPUDevice, X, S>::operator()(             \
+      const GPUDevice& device, X* out, const X* x1, const X* y1, const X* x2, \
+      uint64 elements, bool bc1, bool bc2, bool bc3);                         \
+  template void LaunchFusedMulAdd2Op<GPUDevice, X, S>::operator()(            \
+      const GPUDevice& device, X* out, const X* x1, const X* y1, const X* x2, \
+      const X* y2, uint64 elements, bool bc1, bool bc2, bool bc3, bool bc4);  \
+  template void FallbackLaunchFusedMulAddOp<GPUDevice, X, S>::operator()(     \
+      const GPUDevice& device, X* out, const X* x1, const X* y1, const X* x2, \
+      int64 dims[5], uint8 broadcast_masks[5]);                               \
+  template void FallbackLaunchFusedMulAdd2Op<GPUDevice, X, S>::operator()(    \
+      const GPUDevice& device, X* out, const X* x1, const X* y1, const X* x2, \
+      const X* y2, int64 dims[5], uint8 broadcast_masks[5]);
+
+INSTANTIATE_FMA(Eigen::half, FMAType_Add);
+INSTANTIATE_FMA(float, FMAType_Add);
+INSTANTIATE_FMA(double, FMAType_Add);
+INSTANTIATE_FMA(Eigen::half, FMAType_SubRev);
+INSTANTIATE_FMA(float, FMAType_SubRev);
+INSTANTIATE_FMA(double, FMAType_SubRev);
+INSTANTIATE_FMA(Eigen::half, FMAType_Sub);
+INSTANTIATE_FMA(float, FMAType_Sub);
+INSTANTIATE_FMA(double, FMAType_Sub);
+
+};  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/ops/math_grad.cc
+++ b/tensorflow/core/ops/math_grad.cc
@@ -24,6 +24,127 @@ namespace tensorflow {
 
 typedef FunctionDefHelper FDH;
 
+template <int T>
+Status FusedMulAddGrad(const AttrSlice& attrs, FunctionDef* g) {
+  std::vector<FDH::Node> nodes = {
+      {{"sx1"}, "Shape", {"x1"}},
+      {{"sx2"}, "Shape", {"x2"}},
+      {{"sy1"}, "Shape", {"y1"}},
+      {{"sz"}, "Shape", {"dz"}},
+      {{"gx1"}, "Mul", {"dz", "y1"}},  // dz * y2
+      {{"gy1"}, "Mul", {"x1", "dz"}},  // x2 * dz
+      {{"gx2"}, "Identity", {"dz"}},   // dz
+
+      {{"rx1", "dummy1"}, "BroadcastGradientArgs", {"sx1", "sz"}},
+      {{"ry1", "dummy2"}, "BroadcastGradientArgs", {"sy1", "sz"}},
+      {{"rx2", "dummy3"}, "BroadcastGradientArgs", {"sx2", "sz"}},
+      {{"sum_gx1"}, "Sum", {"gx1", "rx1"}},
+      {{"sum_gx2"}, "Sum", {"gx2", "rx2"}},
+      {{"sum_gy1"}, "Sum", {"gy1", "ry1"}},
+  };
+
+  // Add
+  if (T == 0) {
+    nodes.emplace_back(FDH::Node{{"dx1"}, "Reshape", {"sum_gx1", "sx1"}});
+    nodes.emplace_back(FDH::Node{{"dy1"}, "Reshape", {"sum_gy1", "sy1"}});
+    nodes.emplace_back(FDH::Node{{"dx2"}, "Reshape", {"sum_gx2", "sx2"}});
+  }  // Sub
+  else if (T == 1) {
+    nodes.emplace_back(FDH::Node{{"sum_gx2_neg"}, "Neg", {"sum_gx2"}});
+    nodes.emplace_back(FDH::Node{{"dx1"}, "Reshape", {"sum_gx1", "sx1"}});
+    nodes.emplace_back(FDH::Node{{"dy1"}, "Reshape", {"sum_gy1", "sy1"}});
+    nodes.emplace_back(FDH::Node{{"dx2"}, "Reshape", {"sum_gx2_neg", "sx2"}});
+  } else {
+    nodes.emplace_back(FDH::Node{{"sum_gx1_neg"}, "Neg", {"sum_gx1"}});
+    nodes.emplace_back(FDH::Node{{"sum_gy1_neg"}, "Neg", {"sum_gy1"}});
+    nodes.emplace_back(FDH::Node{{"dx1"}, "Reshape", {"sum_gx1_neg", "sx1"}});
+    nodes.emplace_back(FDH::Node{{"dy1"}, "Reshape", {"sum_gy1_neg", "sy1"}});
+    nodes.emplace_back(FDH::Node{{"dx2"}, "Reshape", {"sum_gx2", "sx2"}});
+  }
+
+  // clang-format on
+  for (auto& n : nodes) {
+    // "BroadcastGradientArgs" doesn't need any attrs.
+    if (n.attr.empty() && n.op != "BroadcastGradientArgs") {
+      n.attr = {{"T", "$T"}};
+    }
+  }
+  *g = FDH::Define(
+      // Arg defs
+      {"x1: T", "y1: T", "x2: T", "dz: T"},
+      // Ret val defs
+      {"dx1: T", "dy1: T", "dx2: T"},
+      // Attr defs
+      {{"T: {half, float, double}"}},
+      // Nodes
+      nodes);
+
+  return Status::OK();
+}
+
+template <int T>
+Status FusedMulAdd2Grad(const AttrSlice& attrs, FunctionDef* g) {
+  std::vector<FDH::Node> nodes = {
+      {{"sx1"}, "Shape", {"x1"}},
+      {{"sx2"}, "Shape", {"x2"}},
+      {{"sy1"}, "Shape", {"y1"}},
+      {{"sy2"}, "Shape", {"y2"}},
+      {{"sz"}, "Shape", {"dz"}},
+      {{"gx1"}, "Mul", {"dz", "y1"}},  // dz * y2
+      {{"gy1"}, "Mul", {"x1", "dz"}},  // x2 * dz
+      {{"gx2"}, "Mul", {"dz", "y2"}},  // dz * y2
+      {{"gy2"}, "Mul", {"x2", "dz"}},  // x2 * dz
+
+      {{"rx1", "dummy1"}, "BroadcastGradientArgs", {"sx1", "sz"}},
+      {{"ry1", "dummy2"}, "BroadcastGradientArgs", {"sy1", "sz"}},
+      {{"rx2", "dummy3"}, "BroadcastGradientArgs", {"sx2", "sz"}},
+      {{"ry2", "dummy4"}, "BroadcastGradientArgs", {"sy2", "sz"}},
+      {{"sum_gx1"}, "Sum", {"gx1", "rx1"}},
+      {{"sum_gx2"}, "Sum", {"gx2", "rx2"}},
+      {{"sum_gy1"}, "Sum", {"gy1", "ry1"}},
+      {{"sum_gy2"}, "Sum", {"gy2", "ry2"}},
+      {{"dx1"}, "Reshape", {"sum_gx1", "sx1"}},
+      {{"dy1"}, "Reshape", {"sum_gy1", "sy1"}},
+  };
+
+  // Add
+  if (T == 0) {
+    nodes.emplace_back(FDH::Node{{"dx2"}, "Reshape", {"sum_gx2", "sx2"}});
+    nodes.emplace_back(FDH::Node{{"dy2"}, "Reshape", {"sum_gy2", "sy2"}});
+  }  // Sub
+  else {
+    nodes.emplace_back(FDH::Node{{"sum_gx2_neg"}, "Neg", {"sum_gx2"}});
+    nodes.emplace_back(FDH::Node{{"sum_gy2_neg"}, "Neg", {"sum_gy2"}});
+    nodes.emplace_back(FDH::Node{{"dx2"}, "Reshape", {"sum_gx2_neg", "sx2"}});
+    nodes.emplace_back(FDH::Node{{"dy2"}, "Reshape", {"sum_gy2_neg", "sy2"}});
+  }
+
+  // clang-format on
+  for (auto& n : nodes) {
+    // "BroadcastGradientArgs" doesn't need any attrs.
+    if (n.attr.empty() && n.op != "BroadcastGradientArgs") {
+      n.attr = {{"T", "$T"}};
+    }
+  }
+  *g = FDH::Define(
+      // Arg defs
+      {"x1: T", "y1: T", "x2: T", "y2: T", "dz: T"},
+      // Ret val defs
+      {"dx1: T", "dy1: T", "dx2: T", "dy2: T"},
+      // Attr defs
+      {{"T: {half, float, double}"}},
+      // Nodes
+      nodes);
+
+  return Status::OK();
+}
+
+REGISTER_OP_GRADIENT("_FusedMulAdd", FusedMulAddGrad<0>);
+REGISTER_OP_GRADIENT("_FusedMulSub", FusedMulAddGrad<1>);
+REGISTER_OP_GRADIENT("_FusedMulSubRev", FusedMulAddGrad<2>);
+REGISTER_OP_GRADIENT("_FusedMulAdd2", FusedMulAdd2Grad<0>);
+REGISTER_OP_GRADIENT("_FusedMulSub2", FusedMulAdd2Grad<1>);
+
 // Cwise binary ops
 Status GradForUnaryCwise(FunctionDef* g, std::vector<FDH::Node> nodes) {
   for (auto& n : nodes) {

--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -494,7 +494,13 @@ class AutoMixedPrecisionTest(test.TestCase):
         # self._assert_output_fp16(node_map, 'dropout/mul')
       # We do not assert dropout's dtype because we do not want to rely on the
       # node names of dropout's internal implementation.
-      self._assert_output_fp16(node_map, 'addition')
+      for x in node_map:
+        print(x)
+      if test.is_built_with_rocm: # rocm fuses addition
+        self._assert_output_fp16(node_map, 
+          'dropout/Mul_1addition/y-0-CastToFp16-AutoMixedPrecision')
+      else:
+        self._assert_output_fp16(node_map, 'addition')
       self._assert_output_fp16(node_map, 'Conv2D_1')
 
       output_val_ref, output_val, cost_graph = self._run(output)

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1884,3 +1884,61 @@ def _NextAfterGrad(op, grad):
         math_ops.reduce_sum(partial_x1 * grad, r_x1), s_x1),
             array_ops.reshape(
                 math_ops.reduce_sum(partial_x2 * grad, r_x2), s_x2))
+
+def _FusedMulAddSubGrad(op, grad, sgn):
+  x1 = op.inputs[0]
+  y1 = op.inputs[1]
+  x2 = op.inputs[2]
+  (sx1, rx1, must_reduce_x1), _= SmartBroadcastGradientArgs(x1, grad, grad)
+  (sy1, ry1, must_reduce_y1), _= SmartBroadcastGradientArgs(y1, grad, grad)
+  (sx2, rx2, must_reduce_x2), _= SmartBroadcastGradientArgs(x2, grad, grad)
+  gx1 = gen_math_ops.mul(grad, y1)
+  gy1 = gen_math_ops.mul(grad, x1)
+  gx2 = grad[:]
+  if sgn==-1:
+    gx2=math_ops.negative(gx2)
+  elif sgn==0:
+    gx1=math_ops.negative(gx1)
+    gy1=math_ops.negative(gy1)
+  return [gx1 if not must_reduce_x1 else math_ops.reduce_sum(gx1,rx1), \
+      gy1 if not must_reduce_y1 else math_ops.reduce_sum(gy1,ry1), \
+      gx2 if not must_reduce_x2 else math_ops.reduce_sum(gx2,rx2)]
+
+def _FusedMulAddSub2Grad(op, grad, sgn):
+  x1 = op.inputs[0]
+  y1 = op.inputs[1]
+  x2 = op.inputs[2]
+  y2 = op.inputs[3]
+  (sx1, rx1, must_reduce_x1), _= SmartBroadcastGradientArgs(x1, grad, grad)
+  (sy1, ry1, must_reduce_y1), _= SmartBroadcastGradientArgs(y1, grad, grad)
+  (sx2, rx2, must_reduce_x2), _= SmartBroadcastGradientArgs(x2, grad, grad)
+  (sy2, ry2, must_reduce_y2), _= SmartBroadcastGradientArgs(y2, grad, grad)
+  gx1 = gen_math_ops.mul(grad, y1)
+  gy1 = gen_math_ops.mul(grad, x1)
+  gx2 = gen_math_ops.mul(grad, y2)*sgn
+  gy2 = gen_math_ops.mul(grad, x2)*sgn
+  return [gx1 if not must_reduce_x1 else math_ops.reduce_sum(gx1,rx1), \
+      gy1 if not must_reduce_y1 else math_ops.reduce_sum(gy1,ry1), \
+      gx2 if not must_reduce_x2 else math_ops.reduce_sum(gx2,rx2),
+      gy2 if not must_reduce_y2 else math_ops.reduce_sum(gy2,ry2)
+      ]
+
+@ops.RegisterGradient("_FusedMulAdd")
+def _FusedMulAddGrad(op, grad):
+  return _FusedMulAddSubGrad(op, grad, 1)
+
+@ops.RegisterGradient("_FusedMulAdd2")
+def _FusedMulAdd2Grad(op, grad):
+  return _FusedMulAddSub2Grad(op, grad, 1)
+
+@ops.RegisterGradient("_FusedMulSub")
+def _FusedMulSubGrad(op, grad):
+  return _FusedMulAddSubGrad(op, grad, -1)
+
+@ops.RegisterGradient("_FusedMulSubRev")
+def _FusedMulSubRevGrad(op, grad):
+  return _FusedMulAddSubGrad(op, grad, 0)
+
+@ops.RegisterGradient("_FusedMulSub2")
+def _FusedMulSub2Grad(op, grad):
+  return _FusedMulAddSub2Grad(op, grad, -1)


### PR DESCRIPTION
This PR adds kernels for component-wise fused multiply-add and fused multiply-subtract and implements automatic fusion of multiplications and additions into FMAs.
It's motivated by the observation of large numbers of unfused component-wise multiply and add kernels in the profile of BERT. I estimate that it reduces the number of kernel launches per training step of BERT by as much as 20% (from ~5300 to ~4200) and increases the training speed by ~5%.