### PR TITLE
pUse python decorator to skip rocm tests

### DIFF
--- a/tensorflow/compiler/tests/image_ops_test.py
+++ b/tensorflow/compiler/tests/image_ops_test.py
@@ -604,10 +604,8 @@ class ResizeBilinearTest(parameterized.TestCase, xla_test.XLATestCase):
       # ("Disabled_384x72To2048x384", 384, 72, 2048, 384),
   )
 
+  @test.disable_for_rocm(skip_message="Disabled on ROCm, because it runs out of memory")
   def test(self, src_y, src_x, dst_y, dst_x, dtype=np.float32):
-    if test.is_built_with_rocm():
-      self.skipTest("Disabled on ROCm, because it runs out of memory")
-
     max_y = max(src_y - 1, 1) * (dst_y - 1) + 1
     max_x = max(src_x - 1, 1) * (dst_x - 1) + 1
 

--- a/tensorflow/python/keras/layers/convolutional_recurrent_test.py
+++ b/tensorflow/python/keras/layers/convolutional_recurrent_test.py
@@ -202,10 +202,8 @@ class ConvLSTMTest(keras_parameterized.TestCase):
       outputs = clone.predict(test_inputs)
       self.assertAllClose(reference_outputs, outputs, atol=1e-5)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as OOM occurred with 1 GB budget.')
   def test_conv_lstm_with_initial_state(self):
-    if test.is_built_with_rocm():
-      return # OOM with 1 GB budget on ROCm platform
-
     num_samples = 32
     sequence_len = 5
     encoder_inputs = keras.layers.Input((None, 32, 32, 3))

--- a/tensorflow/python/keras/layers/gru_test.py
+++ b/tensorflow/python/keras/layers/gru_test.py
@@ -48,10 +48,9 @@ class GRULayerTest(keras_parameterized.TestCase):
                 'return_sequences': True},
         input_shape=(num_samples, timesteps, embedding_dim))
 
+  @test.disable_for_rocm(skip_message='Double type is yet not supported in ROCm')
   @tf_test_util.run_v2_only
   def test_float64_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Double type is yet not supported in ROCm')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -134,9 +133,8 @@ class GRULayerTest(keras_parameterized.TestCase):
     gru_model.fit(x_train, y_train)
     gru_model.predict(x_train)
 
+  @test.disable_for_rocm(skip_message='MIOpen only supports packed input output')
   def test_with_masking_layer_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('MIOpen only supports packed input output')
     layer_class = keras.layers.GRU
     inputs = np.random.random((2, 3, 4))
     targets = np.abs(np.random.random((2, 3, 5)))
@@ -150,9 +148,8 @@ class GRULayerTest(keras_parameterized.TestCase):
         run_eagerly=testing_utils.should_run_eagerly())
     model.fit(inputs, targets, epochs=1, batch_size=2, verbose=1)
 
+  @test.disable_for_rocm(skip_message='MIOpen only supports packed input output')
   def test_statefulness_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('MIOpen only supports packed input output')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4

--- a/tensorflow/python/keras/layers/gru_v2_test.py
+++ b/tensorflow/python/keras/layers/gru_v2_test.py
@@ -149,12 +149,10 @@ class GRUV2Test(keras_parameterized.TestCase):
       l2 = layer_class.from_config(l1.get_config())
       assert l1.get_config() == l2.get_config()
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @test_util.run_v2_only
   def test_gru_v2_feature_parity_with_canonical_gru(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     input_shape = 10
     rnn_state_size = 8
     timestep = 4
@@ -322,11 +320,9 @@ class GRUV2Test(keras_parameterized.TestCase):
 
     self.assertAllClose(y, y_ref)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_with_masking_layer_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     layer_class = rnn.GRU
     inputs = np.random.random((2, 3, 4))
     targets = np.abs(np.random.random((2, 3, 5)))
@@ -338,11 +334,9 @@ class GRUV2Test(keras_parameterized.TestCase):
                   optimizer=gradient_descent.GradientDescentOptimizer(0.001))
     model.fit(inputs, targets, epochs=1, batch_size=2, verbose=1)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_masking_with_stacking_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     inputs = np.random.random((2, 3, 4))
     targets = np.abs(np.random.random((2, 3, 5)))
     targets /= targets.sum(axis=-1, keepdims=True)
