### PR TITLE
Removing references to `*StaticCompiledGEMM` from TF code

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -114,9 +114,6 @@ string ToString(miopenConvFwdAlgorithm_t algorithm) {
     case miopenConvolutionFwdAlgoImplicitGEMM:
       s = "Implicit GEMM";
       break;
-    case miopenConvolutionFwdAlgoStaticCompiledGEMM:
-      s = "Static Compiled GEMM";
-      break;
   }
   return s;
 }
@@ -182,9 +179,6 @@ string ToString(miopenConvAlgorithm_t algorithm) {
       break;
     case miopenConvolutionAlgoImplicitGEMM:
       s = "Implicit GEMM";
-      break;
-    case miopenConvolutionAlgoStaticCompiledGEMM:
-      s = "Static Compiled GEMM";
       break;
   }
   return s;


### PR DESCRIPTION
This commit is in conjunction with this MIOpen PR which removes scgemm from MIOpen
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/325

The MIOpen release that includes that change will be included in the next ROCm release.
This commit removes references to `*StaticCompiledGEMM` from TF code to prepare for switching to the next ROCm release (3.7)

-------------------------------------

/cc @mvermeulen @sunway513 