### PR TITLE
BERT-motivated XLA enhancements

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.h
@@ -138,7 +138,7 @@ class GpuExecutable : public Executable {
   // compute_capability_.
   //
   // May be empty, in which case we leave compilation up to the GPU driver.
-  const std::vector<uint8> binary_;
+  std::vector<uint8> binary_;
 
   // The GPU version for compute compatibility check.
   GpuVersion gpu_version_;

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1310,6 +1310,17 @@ Status IrEmitterUnnested::HandleAfterAll(HloInstruction* after_all) {
   return Status::OK();
 }
 
+struct HloPtrAndShapeComparator {
+  bool operator()(
+      const std::pair<const HloInstruction*, ShapeIndex>& lhs,
+      const std::pair<const HloInstruction*, ShapeIndex>& rhs) const {
+    if (lhs.first != rhs.first)
+      return HloPtrComparator()(lhs.first, rhs.first);
+    else
+      return lhs.second < rhs.second;
+  }
+};
+
 // Figures out how to access the buffers for all subshapes of hlo's operands and
 // for hlo itself (i.e. all the buffers produced by HLO).
 //
@@ -1327,11 +1338,13 @@ Status IrEmitterUnnested::HandleAfterAll(HloInstruction* after_all) {
 // This function conservatively assumes that we'll touch all sub-buffers of
 // every operand and of the output.
 static std::map<std::pair<const HloInstruction*, ShapeIndex>,
-                std::pair<BufferAllocation::Slice, ShapeIndex>>
+                std::pair<BufferAllocation::Slice, ShapeIndex>,
+                HloPtrAndShapeComparator>
 GetHloBufferSlices(const HloInstruction* hlo,
                    const BufferAssignment& buffer_assn) {
   std::map<std::pair<const HloInstruction*, ShapeIndex>,
-           std::pair<BufferAllocation::Slice, ShapeIndex>>
+           std::pair<BufferAllocation::Slice, ShapeIndex>,
+           HloPtrAndShapeComparator>
       slices;
 
   // Tries to find a slice plus an array of indices i1, ..., iN such that the
@@ -1429,9 +1442,7 @@ std::unique_ptr<KernelThunk> IrEmitterUnnested::BuildKernelThunk(
   const BufferAssignment& buffer_assn =
       ir_emitter_context_->buffer_assignment();
 
-  std::map<std::pair<const HloInstruction*, ShapeIndex>,
-           std::pair<BufferAllocation::Slice, ShapeIndex>>
-      hlo_slices = GetHloBufferSlices(inst, buffer_assn);
+  auto hlo_slices = GetHloBufferSlices(inst, buffer_assn);
 
   // Figure out which buffer allocations need to be passed as arguments to our
   // kernel.  This is simply all of the allocations referenced in hlo_slices,


### PR DESCRIPTION
This PR does the following.

- It creates a HSACO cache, which allows the compiler not to rerun LLVM when it is repeatedly asked to compile the same IR over and over
- It fixes an existing problem where temporary files were not deleted from /tmp after compilation
- It eliminates a source of randomness that previously resulted in the compiler generating different IRs for the same HLO from run to run

All these changes together bring the XLA compilation time for BERT under 1 minute (from 3-5 minutes).
