### PR TITLE
port to r2.1 - Fix for JIRA Issue SWDEV-212838

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -282,6 +282,10 @@ bool IsCpuCompatible(const RemapperContext& ctx, const Pattern& matched) {
 // Checks if we can rewrite a pattern to the `_FusedConv2D` on GPU device.
 bool IsGpuCompatible(const RemapperContext& ctx,
                      const ContractionWithBiasAddAndActivation& matched) {
+#if TENSORFLOW_USE_ROCM
+  // _FusedConv2D is not currently supported on the ROCm platform
+  return false;
+#endif
   const GraphDef* graph = ctx.graph_view.graph();
   const NodeDef& contraction_node = graph->node(matched.contraction);
   if (!IsConv2D(contraction_node)) return false;


### PR DESCRIPTION
TF graph optimizer will (sometimes) create _FusedConv2D nodes (which is fusion of Conv2D + [BiasAdd, Relu]).
The runtime implementation for these _FusedConv2D nodes is CUDA specific, and cannot be supported on ROCm.

So for ROCm, we need to ensure these _FusedConv2D* graph optimizations are disabled