### PR TITLE
Fix for the roctracer related segfault - HipApiActivityEnableCheck() 

### DIFF
--- a/tensorflow/cc/profiler/BUILD
+++ b/tensorflow/cc/profiler/BUILD
@@ -10,7 +10,6 @@ tf_cuda_cc_test(
     srcs = ["profiler_test.cc"],
     tags = [
         "no_cuda",  # b/77649654
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     deps = [
         ":profiler",

--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1585,7 +1585,6 @@ cuda_py_test(
     shard_count = 5,
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     xla_enable_strict_auto_jit = False,
     xla_enabled = True,
@@ -1610,7 +1609,6 @@ cuda_py_test(
     srcs = ["dense_layer_test.py"],
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     xla_enable_strict_auto_jit = False,
     xla_enabled = True,

--- a/tensorflow/core/grappler/costs/BUILD
+++ b/tensorflow/core/grappler/costs/BUILD
@@ -88,9 +88,6 @@ tf_cc_test(
     srcs = ["graph_properties_test.cc"],
     args = ["--heap_check=local"],  # The GPU tracer leaks memory
     data = [":graph_properties_testdata"],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":graph_properties",
         "//tensorflow/cc:cc_ops",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -7991,9 +7991,6 @@ tf_cc_test(
     srcs = [
         "remote_fused_graph_execute_utils_test.cc",
     ],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":cwise_op",
         ":remote_fused_graph_execute_op_test_utils",
@@ -8019,9 +8016,6 @@ tf_cc_test(
     size = "small",
     srcs = [
         "remote_fused_graph_execute_op_test.cc",
-    ],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     deps = [
         ":ops_testutil",
@@ -8062,9 +8056,6 @@ tf_cc_test(
     name = "remote_fused_graph_rewriter_transform_test",
     size = "small",
     srcs = ["remote_fused_graph_rewriter_transform_test.cc"],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":remote_fused_graph_execute_op_test_utils",
         ":remote_fused_graph_execute_utils",

--- a/tensorflow/core/kernels/hexagon/BUILD
+++ b/tensorflow/core/kernels/hexagon/BUILD
@@ -20,9 +20,6 @@ tf_cc_test(
         "hexagon_graph_execution_test.cc",
     ],
     data = ["//tensorflow/core/example:example_parser_configuration_testdata"],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":graph_transferer",
         "//tensorflow/cc:cc_ops",
@@ -101,9 +98,6 @@ tf_cc_test(
     name = "hexagon_rewriter_transform_test",
     size = "small",
     srcs = ["hexagon_rewriter_transform_test.cc"],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":graph_transferer",
         ":hexagon_rewriter_transform",

--- a/tensorflow/core/profiler/internal/gpu/BUILD
+++ b/tensorflow/core/profiler/internal/gpu/BUILD
@@ -68,7 +68,6 @@ tf_cc_test_gpu(
     tags = tf_cuda_tests_tags() + [
         "nomac",
         "gpu_cupti",
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     deps = [
         ":device_tracer",

--- a/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
@@ -937,6 +937,12 @@ void RocmTracer::Enable(const RocmTracerOptions& options,
   collector_ = collector;
   api_cb_impl_ = new RocmApiCallbackImpl(options, this, collector);
   activity_cb_impl_ = new RocmActivityCallbackImpl(options, this, collector);
+
+  // From ROCm 3.5 onwards, the following call is required.
+  // don't quite know what it does (no documentation!), only that without it
+  // the call to enable api/activity tracing will run into a segfault
+  roctracer_set_properties(ACTIVITY_DOMAIN_HIP_API, NULL);
+
   EnableApiTracing().IgnoreError();
   EnableActivityTracing().IgnoreError();
   LOG(INFO) << "GpuTracer started";

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -586,9 +586,6 @@ tf_cc_tests(
         "//conditions:default": [],
     }),
     linkstatic = tf_kernel_tests_linkstatic(),
-    tags = [
-        "no_rocm",  # stat_summarizer_test FAILS on ROCm 3.5
-    ],
     visibility = [
         "//tensorflow/core:__pkg__",
     ],

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2273,7 +2273,6 @@ cuda_py_test(
     python_version = "PY3",
     shard_count = 10,
     tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
         "noasan",
         "optonly",
     ],
@@ -6533,7 +6532,6 @@ tf_py_test(
     tags = [
         "no_pip",
         "no_pip_gpu",
-        "no_rocm",  # FAILS on ROCm 3.5
         "notap",
     ],
     deps = [
@@ -7000,7 +6998,6 @@ tf_py_test(
     python_version = "PY3",
     tags = [
         "no_pip",  # Relies on contrib
-        "no_rocm",  # FAILS on ROCm 3.5
         "no_windows",
         "notsan",  # intermittent races on a few percent of runs
     ],
@@ -7094,7 +7091,6 @@ tf_py_test(
     srcs = ["training/monitored_session_test.py"],
     tags = [
         "no_pip",
-        "no_rocm",  # FAILS on ROCm 3.5
         "notsan",  # b/67945581
     ],
     deps = [
@@ -7713,7 +7709,6 @@ cuda_py_test(
     tags = [
         "grappler",
         "no_pip",  # tf_optimizer is not available in pip.
-        "no_rocm",  # FAILS on ROCm 3.5
         "notap",  # TODO(b/135924227): Re-enable after fixing flakiness.
     ],
     # This test will not run on XLA because it primarily tests the TF Classic flow.
@@ -7928,7 +7923,6 @@ tf_py_test(
         "no_cuda_on_cpu_tap",
         "no_mac",
         "no_pip",
-        "no_rocm",  # FAILS on ROCm 3.5
         "no_windows",  # TODO(b/151942037)
     ],
     deps = [

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -269,9 +269,6 @@ cuda_py_test(
     name = "profiler_test",
     srcs = ["profiler_test.py"],
     python_version = "PY3",
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":profiler",
         ":test",

--- a/tensorflow/python/keras/BUILD
+++ b/tensorflow/python/keras/BUILD
@@ -541,7 +541,6 @@ tf_py_test(
     srcs = ["callbacks_v1_test.py"],
     python_version = "PY3",
     tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
         "notsan",
     ],
     deps = [

--- a/tensorflow/python/keras/distribute/BUILD
+++ b/tensorflow/python/keras/distribute/BUILD
@@ -140,9 +140,6 @@ distribute_py_test(
     srcs = ["distributed_training_utils_test.py"],
     full_precision = True,
     main = "distributed_training_utils_test.py",
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":distribute",
         ":distribute_strategy_test_lib",

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -145,7 +145,6 @@ cuda_py_test(
     size = "small",
     srcs = ["benchmark_test.py"],
     tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
         "no_windows",
     ],
     deps = [
@@ -3779,9 +3778,6 @@ cuda_py_test(
     size = "medium",
     srcs = ["while_v2_test.py"],
     grpc_enabled = True,
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         "//tensorflow/core:protos_all_py",
         "//tensorflow/python:array_ops",

--- a/tensorflow/python/profiler/BUILD
+++ b/tensorflow/python/profiler/BUILD
@@ -61,7 +61,6 @@ cuda_py_test(
     python_version = "PY3",
     tags = [
         "no_pip",
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     deps = [
         ":profiler_v2",
@@ -123,7 +122,6 @@ cuda_py_test(
     python_version = "PY3",
     tags = [
         "no_pip",
-        "no_rocm",  # FAILS on ROCm 3.5
     ],
     xla_enable_strict_auto_jit = False,  # Node names are different with autojit
     deps = [

--- a/tensorflow/tools/benchmark/BUILD
+++ b/tensorflow/tools/benchmark/BUILD
@@ -48,9 +48,6 @@ tf_cc_test(
     name = "benchmark_model_test",
     size = "medium",
     srcs = ["benchmark_model_test.cc"],
-    tags = [
-        "no_rocm",  # FAILS on ROCm 3.5
-    ],
     deps = [
         ":benchmark_model_lib",
         "//tensorflow/cc:cc_ops",


### PR DESCRIPTION
After switching to ROCm 3.5, all the TF unit tests that invovled initializing the "GpuTracer" started running into the followingsegfault

```
I tensorflow/core/profiler/internal/gpu/rocm_tracer.cc:975] Enabling API tracing for domain HIP API
HipApiActivityEnableCheck(), hip_act_cb_tracker is NULL
```

This was tracked by JIRA ticket - http://ontrack-internal.amd.com/browse/SWDEV-237599

The fix for the above issue is to add the following call, before enabling any api callbacks and/or activity tracing

```cpp
roctracer_set_properties(ACTIVITY_DOMAIN_HIP_API, NULL);
```

/cc @sunway513 