### PR TITLE
Fixing GpuShuffleXorSync / DepthwiseConv

### DIFF
--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -1735,21 +1735,12 @@ Status LaunchDepthwiseConv2dBackpropFilterGPU(
     OpKernelContext* ctx, const DepthwiseArgs& args, const T* out_backprop,
     const T* input, T* filter_backprop, TensorFormat data_format) {
   if (args.depth_multiplier == 1) {
-    /*
-    // The kernel DepthwiseConv2dBackpropFilterGPUKernelNHWCSmall does not 
-    // work correctly. The test which is supposed to catch its failure
-    // (//tensorflow/python/kernel_tests:depthwise_conv_op_test) itself fails,
-    // because it uses self.cached_session(use_gpu=use_gpu) to compare CPU 
-    // and GPU results, and ends up comparing the GPU result against itself.
-    // TODO: fix the kernel, fix the test, fix any other tests using the same
-    // pattern (of which there are many).
     if (TryLaunchDepthwiseConv2dBackpropFilterGPUSmall<T, kKnownFilterWidth,
                                                        kKnownFilterHeight>(
             ctx, args, out_backprop, input, filter_backprop, data_format)
             .ok()) {
       return Status::OK();
     }
-    */
     return LaunchDepthwiseConv2dBackpropFilterGPU<T, kKnownFilterWidth,
                                                   kKnownFilterHeight, 1>(
         ctx, args, out_backprop, input, filter_backprop, data_format);

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -471,7 +471,7 @@ __device__ T GpuShuffleXorSync(unsigned mask, T value, int lane_mask,
 #endif
 #elif TENSORFLOW_USE_ROCM
   // ROCM TODO: check if HIP should be changed to cope with more types
-  return __shfl_xor(static_cast<int>(value), lane_mask, width);
+  return __shfl_xor(value, lane_mask, width);
 #endif
 }
 


### PR DESCRIPTION
GpuShuffleXorSync was incorrectly casting floats to ints. One of the DepthwiseConv kernels was failing because of this error. This fixes the problem and reenables the kernel.