@@ -366,11 +360,9 @@ class GRUV2Test(keras_parameterized.TestCase):
                 'return_sequences': True},
         input_shape=(num_samples, timesteps, embedding_dim))
 
+  @test.disable_for_rocm(skip_message='Double type is not yet supported in ROCm')
   @test_util.run_v2_only
   def test_float64_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Double type is yet not supported in ROCm')
-
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -383,11 +375,9 @@ class GRUV2Test(keras_parameterized.TestCase):
         input_shape=(num_samples, timesteps, embedding_dim),
         input_dtype='float64')
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_return_states_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     layer_class = rnn.GRU
     x = np.random.random((2, 3, 4))
     y = np.abs(np.random.random((2, 5)))
@@ -467,11 +457,9 @@ class GRUV2Test(keras_parameterized.TestCase):
     else:
       self.assertEqual(len(layer.get_losses_for(x)), 1)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_statefulness_GRU(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -566,12 +554,10 @@ class GRUV2Test(keras_parameterized.TestCase):
         run_eagerly=testing_utils.should_run_eagerly())
     model.fit(x, y, epochs=1, shuffle=False)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @test_util.run_v2_only
   def test_explicit_device_with_go_backward_and_mask(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     batch_size = 8
     timestep = 7
     masksteps = 5
@@ -720,12 +706,10 @@ class GRUGraphRewriteTest(keras_parameterized.TestCase):
     model = keras.models.Model(inputs=inputs, outputs=[outputs, runtime])
     self._test_runtime_with_model(model)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @test_util.run_v2_only
   def test_GRU_runtime_with_mask(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     # Masking will affect which backend is selected based on whether the mask
     # is strictly right padded.
     layer = rnn.GRU(self.rnn_state_size, return_runtime=True)

--- a/tensorflow/python/keras/layers/lstm_test.py
+++ b/tensorflow/python/keras/layers/lstm_test.py
@@ -47,10 +47,9 @@ class LSTMLayerTest(keras_parameterized.TestCase):
                 'return_sequences': True},
         input_shape=(num_samples, timesteps, embedding_dim))
 
