### PR TITLE
Remove duplicate no_rocm tag from tensordot_op_test

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -3531,7 +3531,6 @@ cuda_py_test(
     name = "tensordot_op_test",
     size = "medium",
     srcs = ["tensordot_op_test.py"],
-    tags = ["no_rocm"],
     shard_count = 20,
     tags = ["no_rocm"],
     deps = [


### PR DESCRIPTION
The PR I filed yesterday ( https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1053 ) seems to have introduced a duplicate `no_rocm` tag on the test `//tensorflow/python/kernel_tests:tensorop_dot_test` leading to CI failures.

The tag was added in my PR, and also independently in another PR ( https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1048 ). Since the two additions were on different lines, git did not flag this as a merge-conflict, and the duplicate tag error only manifested itself after my PR was merged.