### PR TITLE
Change references to libhip_hcc.so to refer to libamdhip64.so instead - continued

### DIFF
--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -144,7 +144,7 @@ port::StatusOr<void*> GetHipsparseDsoHandle() {
   return GetDsoHandle("hipsparse", "");
 }
 
-port::StatusOr<void*> GetHipDsoHandle() { return GetDsoHandle("hip_hcc", ""); }
+port::StatusOr<void*> GetHipDsoHandle() { return GetDsoHandle("amdhip64", ""); }
 
 }  // namespace DsoLoader
 


### PR DESCRIPTION
previous PR for the same was missing one change
https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1044

This PR has a commit that updates the dso_loader to open libamdhip64.so instead of libhip_hcc.so

Note that the CI runs for the previous PR passed because 
* the `libhip_hcc.so` softlink is still present in ROCM_PATH, because CI still uses ROCm 3.5 and the softlink will be eliminated in ROCm 3.7
* the `libhip_hcc.so` is picked up from the ROCM_PATH and not from the `local_config_rocm` path.