### PR TITLE
Changing AMP selection for AMD GPUs

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
@@ -24,6 +24,11 @@ namespace grappler {
 
 enum class AutoMixedPrecisionMode { CUDA, MKL };
 
+//Getting FP16 supported devices for ROCm
+#if TENSORFLOW_USE_ROCM
+bool HasEnhancedFP16ComputeSupport(std::pair<int, int> gpu_arch);
+#endif
+
 // Convert data types to float16 or bfloat16 where appropriate to improve
 // performance on GPUs or CPUs.
 class AutoMixedPrecision : public GraphOptimizer {


### PR DESCRIPTION
Changed kMinGPUArch to be Vega10 for now. 

This will GPUArch will become string as per ROCm 3.7 as per https://github.com/ROCm-Developer-Tools/HIP/pull/2045
we will need to change the AMP selection function as such. 

