### PR TITLE
update the tensorflow rocm release wheel package doc

### DIFF
--- a/rocm_docs/tensorflow-rocm-release.md
+++ b/rocm_docs/tensorflow-rocm-release.md
@@ -7,8 +7,12 @@ This document is to list the ROCm compatibility for tensorflow-rocm release pack
 
 | tensorflow-rocm |  ROCm base  |  Installation Instruction  |
 | ------ | ------ |  -------- |
-|   2.2.0RC3  | ROCm3.3  | <https://pypi.org/project/tensorflow-rocm/2.2.0rc3> |
-|   2.2.0RC2  | ROCm3.3  | <https://pypi.org/project/tensorflow-rocm/2.2.0rc2> |
+|   2.2.0  | ROCm3.5  | <https://pypi.org/project/tensorflow-rocm/2.2.0> |
+|   2.2.0RC5  | ROCm3.3  | <https://pypi.org/project/tensorflow-rocm/2.2.0rc5> |
+|   2.2.0RC4  | ROCm3.0  | <https://pypi.org/project/tensorflow-rocm/2.2.0rc4> |
+|   2.2.0RC3  | ROCm3.0  | <https://pypi.org/project/tensorflow-rocm/2.2.0rc3> |
+|   2.2.0RC2  | ROCm3.0  | <https://pypi.org/project/tensorflow-rocm/2.2.0rc2> |
+|   2.1.2  | ROCm3.5  | <https://pypi.org/project/tensorflow-rocm/2.1.2> |
 |   2.1.1  | ROCm3.3  | <https://pypi.org/project/tensorflow-rocm/2.1.1> |
 |   2.1.0  | ROCm3.1  | <https://pypi.org/project/tensorflow-rocm/2.1.0> |
 |   2.1.0RC1  | ROCm3.0  | <https://pypi.org/project/tensorflow-rocm/2.1.0rc1> |
@@ -21,6 +25,7 @@ This document is to list the ROCm compatibility for tensorflow-rocm release pack
 |   2.0.0b3    |   ROCm2.7     | <https://pypi.org/project/tensorflow-rocm/2.0.0b3> |
 |   2.0.0b2    |   ROCm2.6     | <https://pypi.org/project/tensorflow-rocm/2.0.0b2> |
 |   2.0.0b1    |  ROCm2.6    | <https://pypi.org/project/tensorflow-rocm/2.0.0b1> |
+|   1.15.4    |  ROCm3.5      | <https://pypi.org/project/tensorflow-rocm/1.15.4> |
 |   1.15.3    |  ROCm3.3      | <https://pypi.org/project/tensorflow-rocm/1.15.3> |
 |   1.15.2    |  ROCm3.1      | <https://pypi.org/project/tensorflow-rocm/1.15.2> |
 |   1.15.1    |  ROCm3.0      | <https://pypi.org/project/tensorflow-rocm/1.15.1> |


### PR DESCRIPTION
This PR updates the wheel packages build with ROCm3.5 user bits. 