### PR TITLE
Adding hipLaunchKernel to the list of APIs traced via roctracer

### DIFF
--- a/tensorflow/core/profiler/internal/gpu/device_tracer_rocm.cc
+++ b/tensorflow/core/profiler/internal/gpu/device_tracer_rocm.cc
@@ -321,7 +321,6 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
 
   bool IsEventTypeWithoutHCCActivityRecordCallback(RocmTracerEventType type) {
     switch (type) {
-      case RocmTracerEventType::MemcpyH2D:
       case RocmTracerEventType::MemoryAlloc:
         return true;
         break;
@@ -683,6 +682,7 @@ RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
       HIP_API_ID_hipExtModuleLaunchKernel,
       HIP_API_ID_hipFree,
       HIP_API_ID_hipHccModuleLaunchKernel,
+      HIP_API_ID_hipLaunchKernel,
       HIP_API_ID_hipMalloc,
       HIP_API_ID_hipMemcpyAsync,
       HIP_API_ID_hipMemcpyDtoD,


### PR DESCRIPTION
Starting with ROCm 3.6, it seems that hip-runtime is also using the `hipLaunchKernel` API to launch kernels, and hence we need to add it to the list of APIs being traced by roctracer.

Another change in this commit is to remove the "RocmTracerEventType::MemcpyH2D:" events from the list of APIs for which we do not expect HCC_OPS domain activity records. (because we seem to be getting them after the switch to hipclang-VDI runtime in ROCm 3.5)