### PR TITLE
Pass HIP_PLATFORM to bazel build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1442,6 +1442,9 @@ def main():
     write_action_env_to_bazelrc('ROCM_PATH', environ_cp.get('ROCM_PATH'))
     write_action_env_to_bazelrc('ROCM_ROOT', environ_cp.get('ROCM_PATH'))
 
+  if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('HIP_PLATFORM')):
+    write_action_env_to_bazelrc('HIP_PLATFORM', environ_cp.get('HIP_PLATFORM'))
+
   environ_cp['TF_NEED_CUDA'] = str(
       int(get_var(environ_cp, 'TF_NEED_CUDA', 'CUDA', False)))
   if (environ_cp.get('TF_NEED_CUDA') == '1' and


### PR DESCRIPTION
This PR is to address the TF build failure reported in JIRA ticket:
http://ontrack-internal.amd.com/browse/SWDEV-241967

The valid set of values for the env var HIP_PLATFORM is being updated, and as a consequence `hcc` will no longer a valid value (staring with ROCm 3.7). For ROCm 3.7, we will need to change the configure.py script such that the env var HIP_PLATFORM=amd is explicitly when invoked with TF_NEED_ROCM=1.

In the meantime (i.e. until we switch to ROCm 3.7), we need to provide a way for passing HIP_PLATFORM to bazel (to help QA in testing ROCm 3.7). This change provides that way. If the HIP_PLATFORM env var is set in the shell that invokes the "configure.py" script, it will pass it through to bazel.


/cc @mvermeulen @sunway513 @ekuznetsov139 