### PR TITLE
[r1.15-rocm] Fix for a hipclang build error

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -308,7 +308,7 @@ def _hipcc_is_hipclang(repository_ctx,rocm_config):
         ["grep", "HIP_COMPILER=clang", rocm_config.rocm_toolkit_path + "/hip/lib/.hipInfo"],
         empty_stdout_fine = True,
     )
-    result = grep_result.stdout
+    result = grep_result.stdout.strip()
     if result == "HIP_COMPILER=clang":
         return "True"
     return "False"


### PR DESCRIPTION
The grep command to search for `HIP_COMPILER=clang` in the `$ROCM_PATH/hip/lib/.hipInfo` file was not stripping out the leading/trailing whitespaces in the result, which resulted in the `_hipcc_is_hipclang` function incorrectly returning false.


/cc @sunway513 