### PR TITLE
Updating Dockerfile.rocm to allow using RC builds.

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -3,7 +3,9 @@
 FROM ubuntu:xenial
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
-ARG DEB_ROCM_REPO=http://repo.radeon.com/rocm/apt/3.5/
+ARG ROCM_DEB_REPO=http://repo.radeon.com/rocm/apt/3.5/
+ARG ROCM_BUILD_NAME=xenial
+ARG ROCM_BUILD_NUM=main
 ARG ROCM_PATH=/opt/rocm-3.5.0
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -13,8 +15,12 @@ RUN apt update && apt install -y wget software-properties-common
 
 # Add rocm repository
 RUN apt-get clean all
-RUN wget -qO - $DEB_ROCM_REPO/rocm.gpg.key | apt-key add -
-RUN sh -c  "echo deb [arch=amd64] $DEB_ROCM_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
+RUN bin/bash -c 'if [[ $ROCM_DEB_REPO == http://repo.radeon.com/rocm/*  ]] ; then \
+      wget -qO - $ROCM_DEB_REPO/rocm.gpg.key | apt-key add -; \
+      echo "deb [arch=amd64] $ROCM_DEB_REPO $ROCM_BUILD_NAME $ROCM_BUILD_NUM" > /etc/apt/sources.list.d/rocm.list; \
+    else \
+      echo "deb [arch=amd64 trusted=yes] $ROCM_DEB_REPO $ROCM_BUILD_NAME $ROCM_BUILD_NUM" > /etc/apt/sources.list.d/rocm.list ; \
+    fi'
 
 # Install misc pkgs
 RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
This PR/commit updates the Dockerfile.rocm so that it can be used (without any change) to build containers based on internal ROCm builds.

The `--build-arg` command line option to the `docker build` command can be used to specify whether the container should use the public ROCm release (default setting) or an internal ROCm release. The following example shows the options that need to be added for using the updated Dockerfile.rocm to use the internal ROCm3.6 RC1 build (instead of the default, which is the public ROCm 3.5 release)

```python
    version = "3.6"
    release = "rel-22"
    install_dir = "rocm-3.6.0-22"
    docker_build_args = [
        "--build-arg", "ROCM_DEB_REPO=http://compute-artifactory.amd.com/artifactory/list/rocm-release-archive-deb/",
        "--build-arg", "ROCM_BUILD_NAME={}".format(version),
        "--build-arg", "ROCM_BUILD_NUM={}".format(release),
        "--build-arg", "ROCM_PATH=/opt/{}".format(install_dir),
        ]
```

----------------------------------

/cc @sunway513 @parallelo @mvermeulen 