### PR TITLE
Fix for XLA "scatter" op related unit test failures.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -981,8 +981,10 @@ Status IrEmitterUnnested::EmitScatter(
     llvm::Value* output_address =
         GetIrArray(*output_hlo, *output_hlo)
             .EmitArrayElementAddress(input_window_index, &b_);
-    llvm::Value* input_address = Alloca(llvm_ir::PrimitiveTypeToIrType(
-        updates->shape().element_type(), module_));
+    llvm::Value* input_address = llvm_ir::EmitAllocaAtFunctionEntry(
+        llvm_ir::PrimitiveTypeToIrType(updates->shape().element_type(),
+                                       module_),
+        "input_address", &b_);
     TF_ASSIGN_OR_RETURN(llvm::Value* const input_ir_value, updates_gen(index));
     Store(input_ir_value, input_address);
 

--- a/tensorflow/python/keras/optimizer_v2/BUILD
+++ b/tensorflow/python/keras/optimizer_v2/BUILD
@@ -118,9 +118,6 @@ cuda_py_test(
         "//tensorflow/python/eager:context",
         "//tensorflow/python/keras:combinations",
     ],
-    tags = [
-        "no_rocm",
-    ],
 )
 
 cuda_py_test(


### PR DESCRIPTION
After the upstream commit 4de4c60972da38d09662842614ad4dcfd019a6be, the following unit-test started failing

```
//tensorflow/python/keras/optimizer_v2:adam_test_gpu
```

The cause seems to be a change in the commit above that updates the LLVM version in use.

@whchung looked into this issue, and proposed the changing IR generation for "scatter" op to ensure that the alloca instruction gets emitted in the entry basic block of the function. Making that change seems to fix the regression test failure.

I do not yet understand, why the change in LLVM version resulted in the above unit test failure, given that the LLVM IR generated is the same in passing and failing cases. Guessing there was some change in the ISA generated for AMDGPUs, and that change has some assumptions built-in related to alloca instructions being only present in the entry basic block of the function

-----------------------------

@ekuznetsov139  just FYI

This change also seems to fix the XLA unit test failures that I am getting in my CI runs for PR #997

The symptoms for the two failures are related (alloca instruction in the LLVM IR for the "scatter" op, which is not in the entry basic block of the function), and hence the assumption that this is the same bug.

The intermitently failing tests in the CI runs were

```
//tensorflow/compiler/xla/tests:scatter_test_gpu
//tensorflow/compiler/tests:scatter_nd_op_test_gpu
```

Both of them pass for locally (and consistently) after this fix...hopefully the CI runs will pass too.

------------------------------

Details on how to isolate the change the causes the `//tensorflow/python/keras/optimizer_v2:adam_test_gpu` testcase to fail

build TF using the commit a1ae008076e14f7e445abf2605759779d2a1fb8b (which is the parent commit of 4de4c60972da38d09662842614ad4dcfd019a6be), and run the unit test...it should pass.

The commit 4de4c60972da38d09662842614ad4dcfd019a6be has several changes in it (in addition to the LLVM version change), so apply the following patch to pick up just the LLVM version change

```diff
root@prj47-rack-37:/root/tensorflow# git diff
diff --git a/tensorflow/workspace.bzl b/tensorflow/workspace.bzl
index bf64405..15fd1f7 100755
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -655,8 +655,8 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
     )

     # Check out LLVM and MLIR from llvm-project.
-    LLVM_COMMIT = "cf86a234ba86acf0bb875e21d27833be36e08be4"
-    LLVM_SHA256 = "5375bdcdabd4886ab86eddfddef6e21dbc3cac9df67af7d3c44fadb527f74e25"
+    LLVM_COMMIT = "b726d071b4aa46004228fc38ee5bfd167f999bfe"
+    LLVM_SHA256 = "d7e67036dc89906cb2f80df7b0b7de6344d86eddf6e98bb4d01a578242889a73"
     LLVM_URLS = [
         "https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
         "https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
diff --git a/third_party/mlir/BUILD b/third_party/mlir/BUILD
index df875eb..624f17e 100644
--- a/third_party/mlir/BUILD
+++ b/third_party/mlir/BUILD
@@ -1176,28 +1176,6 @@ cc_library(
     ],
 )

-cc_library(
-    name = "GPURuntimeTransforms",
-    srcs = [
-        "lib/Conversion/GPUCommon/ConvertLaunchFuncToRuntimeCalls.cpp",
-        "lib/Conversion/PassDetail.h",
-    ],
-    hdrs = [
-        "include/mlir/Conversion/GPUCommon/GPUCommonPass.h",
-    ],
-    includes = ["include"],
-    deps = [
-        ":ConversionPassIncGen",
-        ":GPUDialect",
-        ":IR",
-        ":LLVMDialect",
-        ":Pass",
-        ":Support",
-        "@llvm-project//llvm:core",
-        "@llvm-project//llvm:support",
-    ],
-)
-
 gentbl(
     name = "GPUToNVVMGen",
     strip_include_prefix = "lib/Conversion/GPUToNVVM",
@@ -1307,12 +1285,13 @@ cc_library(
 )

 cc_library(
-    name = "GPUToCUDATransforms",
+    name = "GPUToGPURuntimeTransforms",
     srcs = [
-        "lib/Conversion/GPUToCUDA/ConvertKernelFuncToCubin.cpp",
+        "lib/Conversion/GPUCommon/ConvertKernelFuncToBlob.cpp",
+        "lib/Conversion/GPUCommon/ConvertLaunchFuncToRuntimeCalls.cpp",
         "lib/Conversion/PassDetail.h",
     ],
-    hdrs = ["include/mlir/Conversion/GPUToCUDA/GPUToCUDAPass.h"],
+    hdrs = ["include/mlir/Conversion/GPUCommon/GPUCommonPass.h"],
     includes = ["include"],
     deps = [
         ":ConversionPassIncGen",
@@ -2490,7 +2469,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":Analysis",
-        ":GPURuntimeTransforms",
+        ":GPUToGPURuntimeTransforms",
         ":GPUToNVVMTransforms",
         ":GPUToROCDLTransforms",
         ":GPUToSPIRVTransforms",
@@ -2570,8 +2549,7 @@ cc_library(
         ":ConversionPassIncGen",
         ":GPUDialect",
         ":GPUPassIncGen",
-        ":GPURuntimeTransforms",
-        ":GPUToCUDATransforms",
+        ":GPUToGPURuntimeTransforms",
         ":GPUToNVVMTransforms",
         ":GPUToROCDLTransforms",
         ":GPUToSPIRVTransforms",
@@ -2776,7 +2754,7 @@ cc_binary(
         ":AllPassesAndDialectsNoRegistration",
         ":ExecutionEngineUtils",
         ":GPUDialect",
-        ":GPURuntimeTransforms",
+        ":GPUToGPURuntimeTransforms",
         ":GPUToNVVMTransforms",
         ":GPUToROCDLTransforms",
         ":GPUTransforms",
@@ -2786,6 +2764,7 @@ cc_binary(
         ":MlirJitRunner",
         ":NVVMDialect",
         ":Pass",
+        ":TargetNVVMIR",
         ":Transforms",
         "//devtools/build/runtime:get_runfiles_dir",
         "//third_party/gpus/cuda:cuda_headers",
diff --git a/third_party/mlir/test.BUILD b/third_party/mlir/test.BUILD
index 24b310f..9b6cb28 100644
--- a/third_party/mlir/test.BUILD
+++ b/third_party/mlir/test.BUILD
@@ -158,7 +158,7 @@ cc_library(
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:EDSC",
         "@llvm-project//mlir:GPUDialect",
-        "@llvm-project//mlir:GPUToCUDATransforms",
+        "@llvm-project//mlir:GPUToGPURuntimeTransforms",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",
@@ -167,6 +167,8 @@ cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TargetNVVMIR",
+        "@llvm-project//mlir:TargetROCDLIR",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorOps",
```

Re-run the unit test, and it will fail.