### PR TITLE
TopK CUDA build fix

### DIFF
--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -331,7 +331,7 @@ __device__ void mergeShards(int num_shards, int k,
 }
 
 #if GOOGLE_CUDA
-__shared__ char shared_memory[];
+extern __shared__ char shared_memory[];
 #endif
 
 template <typename T>


### PR DESCRIPTION
This reverts an accidental change from #831 that broke develop-upstream on CUDA.