### PR TITLE
Removing CC_OPT_FLAGS='-mavx' from the CI scripts. 

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -15,7 +15,7 @@ if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi
 
-ROCM_PATH=$ROCM_INSTALL_DIR ./dummy.sh
+ROCM_PATH=$ROCM_INSTALL_DIR
 
 # Explicitly delete the old whl packages in the /tmp/tensorflow_pkg dir
 # Doing so comes in handy when the TF version number changes, because

--- a/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cc_core.sh
@@ -35,7 +35,6 @@ fi
 
 # Run configure.
 export PYTHON_BIN_PATH=`which python3`
-export CC_OPT_FLAGS='-mavx'
 
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR

--- a/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_csb_tests.sh
@@ -35,7 +35,6 @@ fi
 
 # Run configure.
 export PYTHON_BIN_PATH=`which python3`
-export CC_OPT_FLAGS='-mavx'
 
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR

--- a/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_py3_core.sh
@@ -35,7 +35,6 @@ fi
 
 # Run configure.
 export PYTHON_BIN_PATH=`which python3`
-export CC_OPT_FLAGS='-mavx'
 
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR

--- a/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
+++ b/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
@@ -35,7 +35,6 @@ fi
 
 # Run configure.
 export PYTHON_BIN_PATH=`which python3`
-export CC_OPT_FLAGS='-mavx'
 
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR

--- a/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
+++ b/tensorflow/tools/ci_build/xla/linux/rocm/run_py3.sh
@@ -40,7 +40,6 @@ export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR
 
 yes "" | $PYTHON_BIN_PATH configure.py
-echo "build --distinct_host_configuration=false" >> .tf_configure.bazelrc
 
 # Run bazel test command. Double test timeouts to avoid flakes.
 bazel test \


### PR DESCRIPTION
Having the CC_OPT_FLAGS env var set, prior to running the `configure.py` scritps results in its value taking precendence over the default option, which is the `-march=haswell` setting (which implies `-mavx` amongst others).

Since our build script does not explicitly set CC_OPT_FLAGS, this commit updates the CI scripts to not do it either, making them consistent with the build script

-----------------------

 Removing the bazel build option `--distinct_host_configuration=false` from the rocm-xla CI script. This option has been present for a very long time (we probably inherited it from the original script for running XLA tests on GPU), and I do not quite understand why it is needed (documentation is not helpful). So removing it to see it if it has any adverse side effects. If not, then it goes away permanently
