### PR TITLE
[cleanup] Removing the "linker option" from the hipcc command line.

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -26,10 +26,8 @@ import pipes
 
 # Template values set by rocm_configure.bzl.
 CPU_COMPILER = ('%{cpu_compiler}')
-GCC_HOST_COMPILER_PATH = ('%{gcc_host_compiler_path}')
 
 HIPCC_PATH = '%{hipcc_path}'
-PREFIX_DIR = os.path.dirname(GCC_HOST_COMPILER_PATH)
 HIPCC_ENV = '%{hipcc_env}'
 HIPCC_IS_HIPCLANG = '%{hipcc_is_hipclang}'=="True"
 HIP_RUNTIME_PATH = '%{hip_runtime_path}'
@@ -196,7 +194,6 @@ def InvokeHipcc(argv, log=False):
     depfile = depfiles[0]
     cmd = (HIPCC_PATH + ' ' + hipccopts +
            host_compiler_options +
-           ' ' + GCC_HOST_COMPILER_PATH +
            ' -I .' + includes + ' ' + srcs + ' -M -o ' + depfile)
     cmd = HIPCC_ENV.replace(';', ' ') + ' ' + cmd
     if log: Log(cmd)
@@ -207,13 +204,9 @@ def InvokeHipcc(argv, log=False):
 
   cmd = (HIPCC_PATH + ' ' + hipccopts +
          host_compiler_options + ' -fPIC' +
-         ' ' + GCC_HOST_COMPILER_PATH +
          ' -I .' + opt + includes + ' -c ' + srcs + out)
 
-  # TODO(zhengxq): for some reason, 'gcc' needs this help to find 'as'.
-  # Need to investigate and fix.
-  cmd = 'PATH=' + PREFIX_DIR + ':$PATH '\
-        + HIPCC_ENV.replace(';', ' ') + ' '\
+  cmd = HIPCC_ENV.replace(';', ' ') + ' '\
         + cmd
   if log: Log(cmd)
   if VERBOSE: print(cmd)


### PR DESCRIPTION
Currently we add the gcc compiler (full path to it) as one of the command line arguments to the hipcc command invoked by the crosstool wrapper.

When the underlying compiler is hipclang it leads to the generation of the following warning (one for each hipcc command!)

```
clang-11: warning: /usr/bin/gcc: 'linker' input unused [-Wunused-command-line-argument]
```

So the option seems redundant for the hipclang (is the underlying hip compiler)

My assumption is that this option is redundant on the hcc side too. My local build completes successfully, and will use the PR to run all CI unit tests.

------------

/cc @whchung @sunway513 

Assuming all the CI tests pass, should I take this PR? Does anyone remember why have this option on the hipcc command line to begin with? thanks
