### PR TITLE
Fix for a hipclang build issue

### DIFF
--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -170,6 +170,13 @@ GpuLaunchConfig GetGpuLaunchConfig(int work_element_count,
 #elif TENSORFLOW_USE_ROCM
   // Earlier versions of this HIP routine incorrectly returned void.
   // TODO re-enable hipError_t error checking when HIP is fixed.
+#if TENSORFLOW_COMPILER_IS_HIP_CLANG
+  // ROCm 3.5 (hipclang) and above have the same interface as CUDA
+  // no need anymore for the unsigned int conversions
+  hipOccupancyMaxPotentialBlockSize(&block_count, &thread_per_block, func,
+                                    dynamic_shared_memory_size,
+                                    block_size_limit);
+#else
   // ROCm interface uses unsigned int, convert after checking
   uint32_t block_count_uint = 0;
   uint32_t thread_per_block_uint = 0;
@@ -180,6 +187,7 @@ GpuLaunchConfig GetGpuLaunchConfig(int work_element_count,
                                     block_size_limit_uint);
   block_count = static_cast<int>(block_count_uint);
   thread_per_block = static_cast<int>(thread_per_block_uint);
+#endif
 #endif
 
   block_count =


### PR DESCRIPTION
TF build on ROCm 3.5 (hipclang) is running in to the following error

```
./tensorflow/core/util/gpu_launch_config.h:178:3: error: no matching function for call to 'hipOccupancyMaxPotentialBlockSize'
  hipOccupancyMaxPotentialBlockSize(&block_count_uint, &thread_per_block_uint,
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ./tensorflow/core/kernels/depthwise_conv_op_gpu.h:753:7: note: in instantiation of function template specialization 'tensorflow::GetGpuLaunchConfig<void (*)(tensorflow::DepthwiseArgs, const Eigen::half *, const Eigen::half *, Eigen::half *, int)>' requested here
      GetGpuLaunchConfig(num_outputs, device, kernel, 0, 0);
      ^
./tensorflow/core/kernels/depthwise_conv_op_gpu.h:777:12: note: in instantiation of function template specialization 'tensorflow::LaunchDepthwiseConv2dGPU<Eigen::half, 3, 3, 1>' requested here
    return LaunchDepthwiseConv2dGPU<T, kKnownFilterWidth, kKnownFilterHeight,
           ^
./tensorflow/core/kernels/depthwise_conv_op_gpu.h:795:25: note: in instantiation of function template specialization 'tensorflow::LaunchDepthwiseConv2dGPU<Eigen::half, 3, 3>' requested here
    OP_REQUIRES_OK(ctx, LaunchDepthwiseConv2dGPU<T, 3, 3>(
                        ^
/opt/rocm/hip/include/hip/hcc_detail/hip_runtime_api.h:3800:19: note: candidate function template not viable: no known conversion from 'uint32_t *' (aka 'unsigned int *') to 'int *' for 1st argument
inline hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
                  ^
/opt/rocm/hip/include/hip/hcc_detail/hip_runtime_api.h:3559:35: note: candidate function template not viable: no known conversion from 'uint32_t *' (aka 'unsigned int *') to 'int *' for 1st argument
static hipError_t __host__ inline hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
                                  ^
/opt/rocm/hip/include/hip/hcc_detail/hip_runtime_api.h:3089:12: note: candidate function not viable: no known conversion from 'uint32_t *' (aka 'unsigned int *') to 'int *' for 1st argument
hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
           ^
```

The cause is change in the signature of the "hipOccupancyMaxPotentialBlockSize" API. It now has the same interface as CUDA, and we no longer need to do the uint32 <--> int32 conversions that we have in place currently.