+  # @test.disable_for_rocm(skip_message='Double type is yet not supported in ROCm')
   @tf_test_util.run_v2_only
   def test_float64_LSTM(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Double type is yet not supported in ROCm')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -143,11 +142,9 @@ class LSTMLayerTest(keras_parameterized.TestCase):
     self.assertEqual(layer.cell.recurrent_kernel.constraint, r_constraint)
     self.assertEqual(layer.cell.bias.constraint, b_constraint)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not support padded input.')
   @parameterized.parameters([True, False])
   def test_with_masking_layer_LSTM(self, unroll):
-    if test.is_built_with_rocm():
-      self.skipTest(
-          'Skipping the test as ROCm MIOpen does not support padded input.')
     layer_class = keras.layers.LSTM
     inputs = np.random.random((2, 3, 4))
     targets = np.abs(np.random.random((2, 3, 5)))
@@ -386,10 +383,8 @@ class LSTMLayerTest(keras_parameterized.TestCase):
     else:
       self.assertEqual(len(layer.get_losses_for(x)), 1)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not support padded input.')
   def test_statefulness_LSTM(self):
-    if test.is_built_with_rocm():
-      self.skipTest(
-          'Skipping the test as ROCm MIOpen does not support padded input.')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4

--- a/tensorflow/python/keras/layers/lstm_v2_test.py
+++ b/tensorflow/python/keras/layers/lstm_v2_test.py
@@ -254,10 +254,9 @@ class LSTMV2Test(keras_parameterized.TestCase):
     targets = np.random.random((num_samples, units))
     model.train_on_batch([inputs] + initial_state, targets)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_return_state(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
     num_states = 2
     timesteps = 3
     embedding_dim = 4
@@ -324,11 +323,10 @@ class LSTMV2Test(keras_parameterized.TestCase):
     targets = np.random.random((num_samples, units))
     model.train_on_batch([main_inputs] + initial_state, targets)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @test_util.run_v2_only
   def test_lstm_v2_feature_parity_with_canonical_lstm(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
     input_shape = 10
     rnn_state_size = 8
     timestep = 4
@@ -371,11 +369,10 @@ class LSTMV2Test(keras_parameterized.TestCase):
     self.assertAllClose(y_1, y_3, rtol=1e-5, atol=2e-5)
     self.assertAllClose(y_2, y_4, rtol=1e-5, atol=2e-5)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @parameterized.named_parameters(('v0', 0), ('v1', 1), ('v2', 2))
   def test_implementation_mode_LSTM(self, implementation_mode):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -417,10 +414,9 @@ class LSTMV2Test(keras_parameterized.TestCase):
         optimizer=gradient_descent.GradientDescentOptimizer(0.01))
     model.fit(inputs, targets, epochs=1, batch_size=2, verbose=1)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_masking_with_stacking_LSTM(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
     inputs = np.random.random((2, 3, 4))
     targets = np.abs(np.random.random((2, 3, 5)))
     targets /= targets.sum(axis=-1, keepdims=True)
@@ -592,11 +588,10 @@ class LSTMV2Test(keras_parameterized.TestCase):
         },
         input_shape=(num_samples, timesteps, embedding_dim))
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support float64 yet.')
   @test_util.run_v2_only
   def test_float64_LSTM(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support float64 yet.')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -632,10 +627,9 @@ class LSTMV2Test(keras_parameterized.TestCase):
     else:
       self.assertEqual(len(layer.get_losses_for(x)), 1)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_statefulness_LSTM(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
     num_samples = 2
     timesteps = 3
     embedding_dim = 4
@@ -767,12 +761,10 @@ class LSTMV2Test(keras_parameterized.TestCase):
     model.evaluate(x, y)
     model.predict(x)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @test_util.run_v2_only
   def test_explicit_device_with_go_backward_and_mask(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     batch_size = 8
     timestep = 7
     masksteps = 5
@@ -896,12 +888,10 @@ class LSTMGraphRewriteTest(keras_parameterized.TestCase):
     model = keras.models.Model(inputs=inputs, outputs=[outputs, runtime])
     self._test_runtime_with_model(model)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @test_util.run_v2_only
   def test_LSTM_runtime_with_mask(self):
-    if test.is_built_with_rocm():
-      self.skipTest('Skipping the test as ROCm MIOpen does not '
-                    'support padded input yet.')
-
     # Masking will affect which backend is selected based on whether the mask
     # is strictly right padded.
     layer = rnn.LSTM(self.rnn_state_size, return_runtime=True)

--- a/tensorflow/python/keras/layers/wrappers_test.py
+++ b/tensorflow/python/keras/layers/wrappers_test.py
@@ -939,13 +939,9 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
           input_layer.compute_output_shape([None, 2, 4]).as_list(),
           [None, 2, 16])
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   def test_Bidirectional_last_output_with_masking(self):
-    if test.is_built_with_rocm():
-      # testcase uses input and/or output sequences which require padding
-      # leading to the following error on ROCm platform
-      # ROCm MIOpen only supports packed input output
-      # Skip this subtest for now
-      self.skipTest('Test not supported on the ROCm platform')
     rnn = keras.layers.LSTM
     samples = 2
     dim = 5
@@ -971,14 +967,10 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
       self.assertLen(y, 5)
       self.assertAllClose(y[0], np.concatenate([y[1], y[3]], axis=1))
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen does not '
+                                      'support padded input yet.')
   @parameterized.parameters([keras.layers.LSTM, keras.layers.GRU])
   def test_Bidirectional_sequence_output_with_masking(self, rnn):
-    if test.is_built_with_rocm():
-      # testcase uses input and/or output sequences which require padding
-      # leading to the following error on ROCm platform
-      # ROCm MIOpen only supports packed input output
-      # Skip this subtest for now
-      self.skipTest('Test not supported on the ROCm platform')
     samples = 2
     dim = 5
     timesteps = 3
@@ -1179,11 +1171,10 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
         epochs=1,
         batch_size=10)
 
+  @test.disable_for_rocm(skip_message='Skipping the test as ROCm RNN does not '
+                                      'support ragged tensors yet.')
   @parameterized.parameters(['ave', 'concat', 'mul'])
   def test_Bidirectional_ragged_input(self, merge_mode):
-    if test.is_built_with_rocm():
-      # ragged tenors are not supported in ROCM RNN implementation
-      self.skipTest('Test not supported on the ROCm platform')
     np.random.seed(100)
     rnn = keras.layers.LSTM
     units = 3

--- a/tensorflow/python/kernel_tests/banded_triangular_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/banded_triangular_solve_op_test.py
@@ -142,10 +142,9 @@ class BandedTriangularSolveOpTest(test.TestCase):
     matrix = 2. * np.random.uniform(size=[3, 6]) + 1.
     self._verifySolveAllWaysReal(matrix, rhs0)
 
+  @test.disable_for_rocm(skip_message='ROCm does not support BLAS operations for complex types')
   @test_util.run_deprecated_v1
   def testSolveComplex(self):
-    if test.is_built_with_rocm():
-      self.skipTest("ROCm does not support BLAS operations for complex types")
     # 1x1 matrix, single rhs.
     matrix = np.array([[0.1 + 1j * 0.1]])
     rhs0 = np.array([[1. + 1j]])
@@ -180,10 +179,9 @@ class BandedTriangularSolveOpTest(test.TestCase):
     # Batch of 3x2x4x4 matrices with 3 bands, 3x2x4x2 right-hand sides.
     self._verifySolveAllWaysReal(matrix, rhs, batch_dims=[3, 2])
 
+  @test.disable_for_rocm(skip_message='ROCm does not support BLAS operations for complex types')
   @test_util.run_deprecated_v1
   def testSolveBatchComplex(self):
-    if test.is_built_with_rocm():
-      self.skipTest("ROCm does not support BLAS operations for complex types")
     matrix = np.array([[1., 2.], [3., 4.]]).astype(np.complex64)
     matrix += 1j * matrix
     rhs = np.array([[1., 0., 1.], [0., 1., 1.]]).astype(np.complex64)

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_grad_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_grad_test.py
@@ -79,13 +79,11 @@ class CSRSparseMatrixGradTest(test.TestCase):
                         dense_shape)
         self.assertAllEqual(grad_vals, grad_out_value)
 
