### PR TITLE
 Adding #defines for ROCm / MIOpen / HIP Runtime version numbers 

### DIFF
--- a/third_party/gpus/find_rocm_config.py
+++ b/third_party/gpus/find_rocm_config.py
@@ -1,0 +1,284 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Prints ROCm library and header directories and versions found on the system.
+
+The script searches for ROCm library and header files on the system, inspects
+them to determine their version and prints the configuration to stdout.
+The path to inspect is specified through an environment variable (ROCM_PATH).
+If no valid configuration is found, the script prints to stderr and
+returns an error code.
+
+The script takes the directory specified by the ROCM_PATH environment variable.
+The script looks for headers and library files in a hard-coded set of
+subdirectories from base path of the specified directory. If ROCM_PATH is not
+specified, then "/opt/rocm" is used as it default value
+
+"""
+
+import io
+import os
+import re
+import sys
+
+class ConfigError(Exception):
+  pass
+
+
+def _get_default_rocm_path():
+  return "/opt/rocm"
+
+
+def _get_rocm_install_path():
+  """Determines and returns the ROCm installation path"""
+  rocm_install_path = _get_default_rocm_path()
+  if "ROCM_PATH" in os.environ:
+    rocm_install_path = os.environ["ROCM_PATH"]
+  # rocm_install_path = os.path.realpath(rocm_install_path)
+  return rocm_install_path
+
+
+def _get_composite_version_number(major, minor, patch):
+  return 10000*major + 100*minor + patch
+
+
+def _get_header_version(path, name):
+  """Returns preprocessor defines in C header file."""
+  for line in io.open(path, "r", encoding="utf-8").readlines():
+    match = re.match("#define %s +(\d+)" % name, line)
+    if match:
+      value = match.group(1)
+      return int(value)
+
+  raise ConfigError(
+    '#define "{}" is either\n'.format(name) +
+    '  not present in file {} OR\n'.format(path) +
+    '  its value is not an integer literal')
+
+
+def _find_rocm_config(rocm_install_path):
+
+  def rocm_version_numbers(path):
+    version_file = os.path.join(path, ".info/version-dev")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'ROCm version file "{}" not found'.format(version_file))
+    version_numbers = []
+    with open(version_file) as f:
+      version_string = f.read().strip()
+      version_numbers = version_string.split(".")
+    major = int(version_numbers[0])
+    minor = int(version_numbers[1])
+    patch = int(version_numbers[2].split("-")[0])
+    return  major, minor, patch
+
+  major, minor, patch = rocm_version_numbers(rocm_install_path)
+
+  rocm_config = {
+    "rocm_version_number" :
+    _get_composite_version_number(major, minor, patch)
+  }
+
+  return rocm_config
+
+
+def _find_hipruntime_config(rocm_install_path):
+
+  def hipruntime_version_number(path):
+    version_file = os.path.join(path, "hip/include/hip/hip_version.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'HIP Runtime version file "{}" not found'.format(version_file))
+    # This header file has an explicit #define for HIP_VERSION, whose value
+    # is (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR)
+    # Retreive the major + minor and re-calculate here, since we do not
+    # want get into the business of parsing arith exprs
+    major = _get_header_version(version_file, "HIP_VERSION_MAJOR")
+    minor = _get_header_version(version_file, "HIP_VERSION_MINOR")
+    return 100*major + minor
+
+  hipruntime_config = {
+    "hipruntime_version_number" :
+    hipruntime_version_number(rocm_install_path)
+  }
+
+  return hipruntime_config
+
+
+def _find_miopen_config(rocm_install_path):
+
+  def miopen_version_numbers(path):
+    version_file = os.path.join(path, "miopen/include/miopen/version.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'MIOpen version file "{}" not found'.format(version_file))
+    version_numbers = []
+    major = _get_header_version(version_file, "MIOPEN_VERSION_MAJOR")
+    minor = _get_header_version(version_file, "MIOPEN_VERSION_MINOR")
+    patch = _get_header_version(version_file, "MIOPEN_VERSION_PATCH")
+    return  major, minor, patch
+
+  major, minor, patch = miopen_version_numbers(rocm_install_path)
+
+  miopen_config = {
+    "miopen_version_number" :
+    _get_composite_version_number(major, minor, patch)
+  }
+
+  return miopen_config
+
+
+def _find_rocblas_config(rocm_install_path):
+
+  def rocblas_version_numbers(path):
+    version_file = os.path.join(path, "rocblas/include/rocblas-version.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'rocblas version file "{}" not found'.format(version_file))
+    version_numbers = []
+    major = _get_header_version(version_file, "ROCBLAS_VERSION_MAJOR")
+    minor = _get_header_version(version_file, "ROCBLAS_VERSION_MINOR")
+    patch = _get_header_version(version_file, "ROCBLAS_VERSION_PATCH")
+    return  major, minor, patch
+
+  major, minor, patch = rocblas_version_numbers(rocm_install_path)
+
+  rocblas_config = {
+    "rocblas_version_number" :
+    _get_composite_version_number(major, minor, patch)
+  }
+
+  return rocblas_config
+
+
+def _find_rocrand_config(rocm_install_path):
+
+  def rocrand_version_number(path):
+    version_file = os.path.join(path, "rocrand/include/rocrand_version.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'rocblas version file "{}" not found'.format(version_file))
+    version_number = _get_header_version(version_file, "ROCRAND_VERSION")
+    return  version_number
+
+  rocrand_config = {
+    "rocrand_version_number" : rocrand_version_number(rocm_install_path)
+  }
+
+  return rocrand_config
+
+
+def _find_rocfft_config(rocm_install_path):
+
+  def rocfft_version_numbers(path):
+    version_file = os.path.join(path, "rocfft/include/rocfft-version.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'rocfft version file "{}" not found'.format(version_file))
+    version_numbers = []
+    major = _get_header_version(version_file, "rocfft_version_major")
+    minor = _get_header_version(version_file, "rocfft_version_minor")
+    patch = _get_header_version(version_file, "rocfft_version_patch")
+    return  major, minor, patch
+
+  major, minor, patch = rocfft_version_numbers(rocm_install_path)
+
+  rocfft_config = {
+    "rocfft_version_number" :
+    _get_composite_version_number(major, minor, patch)
+  }
+
+  return rocfft_config
+
+
+def _find_roctracer_config(rocm_install_path):
+
+  def roctracer_version_numbers(path):
+    version_file = os.path.join(path, "roctracer/include/roctracer.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'roctracer version file "{}" not found'.format(version_file))
+    version_numbers = []
+    major = _get_header_version(version_file, "ROCTRACER_VERSION_MAJOR")
+    minor = _get_header_version(version_file, "ROCTRACER_VERSION_MINOR")
+    # roctracer header does not have a patch version number
+    patch = 0
+    return  major, minor, patch
+
+  major, minor, patch = roctracer_version_numbers(rocm_install_path)
+
+  roctracer_config = {
+    "roctracer_version_number" :
+    _get_composite_version_number(major, minor, patch)
+  }
+
+  return roctracer_config
+
+
+def _find_hipsparse_config(rocm_install_path):
+
+  def hipsparse_version_numbers(path):
+    version_file = os.path.join(path, "hipsparse/include/hipsparse-version.h")
+    if not os.path.exists(version_file):
+      raise ConfigError(
+        'hipsparse version file "{}" not found'.format(version_file))
+    version_numbers = []
+    major = _get_header_version(version_file, "hipsparseVersionMajor")
+    minor = _get_header_version(version_file, "hipsparseVersionMinor")
+    patch = _get_header_version(version_file, "hipsparseVersionPatch")
+    return  major, minor, patch
+
+  major, minor, patch = hipsparse_version_numbers(rocm_install_path)
+
+  hipsparse_config = {
+    "hipsparse_version_number" :
+    _get_composite_version_number(major, minor, patch)
+  }
+
+  return hipsparse_config
+
+
+def find_rocm_config():
+  """Returns a dictionary of ROCm components config info."""
+  rocm_install_path = _get_rocm_install_path()
+  if not os.path.exists(rocm_install_path):
+    raise ConfigError(
+      'Specified ROCM_PATH "{}" does not exist'.format(rocm_install_path))
+
+  result = {}
+
+  result["rocm_toolkit_path"] = rocm_install_path
+  result.update(_find_rocm_config(rocm_install_path))
+  result.update(_find_hipruntime_config(rocm_install_path))
+  result.update(_find_miopen_config(rocm_install_path))
+  result.update(_find_rocblas_config(rocm_install_path))
+  result.update(_find_rocrand_config(rocm_install_path))
+  result.update(_find_rocfft_config(rocm_install_path))
+  result.update(_find_roctracer_config(rocm_install_path))
+  result.update(_find_hipsparse_config(rocm_install_path))
+
+  return result
+
+
+def main():
+  try:
+    for key, value in sorted(find_rocm_config().items()):
+      print("%s: %s" % (key, value))
+  except ConfigError as e:
+    sys.stderr.write("\nERROR: {}\n\n".format(str(e)))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/gpus/rocm/rocm_config.h.tpl
@@ -18,4 +18,8 @@ limitations under the License.
 
 #define TF_ROCM_TOOLKIT_PATH "%{rocm_toolkit_path}"
 
+#define TF_ROCM_VERSION %{rocm_version_number}
+#define TF_MIOPEN_VERSION %{miopen_version_number}
+#define TF_HIPRUNTIME_VERSION %{hipruntime_version_number}
+
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -4,11 +4,7 @@
 
   * `TF_NEED_ROCM`: Whether to enable building with ROCm.
   * `GCC_HOST_COMPILER_PATH`: The GCC host compiler path
-  * `ROCM_TOOLKIT_PATH`: The path to the ROCm toolkit. Default is
-    `/opt/rocm`.
-  * `TF_ROCM_VERSION`: The version of the ROCm toolkit. If this is blank, then
-    use the system default.
-  * `TF_MIOPEN_VERSION`: The version of the MIOpen library.
+  * `ROCM_PATH`: The path to the ROCm toolkit. Default is `/opt/rocm`.
   * `TF_ROCM_AMDGPU_TARGETS`: The AMDGPU targets.
 """
 
