### PR TITLE
Switch to use ROCm 3.1

### DIFF
--- a/build_rocm
+++ b/build_rocm
@@ -20,7 +20,7 @@
 TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
 
-yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
 pip install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -20,7 +20,7 @@
 #TF_PKG_LOC=/tmp/tensorflow_pkg
 #rm -f $TF_PKG_LOC/tensorflow*.whl
 
-yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
 pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/build_rocm_verbs
+++ b/build_rocm_verbs
@@ -8,7 +8,7 @@
 #
 # press enter all the way
 #
-yes "" | TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python ./configure
 bazel build --config=opt --config=rocm --config=verbs --config=gdr //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg &&
 pip install --upgrade /tmp/tensorflow_pkg/tensorflow-1.12.0rc0-cp27-cp27m-linux_x86_64.whl

--- a/build_rocm_xla_python3
+++ b/build_rocm_xla_python3
@@ -20,7 +20,7 @@
 TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
 
-yes "" | TF_NEED_ROCM=1 TF_ENABLE_XLA=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 TF_NEED_ROCM=1 TF_ENABLE_XLA=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC &&
 pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -3,8 +3,8 @@
 FROM ubuntu:xenial
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
-ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/3.0/
-ARG ROCM_PATH=/opt/rocm
+ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/3.1/
+ARG ROCM_PATH=/opt/rocm-3.1.0
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TF_NEED_ROCM 1

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -32,7 +32,7 @@ export CC_OPT_FLAGS='-mavx'
 export TF_NEED_ROCM=1
 export TF_GPU_COUNT=${N_GPUS}
 
-yes "" | $PYTHON_BIN_PATH configure.py
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
 bazel test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -32,7 +32,7 @@ export CC_OPT_FLAGS='-mavx'
 export TF_NEED_ROCM=1
 export TF_GPU_COUNT=${N_GPUS}
 
-yes "" | $PYTHON_BIN_PATH configure.py
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
 bazel test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -32,7 +32,7 @@ export CC_OPT_FLAGS='-mavx'
 export TF_NEED_ROCM=1
 export TF_GPU_COUNT=${N_GPUS}
 
-yes "" | $PYTHON_BIN_PATH configure.py
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 $PYTHON_BIN_PATH configure.py
 
 # Run bazel test command. Double test timeouts to avoid flakes.
 bazel test \

--- a/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
+++ b/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
@@ -32,7 +32,7 @@ export CC_OPT_FLAGS='-mavx'
 export TF_NEED_ROCM=1
 export TF_GPU_COUNT=${N_GPUS}
 
-yes "" | $PYTHON_BIN_PATH configure.py
+yes "" | ROCM_TOOLKIT_PATH=/opt/rocm-3.1.0 $PYTHON_BIN_PATH configure.py
 echo "build --distinct_host_configuration=false" >> .tf_configure.bazelrc
 
 # Run bazel test command. Double test timeouts to avoid flakes.


### PR DESCRIPTION
Note that starting with ROCm 3.1, we need to account for "relocatable rocm" support.

Starting with ROCm 3.1 and going forward, everytime we change the ROCm version we will need to
* in `Dockerfile.rocm` 
  * update the pointer to ROCm repo (we already do this)
  * set ROCM_PATH to `/opt/rocm-<version>/` 
* in all the scripts that invoke `configure.py`
  * explicitly set `ROCM_TOOLKIT_PATH=/opt/rocm-<version>/`, before calling `configure.py`

`<version> == 3.1.0` for this PR