### PR TITLE
Workaround for SWDEV-225502

### DIFF
--- a/tensorflow/compiler/jit/xla_device_context.cc
+++ b/tensorflow/compiler/jit/xla_device_context.cc
@@ -279,4 +279,13 @@ se::Stream* XlaDeviceContext::GetDeviceToDeviceStream() {
   return device_to_device_stream(stream);
 }
 
+Status XlaDeviceContext::ThenExecute(Device* device, stream_executor::Stream* stream,
+                           std::function<void()> func) 
+{
+  VLOG(2) << "XlaDeviceContext::ThenExecute";
+  stream->ThenDoHostCallback(std::move(func));
+  return Status::OK();
+}
+
+
 }  // namespace tensorflow

--- a/tensorflow/compiler/jit/xla_device_context.h
+++ b/tensorflow/compiler/jit/xla_device_context.h
@@ -86,6 +86,9 @@ class XlaDeviceContext : public DeviceContext {
   // Returns a device-to-device stream, in round-robin fashion.
   se::Stream* GetDeviceToDeviceStream();
 
+  virtual Status ThenExecute(Device* device, stream_executor::Stream* stream,
+                             std::function<void()> func) override;
+
  private:
   bool UseMultipleStreams() const { return stream_ != host_to_device_stream_; }
 


### PR DESCRIPTION
This PR adds an explicit wait on callbacks as a workaround for the hipStreamAddCallback's failure to do same. 