### PR TITLE
Pass some env vars through MLIR

### DIFF
--- a/tensorflow/compiler/mlir/runlit.cfg.py
+++ b/tensorflow/compiler/mlir/runlit.cfg.py
@@ -65,6 +65,11 @@ llvm_config.config.substitutions.append(
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
+for key in ['HIP_VISIBLE_DEVICES', 'CUDA_VISIBLE_DEVICES', 'TF_PER_DEVICE_MEMORY_LIMIT_MB']:
+   value = os.environ.get(key, None)
+   if value!=None:
+     llvm_config.with_environment(key, value)
+
 tool_dirs = config.mlir_tf_tools_dirs + [
     config.mlir_tools_dir, config.llvm_tools_dir
 ]


### PR DESCRIPTION
This passes some environment variables from the caller's environment to the MLIR subprocess. If it's not done, the subprocess does not respect settings like HIP_VISIBLE_DEVICES and it ends up interfering with other concurrently running processes (e.g. running a MLIR-related unit test may cause other unit tests running at the same time to fail with OOMs.)