@@ -35,13 +31,9 @@ load(
 _GCC_HOST_COMPILER_PATH = "GCC_HOST_COMPILER_PATH"
 _GCC_HOST_COMPILER_PREFIX = "GCC_HOST_COMPILER_PREFIX"
 _ROCM_TOOLKIT_PATH = "ROCM_PATH"
-_TF_ROCM_VERSION = "TF_ROCM_VERSION"
-_TF_MIOPEN_VERSION = "TF_MIOPEN_VERSION"
 _TF_ROCM_AMDGPU_TARGETS = "TF_ROCM_AMDGPU_TARGETS"
 _TF_ROCM_CONFIG_REPO = "TF_ROCM_CONFIG_REPO"
 
-_DEFAULT_ROCM_VERSION = ""
-_DEFAULT_MIOPEN_VERSION = ""
 _DEFAULT_ROCM_TOOLKIT_PATH = "/opt/rocm"
 
 def verify_build_defines(params):
@@ -818,8 +810,6 @@ _ENVIRONS = [
     _GCC_HOST_COMPILER_PREFIX,
     "TF_NEED_ROCM",
     _ROCM_TOOLKIT_PATH,
-    _TF_ROCM_VERSION,
-    _TF_MIOPEN_VERSION,
     _TF_ROCM_AMDGPU_TARGETS,
 ]
 

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -23,6 +23,7 @@ load(
     "get_bash_bin",
     "get_cpu_value",
     "get_host_environ",
+    "get_python_bin",
     "raw_exec",
     "realpath",
     "which",
@@ -205,20 +206,6 @@ def _enable_rocm(repository_ctx):
         return True
     return False
 
-def _rocm_toolkit_path(repository_ctx, bash_bin):
-    """Finds the rocm toolkit directory.
-
-    Args:
-      repository_ctx: The repository context.
-
-    Returns:
-      A speculative real path of the rocm toolkit install directory.
-    """
-    rocm_toolkit_path = get_host_environ(repository_ctx, _ROCM_TOOLKIT_PATH, _DEFAULT_ROCM_TOOLKIT_PATH)
-    if files_exist(repository_ctx, [rocm_toolkit_path], bash_bin) != [True]:
-        auto_configure_fail("Cannot find rocm toolkit path.")
-    return rocm_toolkit_path
-
 def _amdgpu_targets(repository_ctx, rocm_toolkit_path, bash_bin):
     """Returns a list of strings representing AMDGPU targets."""
     amdgpu_targets_str = get_host_environ(repository_ctx, _TF_ROCM_AMDGPU_TARGETS)
@@ -395,7 +382,20 @@ def _find_libs(repository_ctx, rocm_config, bash_bin):
 
     return _select_rocm_lib_paths(repository_ctx, libs_paths, bash_bin)
 
-def _get_rocm_config(repository_ctx, bash_bin):
+def _exec_find_rocm_config(repository_ctx, script_path):
+    python_bin = get_python_bin(repository_ctx)
+    return execute(repository_ctx, [python_bin, script_path])
+
+def find_rocm_config(repository_ctx, script_path):
+    """Returns ROCm config dictionary from running find_rocm_config.py"""
+    exec_result = _exec_find_rocm_config(repository_ctx, script_path)
+    if exec_result.return_code:
+        auto_configure_fail("Failed to run find_rocm_config.py: %s" % err_out(exec_result))
+
+    # Parse the dict from stdout.
+    return dict([tuple(x.split(": ")) for x in exec_result.stdout.splitlines()])
+
+def _get_rocm_config(repository_ctx, bash_bin, find_rocm_config_script):
     """Detects and returns information about the ROCm installation on the system.
 
     Args:
@@ -406,11 +406,21 @@ def _get_rocm_config(repository_ctx, bash_bin):
       A struct containing the following fields:
         rocm_toolkit_path: The ROCm toolkit installation directory.
         amdgpu_targets: A list of the system's AMDGPU targets.
+        rocm_version_number: The version of ROCm on the system.
+        miopen_version_number: The version of MIOpen on the system.
+        hipruntime_version_number: The version of HIP Runtime on the system.
     """
-    rocm_toolkit_path = _rocm_toolkit_path(repository_ctx, bash_bin)
+    config = find_rocm_config(repository_ctx, find_rocm_config_script)
+    rocm_toolkit_path = config["rocm_toolkit_path"]
+    rocm_version_number = config["rocm_version_number"]
+    miopen_version_number = config["miopen_version_number"]
+    hipruntime_version_number = config["hipruntime_version_number"]
     return struct(
-        rocm_toolkit_path = rocm_toolkit_path,
         amdgpu_targets = _amdgpu_targets(repository_ctx, rocm_toolkit_path, bash_bin),
+        rocm_toolkit_path = rocm_toolkit_path,
+        rocm_version_number = rocm_version_number,
+        miopen_version_number = miopen_version_number,
+        hipruntime_version_number = hipruntime_version_number,
     )
 
 def _tpl_path(repository_ctx, labelname):
@@ -544,8 +554,10 @@ def _create_local_rocm_repository(repository_ctx):
         "rocm:rocm_config.h",
     ]}
 
