### PR TITLE
Undoing what seems to be a faulty auto-merge in last weekly sync.

### DIFF
--- a/tensorflow/python/eager/def_function_xla_jit_test.py
+++ b/tensorflow/python/eager/def_function_xla_jit_test.py
@@ -76,9 +76,7 @@ class DefFunctionTest(xla_test.XLATestCase):
 
       inputs = constant_op.constant([1, 2, 2, 3, 3])
       self.assertAllClose([2, 3, 3, 4, 4], func(inputs, 1))
-      if not test.is_built_with_rocm():
-        # XLA support is not yet enabled for TF ROCm
-        self.assertAllClose([2, 3, 3, 4, 4], xla_func(inputs, 1))
+      self.assertAllClose([2, 3, 3, 4, 4], xla_func(inputs, 1))
 
   def testBasicInt32(self):
     with ops.device('device:{}:0'.format(self.device)):
@@ -88,14 +86,10 @@ class DefFunctionTest(xla_test.XLATestCase):
         return x + a
 
       inputs = constant_op.constant([1, 2, 2, 3, 3], dtype=dtypes.int32)
-      if not test.is_built_with_rocm():
-        # XLA support is not yet enabled for TF ROCm
-        self.assertAllClose([2, 3, 3, 4, 4], fn(inputs, 1))
+      self.assertAllClose([2, 3, 3, 4, 4], fn(inputs, 1))
 
   def testDerivative(self):
     with ops.device('device:{}:0'.format(self.device)):
-      if test.is_built_with_rocm():
-        return
 
       def fn(x, a):
         return 2 * x + a
@@ -135,9 +129,7 @@ class DefFunctionTest(xla_test.XLATestCase):
         return fn(x, a)
 
       inputs = constant_op.constant([1, 2, 2, 3, 3])
-      if not test.is_built_with_rocm():
-        # XLA support is not yet enabled for TF ROCm
-        self.assertAllClose([2, 3, 3, 4, 4], fn2(inputs, 1))
+      self.assertAllClose([2, 3, 3, 4, 4], fn2(inputs, 1))
 
   @test_util.disable_mlir_bridge('TODO(b/162272821): MLIR bridge returns'
                                  ' wrong status type')
@@ -154,10 +146,9 @@ class DefFunctionTest(xla_test.XLATestCase):
 
       func = def_function.function(fn2, experimental_compile=False)
       inputs = constant_op.constant([1, 2, 2, 3, 3])
-      if not test.is_built_with_rocm():
-        with self.assertRaisesRegex(errors.InvalidArgumentError,
+      with self.assertRaisesRegex(errors.InvalidArgumentError,
                                     'not compilable'):
-          func(inputs)
+        func(inputs)
 
   @test_util.disable_mlir_bridge('TODO(b/162272821): MLIR bridge returns'
                                  ' wrong status type')
@@ -196,9 +187,7 @@ class DefFunctionTest(xla_test.XLATestCase):
         self.assertAllClose(3.0, dy)
 
       run_and_check(func)
-      if not test.is_built_with_rocm():
-        # XLA support is not yet enabled for TF ROCm
-        run_and_check(xla_func)
+      run_and_check(xla_func)
 
   @test_util.disable_mlir_bridge('TODO(b/162521846): MLIR bridge fails'
                                  ' msan, function library not found')
@@ -233,8 +222,6 @@ class DefFunctionTest(xla_test.XLATestCase):
       self.assertAllClose([40.0, 28.0], g(2.0))
 
   def testMethodCompilation(self):
-    if test.is_built_with_rocm():
-      return
 
     with ops.device('device:{}:0'.format(self.device)):
 
@@ -251,8 +238,6 @@ class DefFunctionTest(xla_test.XLATestCase):
   @test_util.disable_mlir_bridge('TODO(b/162272821): MLIR bridge returns '
                                  ' wrong status type')
   def testMethodCompilationUnsupportedFunc(self):
-    if test.is_built_with_rocm():
-      return
 
     with ops.device('device:{}:0'.format(self.device)):
 
@@ -273,8 +258,6 @@ class DefFunctionTest(xla_test.XLATestCase):
       self.skipTest('b/162799319: Cannot resolve constant on TPU')
 
     with ops.device('device:{}:0'.format(self.device)):
-      if test.is_built_with_rocm():
-        return
 
       @def_function.function(experimental_compile=True)
       def f():


### PR DESCRIPTION
It seems to have re-introduced ROCm specific "skips" in the subtests within the test def_function_xla_jit_test.py. We had removed them a while back, but had not upstreamed that change. Somehow the old upstream code flowed back to us as part of weekly merge...not quite sure how/why that happened.

