### PR TITLE
Memory broadcast copy

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -1816,6 +1816,36 @@ bool ROCMBlas::DoBlasGemmWithAlgorithm(
   return false;
 }
 
+struct memory_copy_op {
+  char* src_ptr;
+  char* dst_ptr;
+  uint64_t size;
+  uint64_t count;
+  uint64_t dst_stride;
+};
+
+static bool fold(memory_copy_op& y, const memory_copy_op& x) {
+  bool misaligned = (x.size & 3) ||
+                    (reinterpret_cast<uint64_t>(x.dst_ptr) & 3) ||
+                    (reinterpret_cast<uint64_t>(x.src_ptr) & 3) ||
+                    (reinterpret_cast<uint64_t>(y.dst_ptr) & 3) ||
+                    (reinterpret_cast<uint64_t>(y.src_ptr) & 3);
+  int64_t dst_step = reinterpret_cast<int64_t>(x.dst_ptr) -
+                     reinterpret_cast<int64_t>(y.dst_ptr);
+  if (x.src_ptr == y.src_ptr && x.size == y.size &&
+      (y.count == 1 || x.dst_ptr == y.dst_ptr + y.count * y.dst_stride) &&
+      !misaligned && !(dst_step & 3)) {
+    if (y.count == 1) y.dst_stride = dst_step;
+    y.count++;
+    return true;
+  } else if (x.src_ptr == y.src_ptr + y.size &&
+             x.dst_ptr == y.dst_ptr + y.size && y.count == 1) {
+    y.size += x.size;
+    return true;
+  }
+  return false;
+}
+
 // This copies from source memory: raw_ptrs[i] to target memory:
 // device_memory_ptr at the interval of matrix_byte_size, or vice versa. 
 // The below algorithm tries to minimize the number of memcpy by consolidating neighboring