+  @test.disable_for_rocm(skip_message='sparse-matrix-add op not supported on ROCm')
   @test_util.run_deprecated_v1
   def testLargeBatchSparseMatrixAddGrad(self):
     if not self._gpu_available:
       return
-
-    if test.is_built_with_rocm():
-      self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)
     for dense_shape in ([53, 65, 127], [127, 65]):

--- a/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/sparse/csr_sparse_matrix_ops_test.py
@@ -427,13 +427,11 @@ class CSRSparseMatrixOpsTest(test.TestCase):
     for (mat, sm_rt_value) in zip(mats, sm_rt_values):
       self.assertAllEqual(mat, sm_rt_value)
 
+  @test.disable_for_rocm(skip_message='sparse-matrix-add op not supported on ROCm')
   @test_util.run_in_graph_and_eager_modes
   def testSparseMatrixAdd(self):
     if not self._gpu_available:
       return
-
-    if test.is_built_with_rocm():
-      self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     a_indices = np.array([[0, 0], [2, 3]])
     a_values = np.array([1.0, 5.0]).astype(np.float32)
@@ -467,13 +465,11 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
       self.assertAllClose(a_sum_b_sparse_mat.todense(), c_dense_value)
 
+  @test.disable_for_rocm(skip_message='sparse-matrix-add op not supported on ROCm')
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchSparseMatrixAdd(self):
     if not self._gpu_available:
       return
-
-    if test.is_built_with_rocm():
-      self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)
     dense_shape = [53, 65, 127]
@@ -589,18 +585,16 @@ class CSRSparseMatrixOpsTest(test.TestCase):
             self.assertAllClose(
                 c_t_value, c_dense_t_value, rtol=1e-6, atol=1e-5)
 
