### PR TITLE
Add "rocm/include/roctracer" to the list of system include dirs.

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -21,6 +21,7 @@ cc_library(
         ".",
         "rocm/include",
         "rocm/include/rocrand",
+        "rocm/include/roctracer",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Building TF with ROCm3.5-rc1 runs into the following error

```
Execution platform: @local_execution_config_platform//:platform
In file included from ./tensorflow/core/profiler/internal/gpu/rocm_tracer.h:23:0,
                 from tensorflow/core/profiler/internal/gpu/rocm_tracer.cc:16:
bazel-out/k8-opt/bin/external/local_config_rocm/rocm/rocm/include/roctracer/roctracer_hcc.h:43:23: fatal error: roctracer.h: No such file or directory
compilation terminated.
Target //tensorflow/tools/pip_package:build_pip_package failed to build
```

The error is caused because the following change in the roctracer_hcc.h file

ROCm 3.3 version : `#include "roctracer.h"`
ROCm 3.5 version : `#include <roctracer.h>`

In order to accomodate this change, we need to add "rocm/include/roctracer" to list of system include dirs. This is not the ideal fix (think that would be to revert the change in roctracer), but will have to do for now


----------------------------

/cc @sunway513 @whchung @jerryyin @ekuznetsov139 