### PR TITLE
Adding ROCm FUSION ops to the AMP whitelist/graylist. 

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -100,6 +100,9 @@ class AutoMixedPrecisionLists {
       list.insert("Conv3DBackpropInput");
       list.insert("Conv3DBackpropInputV2");
     }
+#if TENSORFLOW_USE_ROCM
+      list.insert("_ROCmFusedConvolutionBiasActivation");
+#endif
     UpdateList(&list, to_add, to_remove);
     return list;
   }
@@ -162,6 +165,19 @@ class AutoMixedPrecisionLists {
         "Tanh",
         "TanhGrad",
     };
+#if TENSORFLOW_USE_ROCM
+      list.insert("_FusedMulAdd");
+      list.insert("_FusedMulAdd2");
+      list.insert("_FusedMulSub");
+      list.insert("_FusedMulSub2");
+      list.insert("_FusedMulSubRev");
+      list.insert("_ROCmFusedAddRelu");
+      list.insert("_ROCmFusedAddNReluGrad");
+      list.insert("_ROCmFusedBatchNormActivationForward");
+      list.insert("_ROCmFusedBatchNormActivationInference");
+      list.insert("_ROCmFusedBatchNormActivationBackward");
+      list.insert("_ROCmFusedConvolutionBiasBatchNormActivation");
+#endif
     UpdateList(&list, to_add, to_remove);
     return list;
   }


### PR DESCRIPTION
By default the ROCm FUSION ops are not considered AMP eligible, and hence they are computed in FP32 even with AMP enabled. Adding the ROCm FUSION ops to the AMP whitelist / graylist, will enable those ops to the computed in FP16 where appropriate.


/cc @ekuznetsov139 