+  # TODO(rocm): fix this
+  # This test is currently failing on the ROCm platform
+  # Re-enable it once the fix is available
+  @test.disable_for_rocm(skip_message='hipSPARSE all failure on the ROCm platform')
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchSparseMatrixMatMulTransposed(self):
     dtypes_to_test = [np.float32]
     if not test.is_built_with_rocm():
       # complex types is not supported on the ROCm platform
       dtypes_to_test += [np.complex64]
-
-    if test.is_built_with_rocm():
-      # TODO(rocm): fix this
-      # This test is currently failing on the ROCm platform
-      # Ren-enable it once the fix is available
-      self.skipTest("hipSPARSE all failure on the ROCm platform")
 
     sparsify = lambda m: m * (m > 0)
     for dtype in dtypes_to_test:
@@ -652,12 +646,9 @@ class CSRSparseMatrixOpsTest(test.TestCase):
             self.assertAllClose(
                 c_t_value, c_dense_t_value, rtol=1e-6, atol=1e-5)
 
+  @test.disable_for_rocm(skip_message='complex type is yet not supported in ROCm')
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchSparseMatrixMatMulConjugate(self):
-    if test.is_built_with_rocm():
-      # complex types are not yet supported on the ROCm platform
-      self.skipTest("complex type not supported on ROCm")
-
     sparsify = lambda m: m * (m > 0)
     a_dense_shape = [53, 65, 127]
     b_dense_shape = [53, 127, 67]
@@ -784,14 +775,11 @@ class CSRSparseMatrixOpsTest(test.TestCase):
 
         self.assertAllClose(c_sm_dense_value, c_dense_t_value)
 
+  @test.disable_for_rocm(skip_message='sparse-matrix-add op is not yet supported on ROCm')
   @test_util.run_in_graph_and_eager_modes
   def testLargeBatchRegisteredAddN(self):
     if not self._gpu_available:
       return
-
-    if test.is_built_with_rocm():
-      # sparse-matrix-add op is not yet supported on the ROCm platform
-      self.skipTest("sparse-matrix-add op not supported on ROCm")
 
     sparsify = lambda m: m * (m > 0)
     dense_shape = [53, 65, 127]

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -82,11 +82,9 @@ class BaseFFTOpsTest(test.TestCase):
     with self.cached_session(config=config, force_gpu=True):
       self._tf_fft(x, rank, fft_length=None)
 
+  @test.disable_for_rocm(skip_message='Complex datatype not yet supported in ROCm.')
   def _check_grad_complex(self, func, x, y, result_is_complex=True,
                           rtol=1e-2, atol=1e-2):
-    if test.is_built_with_rocm():
-      self.skipTest("Complex datatype not yet supported in ROCm.")
-      return
     with self.cached_session(use_gpu=True):
       def f(inx, iny):
         inx.set_shape(x.shape)
@@ -179,13 +177,11 @@ class FFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     self.assertEqual(x.shape, self._tf_fft(x, rank).shape)
     self.assertEqual(x.shape, self._tf_ifft(x, rank).shape)
 
+  @test.disable_for_rocm(skip_message='Complex datatype not yet supported in ROCm.')
   @parameterized.parameters(
       itertools.product(VALID_FFT_RANKS, range(3),
                         (np.complex64, np.complex128)))
   def test_basic(self, rank, extra_dims, np_type):