+    find_rocm_config_script = repository_ctx.path(Label("@org_tensorflow//third_party/gpus:find_rocm_config.py"))
+
     bash_bin = get_bash_bin(repository_ctx)
-    rocm_config = _get_rocm_config(repository_ctx, bash_bin)
+    rocm_config = _get_rocm_config(repository_ctx, bash_bin, find_rocm_config_script)
 
     # Copy header and library files to execroot.
     # rocm_toolkit_path
@@ -746,6 +758,9 @@ def _create_local_rocm_repository(repository_ctx):
                 ["\"%s\"" % c for c in rocm_config.amdgpu_targets],
             ),
             "%{rocm_toolkit_path}": rocm_config.rocm_toolkit_path,
+            "%{rocm_version_number}": rocm_config.rocm_version_number,
+            "%{miopen_version_number}": rocm_config.miopen_version_number,
+            "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
         },
     )
 


### PR DESCRIPTION
This PR/commit introduces the following #defines in the `rocm/rocm_config.h` file

```
#define TF_ROCM_VERSION <Version Number of ROCm install>
#define TF_MIOPEN_VERSION <Verion Number of MIOpen in ROCm install>
#define TF_HIPRUNTIME_VERSION <Version Number of HIP Runtinme in ROCm install>
```

These #defines should be used within TF code to add ROCm/MIOpen/HIP Runtime version specific code.

Details on how we go about determining these version numbers can found on the following wiki-page

https://github.com/ROCmSoftwarePlatform/tensorflow-internal/wiki/How-to-add-ROCm-version-specific-code-changes-in-the-TensorFlow-code%3F

A new script `find_rocm_config.py` is being added by this commit. This script does all the work of determining the version number information and it is pretty easy to extend it to query more information about the ROCM install.

The information collected by the script is available to `rocm_configure.bzl` and hence can be used to add version specific code in `rocm_configure.bzl` as well.
