### PR TITLE
Fixing XLA convolution without autotune

### DIFF
--- a/tensorflow/compiler/xla/tests/BUILD
+++ b/tensorflow/compiler/xla/tests/BUILD
@@ -1103,7 +1103,6 @@ xla_test(
     srcs = ["convolution_test.cc"],
     shard_count = 40,
     tags = [
-        "no_rocm",
         "nozapfhahn",
         "optonly",
     ],
@@ -1124,7 +1123,6 @@ xla_test(
     backends = ["gpu"],
     shard_count = 40,
     tags = [
-        "no_rocm",
         "optonly",
     ],
     deps = CONVOLUTION_TEST_DEPS + [
@@ -1140,9 +1138,6 @@ xla_test(
     backend_args = {"gpu": ["--xla_backend_extra_options=xla_gpu_experimental_conv_disable_layout_heuristic"]},
     backends = ["gpu"],
     shard_count = 25,
-    tags = [
-        "no_rocm",
-    ],
     deps = CONVOLUTION_TEST_DEPS + [
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",


### PR DESCRIPTION
When convolution is used through XLA without autotune, TF expects the first call to DoConvolve to figure out the amount of needed scratch memory on its own (but does not provide an allocator that we could use to allocate that memory).  

This ensures that scratch memory is allocated correctly, which fixes tests //tensorflow/compiler/xla/tests:convolution_test_... .