-    if test.is_built_with_rocm():
-      self.skipTest("Complex datatype not yet supported in ROCm.")
-      return
     dims = rank + extra_dims
     tol = 1e-4 if np_type == np.complex64 else 1e-8
     self._compare(

--- a/tensorflow/python/kernel_tests/signal/spectral_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/spectral_ops_test.py
@@ -283,6 +283,8 @@ class SpectralOpsTest(test.TestCase, parameterized.TestCase):
       sinusoid_gradient = self.evaluate(self._compute_stft_gradient(sinusoid))
       self.assertFalse((sinusoid_gradient == 0.0).all())
 
+  @test.disable_for_rocm(skip_message='On ROCm, this fails with mismatches at some locations '
+                                      '(possibly due to peculiarities of rocFFT - investigate)')
   @parameterized.parameters(
       (64, 16, 8, 16, np.float32, 2e-3, 5e-4),
       (64, 16, 8, 16, np.float64, 1e-8, 1e-8),
@@ -296,10 +298,6 @@ class SpectralOpsTest(test.TestCase, parameterized.TestCase):
       (29, 5, 1, 10, np.float64, 1e-8, 1e-8))
   def test_gradients_numerical(self, signal_length, frame_length, frame_step,
                                fft_length, np_rtype, forward_tol, backward_tol):
-    # On ROCm, this fails with mismatches at some locations
-    # (possibly due to peculiarities of rocFFT - investigate)
-    if test.is_built_with_rocm():
-      return
     # TODO(rjryan): Investigate why STFT gradient error is so high.
     signal = np.random.rand(signal_length).astype(np_rtype) * 2 - 1
 

--- a/tensorflow/python/ops/init_ops_test.py
+++ b/tensorflow/python/ops/init_ops_test.py
@@ -176,12 +176,9 @@ class InitializersTest(test.TestCase):
         self._runner(
             init_ops.Orthogonal(seed=123), tensor_shape, target_mean=0.)
 
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm due to missing QR op support')
   @test_util.run_gpu_only
   def testVariablePlacementWithOrthogonalInitializer(self):
-
-    if test.is_built_with_rocm():
-      self.skipTest('Disable subtest on ROCm due to missing QR op support')
-
     with ops.Graph().as_default() as g:
       with ops.device('gpu:0'):
         variable_scope.get_variable(

--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -2047,15 +2047,13 @@ class SpectralTest(PForTestCase, parameterized.TestCase):
 
     self._test_loop_fn(loop_fn, 2)
 
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm due to rocfft issues')
   @parameterized.parameters(
       (fft_ops.rfft,),
       (fft_ops.rfft2d,),
       (fft_ops.rfft3d,),
   )
   def test_rfft(self, op_func):
-    if test.is_built_with_rocm():
-      self.skipTest('Disable subtest on ROCm due to rocfft issues')
-
     for dtype in (dtypes.float32, dtypes.float64):
       x = random_ops.random_uniform([2, 3, 4, 3, 4], dtype=dtype)
 
@@ -2068,14 +2066,13 @@ class SpectralTest(PForTestCase, parameterized.TestCase):
 
       self._test_loop_fn(loop_fn, 2)
 
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm due to rocfft issues')
   @parameterized.parameters(
       (fft_ops.irfft,),
       (fft_ops.irfft2d,),
       (fft_ops.irfft3d,),
   )
   def test_irfft(self, op_func):
-    if test.is_built_with_rocm():
-      self.skipTest('Disable subtest on ROCm due to rocfft issues')
     if config.list_physical_devices("GPU"):
       # TODO(b/149957923): The test is flaky
       self.skipTest("b/149957923: irfft vectorization flaky")

--- a/tensorflow/python/ops/parallel_for/math_test.py
+++ b/tensorflow/python/ops/parallel_for/math_test.py
@@ -81,12 +81,8 @@ class MathTest(PForTestCase, parameterized.TestCase):
     ]
     self._test_unary_cwise_ops(complex_ops, True)
 
+  @test.disable_for_rocm(skip_message='This fails on ROCm.') #...see JIRA ticket 236756
   def test_unary_cwise_real_ops_1(self):
-    if test.is_built_with_rocm():
-      # TODO(rocm):
-      # This fails on ROCm...see JIRA ticket 236756
-      return
-
     real_ops = [
         lambda x: math_ops.acosh(1 + math_ops.square(x)),
         math_ops.abs,

--- a/tensorflow/python/platform/test.py
+++ b/tensorflow/python/platform/test.py
@@ -35,6 +35,8 @@ from tensorflow.python.ops.gradient_checker import compute_gradient_error
 from tensorflow.python.ops.gradient_checker import compute_gradient
 # pylint: enable=unused-import,g-bad-import-order
 
+from tensorflow.python.util import tf_decorator
+
 import sys
 from tensorflow.python.util.tf_export import tf_export
 if sys.version_info.major == 2:
@@ -95,12 +97,22 @@ def is_built_with_rocm():
   """Returns whether TensorFlow was built with ROCm (GPU) support."""
   return _test_util.IsBuiltWithROCm()
 
+@tf_export('test.disable_for_rocm')
+def disable_for_rocm(skip_message):
+  """Decorator that disables the test if TensorFlow was built with ROCm (GPU) support."""
+  def decorator_disable_for_rocm(func):
+    def wrapper_disable_for_rocm(self, *args, **kwargs):
+      if is_built_with_rocm():
+        self.skipTest(skip_message)
+      else:
+        return func(self, *args, **kwargs)
+    return tf_decorator.make_decorator(func, wrapper_disable_for_rocm)
+  return decorator_disable_for_rocm
 
 @tf_export('test.is_built_with_gpu_support')
 def is_built_with_gpu_support():
   """Returns whether TensorFlow was built with GPU (i.e. CUDA or ROCm) support."""
   return is_built_with_cuda() or is_built_with_rocm()
-
 
 @tf_export('test.is_built_with_xla')
 def is_built_with_xla():

--- a/tensorflow/python/profiler/internal/run_metadata_test.py
+++ b/tensorflow/python/profiler/internal/run_metadata_test.py
@@ -115,17 +115,15 @@ def _run_loop_model():
 
 class RunMetadataTest(test.TestCase):
 
+  # This test requires HARDWARE_TRACE or FULL_TRACE to be specified to
+  # work as expected. Since we now run this test with SOFTWARE_TRACE
+  # (see _run_model routine above), this test will / should fail since
+  # GPU device tracers are not enabled
+  @test.disable_for_rocm(skip_message="Test fails on ROCm when run without FULL_TRACE")
   @test_util.run_deprecated_v1
   def testGPU(self):
     if not test.is_gpu_available(cuda_only=True):
       return
-
-    # This test requires HARDWARE_TRACE or FULL_TRACE to be specified to
-    # work as expected. Since we now run this test with SOFTWARE_TRACE
-    # (see _run_model routine above), this test will / should fail since
-    # GPU device tracers are not enabled
-    if test.is_built_with_rocm():
-      self.skipTest("Test fails on ROCm when run without FULL_TRACE")
 
     gpu_dev = test.gpu_device_name()
     ops.reset_default_graph()
@@ -225,16 +223,14 @@ class RunMetadataTest(test.TestCase):
     for _, f in six.iteritems(back_to_forward):
       self.assertTrue(f in forward_op)
 
+  # This test requires HARDWARE_TRACE or FULL_TRACE to be specified to
+  # work as expected. Since we now run this test with SOFTWARE_TRACE
+  # (see _run_model routine above), this test will / should fail since
+  # GPU device tracers are not enabled
+  @test.disable_for_rocm(skip_message="Test fails on ROCm when run without FULL_TRACE")
   def testLoopGPU(self):
     if not test.is_gpu_available():
       return
-
-    # This test requires HARDWARE_TRACE or FULL_TRACE to be specified to
-    # work as expected. Since we now run this test with SOFTWARE_TRACE
-    # (see _run_model routine above), this test will / should fail since
-    # GPU device tracers are not enabled
-    if test.is_built_with_rocm():
-      self.skipTest("Test fails on ROCm when run without FULL_TRACE")
 
     ops.reset_default_graph()
     with ops.device('/device:GPU:0'):

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -466,6 +466,7 @@ def _create_dummy_repository(repository_ctx):
         {
             "%{rocm_is_configured}": "False",
             "%{rocm_extra_copts}": "[]",
+            "%{rocm_gpu_architectures}": "[]",
         },
     )
     _tpl(

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -466,7 +466,6 @@ def _create_dummy_repository(repository_ctx):
         {
             "%{rocm_is_configured}": "False",
             "%{rocm_extra_copts}": "[]",
-            "%{rocm_gpu_architectures}": "[]",
         },
     )
     _tpl(


### PR DESCRIPTION
Previously, any unit test that failed on the ROCm platform for reasons such some feature not being supported were skipped using inline checks in the unit test source itself.

This change converts most of those to use a standard decorator.

This change stems from this feedback comment
tensorflow/tensorflow#42689 (comment)