### PR TITLE
Putting no_rocm tag on flaky tests.

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -544,6 +544,7 @@ tf_xla_py_test(
     shard_count = 5,
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
+        "no_rocm",
         "noasan",
         "nomsan",
         "notsan",

--- a/tensorflow/python/keras/distribute/BUILD
+++ b/tensorflow/python/keras/distribute/BUILD
@@ -753,6 +753,7 @@ distribute_py_test(
     shard_count = 7,
     tags = [
         "multi_and_single_gpu",
+        "no_rocm",
     ],
     deps = [
         ":saved_model_test_base",

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -3532,6 +3532,7 @@ cuda_py_test(
     size = "medium",
     srcs = ["tensordot_op_test.py"],
     shard_count = 20,
+    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/kernel_tests/linalg/sparse/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/sparse/BUILD
@@ -75,6 +75,7 @@ cuda_py_test(
     srcs = ["csr_sparse_matrix_sparse_mat_mul_grad_test.py"],
     main = "csr_sparse_matrix_sparse_mat_mul_grad_test.py",
     shard_count = 50,
+    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python/ops/linalg/sparse",
     ],


### PR DESCRIPTION
The switch to ROCm 3.5 seems to have introduced flakiness in some of unit-tests. This PR/commit adds the no_rocm tag on such tests.

In order to determine which tests are flaky, I looked at the CI log files for all `rocm`, `rocm-xla`, `rocm-cpp` runs since the switch to ROCm 3.5 and determined the `FAILED`, `TIMEOUT`, and `FLAKY` counts for each test.
Tests which either
 * had a `FAILED` count >= 10
 or
 * had a `FAILED` count >=1 AND `FLAKY` count >= 10
are the ones for which this commit adds the `no_rocm` tag

`rocm` CI numbers
```
testname                                                                                            ,     FAILED,    TIMEOUT,      FLAKY
//tensorflow/python/kernel_tests/linalg/sparse:csr_sparse_matrix_sparse_mat_mul_grad_test_gpu       ,         13,          0,         13
//tensorflow/python/kernel_tests/linalg/sparse:csr_sparse_matrix_sparse_mat_mul_grad_test           ,         13,          0,          8
//tensorflow/python/keras/distribute:saved_model_save_load_test                                     ,          2,          3,         10
//tensorflow/python/kernel_tests:tensordot_op_test_gpu                                              ,          2,          0,         15
//tensorflow/python/kernel_tests:tensordot_op_test                                                  ,          2,          0,         13
//tensorflow/python/keras/distribute:saved_model_save_load_test_gpu                                 ,          0,          2,         12
//tensorflow/python/keras/distribute:keras_embedding_model_correctness_test_gpu                     ,          3,          0,          8
//tensorflow/python/kernel_tests:linalg_grad_test                                                   ,          0,          0,         15
//tensorflow/python/kernel_tests:cwise_ops_test_gpu                                                 ,          0,          3,          6
//tensorflow/python/keras/layers:convolutional_test                                                 ,          0,          4,          2
//tensorflow/python/kernel_tests:cwise_ops_test                                                     ,          0,          3,          4
//tensorflow/python/keras/layers:convolutional_test_gpu                                             ,          0,          4,          0
//tensorflow/python/ops/parallel_for:xla_control_flow_ops_test_gpu                                  ,          0,          0,         10
//tensorflow/python/keras/distribute:keras_premade_models_test                                      ,          0,          1,          7
//tensorflow/python/keras/distribute:keras_premade_models_test_gpu                                  ,          0,          1,          7
//tensorflow/python/eager:function_test_gpu                                                         ,          0,          0,          9
//tensorflow/python/keras/distribute:keras_embedding_model_correctness_test                         ,          1,          0,          6
//tensorflow/python/kernel_tests:linalg_grad_test_gpu                                               ,          1,          0,          6
//tensorflow/python/ops/parallel_for:xla_control_flow_ops_test                                      ,          0,          0,          8
//tensorflow/python/eager:function_test                                                             ,          0,          0,          7
//tensorflow/python/kernel_tests:cholesky_op_test_gpu                                               ,          0,          0,          7
//tensorflow/python/ops/ragged:ragged_getitem_test                                                  ,          0,          0,          7
//tensorflow/python/ops/ragged:ragged_gather_op_test                                                ,          0,          0,          7
//tensorflow/python/kernel_tests:pooling_ops_3d_test_gpu                                            ,          0,          0,          6
//tensorflow/python/ops/parallel_for:control_flow_ops_test_gpu                                      ,          0,          0,          5
//tensorflow/python/kernel_tests:rnn_cell_test                                                      ,          0,          0,          5
//tensorflow/python/data/experimental/kernel_tests:stats_dataset_ops_test                           ,          0,          0,          5
//tensorflow/python/kernel_tests:pooling_ops_test                                                   ,          0,          0,          5
//tensorflow/python/kernel_tests:pooling_ops_3d_test                                                ,          0,          0,          5
//tensorflow/python/distribute:mirrored_strategy_test_gpu                                           ,          0,          0,          5
//tensorflow/python/kernel_tests:pooling_ops_test_gpu                                               ,          0,          0,          4
//tensorflow/python/kernel_tests:cond_v2_test                                                       ,          0,          0,          4
//tensorflow/python/kernel_tests/linalg/sparse:csr_sparse_matrix_dense_mat_mul_grad_test            ,          0,          0,          4
```

`rocm-xla` CI numbers
```
testname                                                                                            ,     FAILED,    TIMEOUT,      FLAKY
//tensorflow/compiler/tests:depthwise_conv_op_test_cpu                                              ,          3,          0,         10
//tensorflow/compiler/tests:image_ops_test_gpu                                                      ,          5,          0,          2
//tensorflow/compiler/tests:jit_test                                                                ,          0,          0,          7
//tensorflow/compiler/xla/tests:reduce_window_test_gpu                                              ,          0,          0,          6
//tensorflow/compiler/tests:sort_ops_test_gpu                                                       ,          0,          0,          5
//tensorflow/compiler/xla/tests:conv_depthwise_test_gpu                                             ,          0,          0,          4
//tensorflow/compiler/tests:special_math_test_gpu_mlir_bridge_test                                  ,          0,          0,          4
//tensorflow/compiler/tests:stateful_random_ops_test_cpu                                            ,          0,          0,          4
```


`rocm-cpp` CI numbers
```
testname                                                                                            ,     FAILED,    TIMEOUT,      FLAKY
//tensorflow/core/nccl:nccl_manager_test                                                            ,          0,          5,         24
//tensorflow/c/eager:c_api_cluster_test                                                             ,          2,          0,          6
//tensorflow/c/eager:c_api_distributed_test_gpu                                                     ,          0,          0,          8
//tensorflow/c/eager:c_api_remote_test_gpu                                                          ,          0,          0,          7
//tensorflow/c/eager:c_api_cluster_test_gpu                                                         ,          0,          0,          6
//tensorflow/c/eager:c_api_remote_test                                                              ,          0,          0,          4
```