### PR TITLE
Populating memory bandwidth information in the DeviceDescription

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -892,6 +892,11 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
 
     float clock_rate_ghz = static_cast<float>(prop.clockRate) / 1e6;
     builder.set_clock_rate_ghz(clock_rate_ghz);
+
+    // mem_bandwidth = 2 * mem_bus_width_in_bytes * mem_clock_rate_in_hz
+    int64 memory_bandwidth = 2 * (int64(prop.memoryBusWidth) / 8) *
+                             (int64(prop.memoryClockRate) * 1000);
+    builder.set_memory_bandwidth(memory_bandwidth);
   }
 
   {


### PR DESCRIPTION
Populating memory bandwidth information in the DeviceDescription, using information from the call to hipGetDeviceProperties

/cc @sunway513 @ekuznetsov139 