@@ -1827,76 +1857,41 @@ port::Status ReorganizeMemory(Stream* stream,
     int batch_count, uint64_t batch_stride,
     bool gather)
 {
+  if (gather == false)
+    return port::Status(port::error::INTERNAL, "gather=false unsupported");
   assert(batch_count > 0);
   char *device_memory_ptr = static_cast<char *>(device_memory->opaque());
   char* src_ptr = reinterpret_cast<char*>(raw_ptrs[0]);
   char* dst_ptr = device_memory_ptr;
-  size_t matrix_byte_size = batch_stride * sizeof(MAPPED_T);  
-  uint64_t cur_stride_size = matrix_byte_size;
+  size_t matrix_byte_size = batch_stride * sizeof(MAPPED_T);
 
-  struct memory_copy_op {
-    char* src_ptr;
-    char* dst_ptr;
-    uint64_t size;
-  };
-  std::vector<memory_copy_op> write_ops;
-
+  std::vector<memory_copy_op> ops;
+  ops.push_back(memory_copy_op{src_ptr, dst_ptr, matrix_byte_size, 1, 0});
   for (int i = 1; i < batch_count; ++i) {
-    if (reinterpret_cast<char*>(raw_ptrs[i]) == src_ptr + cur_stride_size) {
-      cur_stride_size += matrix_byte_size;
-    } else {
-      write_ops.push_back(memory_copy_op{src_ptr, dst_ptr, cur_stride_size});
-      src_ptr = reinterpret_cast<char*>(raw_ptrs[i]);
-      dst_ptr = device_memory_ptr + i * matrix_byte_size;
-      cur_stride_size = matrix_byte_size;
-    }
+    memory_copy_op& op = ops.back();
+    src_ptr = reinterpret_cast<char*>(raw_ptrs[i]);
+    dst_ptr = device_memory_ptr + i * matrix_byte_size;
+
+    memory_copy_op x{src_ptr, dst_ptr, matrix_byte_size, 1, 0};
+    if (fold(op, x)) continue;
+    if (ops.size() > 1 && fold(ops[ops.size() - 2], op)) ops.pop_back();
+    ops.push_back(x);
   }
-  write_ops.push_back(memory_copy_op{src_ptr, dst_ptr, cur_stride_size});
-
-  bool misaligned = (write_ops[0].size & 3)
-    || (reinterpret_cast<uint64_t>(write_ops[0].dst_ptr) & 3)
-    || (reinterpret_cast<uint64_t>(write_ops[0].src_ptr) & 3)
-    || (write_ops.size()>1 
-      && (reinterpret_cast<uint64_t>(write_ops[1].dst_ptr) & 3))
-    ;
-
-  // if the requested operation is reducible to a broadcast (copying the same
-  // buffer multiple times to N uniformly distributed destinations), it's often
-  // more efficient to launch a single broadcast kernel than to launch N
-  // hipMemcpy's.
-  // On tested hardware, broadcast with N>1 is always faster than memcpy (since
-  // it needs fewer global loads), but the gains are highest with lots (>10) of
-  // small copies (<1MB each).
-  if ((write_ops.size() > 1) && !misaligned) {
-    bool is_broadcast = true;
-    int stride = write_ops[1].dst_ptr - write_ops[0].dst_ptr;
-    for (int i = 1; i < write_ops.size(); i++) {
-      if (write_ops[i].src_ptr != write_ops[0].src_ptr ||
-          write_ops[i].size != write_ops[0].size ||
-          write_ops[i].dst_ptr - write_ops[i - 1].dst_ptr != stride ||
-          write_ops[i].size < stride
-          ) {
-        is_broadcast = false;
-        break;
-      }
-    }
-    if (is_broadcast && !(stride & 3)) {
+  if (ops.size() > 1 && fold(ops[ops.size() - 2], ops.back())) ops.pop_back();
+  for (auto& x : ops) {
+    if (x.count > 1) {
       broadcast_fp32(AsGpuStreamValue(stream),
-                     reinterpret_cast<float*>(write_ops[0].dst_ptr),
-                     stride >> 2, write_ops.size(),
-                     reinterpret_cast<float*>(write_ops[0].src_ptr),
-                     write_ops[0].size >> 2);
-      return port::Status::OK();
-    }
-  }
-  for (auto& x : write_ops) {
-    DeviceMemoryBase src_mem = DeviceMemoryBase(x.src_ptr, x.size);
-    DeviceMemoryBase target_mem = DeviceMemoryBase(x.dst_ptr, x.size);
-    bool a_status = stream->ThenMemcpy(&target_mem, src_mem, x.size).ok();
-    if (!a_status) {
-      return port::Status(
-          port::error::INTERNAL,
-          "failed to copy device memory in ROCMBlas::DoBlasGemmBatched");
+                     reinterpret_cast<float*>(x.dst_ptr), x.dst_stride >> 2,
+                     x.count, reinterpret_cast<float*>(x.src_ptr), x.size >> 2);
+    } else {
+      DeviceMemoryBase src_mem = DeviceMemoryBase(x.src_ptr, x.size);
+      DeviceMemoryBase target_mem = DeviceMemoryBase(x.dst_ptr, x.size);
+      bool a_status = stream->ThenMemcpy(&target_mem, src_mem, x.size).ok();
+      if (!a_status) {
+        return port::Status(
+            port::error::INTERNAL,
+            "failed to copy device memory in ROCMBlas::DoBlasGemmBatched");
+      }
     }
   }
   return port::Status::OK();

--- a/tensorflow/stream_executor/rocm/rocm_blas.h
+++ b/tensorflow/stream_executor/rocm/rocm_blas.h
@@ -121,7 +121,7 @@ class ROCMBlas : public blas::BlasSupport {
       std::unique_ptr<TemporaryDeviceMemory<
           typename RocBlasTypeConversionHelper<T>::mapped_type>> *temp_memory,
       DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>
-          *device_memory);
+          *device_memory, bool copy_data, bool& reallocated);
 
   // A helper function to implement DoBlasGemmBatched interfaces for generic
   // types.


### PR DESCRIPTION
The broadcast fix was incorrectly merged into 1.15 and was effectively disabled. This PR takes care of the problem.