### PR TITLE
[r1.15-rocm-enhanced] Updating the run_pip_tests.sh script to properly pick up the ROCM specific bazel test options

### DIFF
--- a/tensorflow/tools/ci_build/builds/run_pip_tests.sh
+++ b/tensorflow/tools/ci_build/builds/run_pip_tests.sh
@@ -54,7 +54,7 @@ while true; do
   elif [[ "$1" == "--gpu" ]]; then
     IS_GPU=1
   elif [[ "$1" == "--rocm" ]]; then
-      IS_ROCM=1
+    IS_ROCM=1
   elif [[ "$1" == "--mac" ]]; then
     IS_MAC=1
   elif [[ "$1" == "--oss_serial" ]]; then
@@ -68,6 +68,11 @@ while true; do
 done
 
 TF_GPU_COUNT=${TF_GPU_COUNT:-4}
+if [[ ${IS_ROCM} == "1" ]]; then
+  TF_GPU_COUNT=$(lspci|grep 'controller'|grep 'AMD/ATI'|wc -l)
+  TF_TESTS_PER_GPU=1
+  N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
+fi
 
 # PIP tests should have a "different" path. Different than the one we place
 # virtualenv, because we are deleting and recreating it here.
@@ -87,7 +92,7 @@ else
   PIP_TEST_FILTER_TAG="${PIP_TEST_FILTER_TAG},-oss_serial"
 fi
 
-if [[ ${IS_GPU} == "1" ]]; then
+if [[ ${IS_GPU} == "1" ]] || [[ ${IS_ROCM} == "1" ]]; then
   PIP_TEST_FILTER_TAG="-no_gpu,-no_pip_gpu,${PIP_TEST_FILTER_TAG}"
 fi
 if [[ ${IS_ROCM} == "1" ]]; then
@@ -104,8 +109,17 @@ fi
 #     TF_BUILD_APPEND_ARGUMENTS any user supplied args.
 BAZEL_FLAGS="--define=no_tensorflow_py_deps=true --test_lang_filters=py \
   --build_tests_only -k --test_tag_filters=${PIP_TEST_FILTER_TAG} \
-  --test_timeout 300,450,1200,3600 ${TF_BUILD_APPEND_ARGUMENTS} \
+  ${TF_BUILD_APPEND_ARGUMENTS} \
   --test_output=errors"
+
+if [[ ${IS_ROCM} == "1" ]]; then
+  BAZEL_FLAGS="${BAZEL_FLAGS} \
+  --test_timeout 600,900,2400,7200"
+else
+  BAZEL_FLAGS="${BAZEL_FLAGS} \
+  --test_timeout 300,450,1200,3600"
+fi
+
 
 BAZEL_TEST_TARGETS="//${PIP_TEST_PREFIX}/tensorflow/contrib/... \
   //${PIP_TEST_PREFIX}/tensorflow/python/... \
@@ -129,7 +143,7 @@ fi
 
 export TF_NEED_CUDA=$IS_GPU
 export TF_NEED_ROCM=$IS_ROCM
-${PYTHON_BIN_PATH} configure.py
+yes "" | ${PYTHON_BIN_PATH} configure.py
 
 # Figure out how many concurrent tests we can run and do run the tests.
 BAZEL_PARALLEL_TEST_FLAGS=""
@@ -137,6 +151,12 @@ if [[ $IS_GPU == 1 ]] || [[ $IS_ROCM == 1 ]]; then
   # Number of test threads is the number of GPU cards available.
   if [[ $IS_MAC == 1 ]]; then
     BAZEL_PARALLEL_TEST_FLAGS="--local_test_jobs=1"
+  elif [[ $IS_ROCM == 1 ]]; then
+    BAZEL_PARALLEL_TEST_FLAGS="--local_test_jobs=${N_TEST_JOBS} \
+        --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+        --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+        --test_sharding_strategy=disabled \
+        --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute"
   else
     PAR_TEST_JOBS=$TF_GPU_COUNT
     BAZEL_PARALLEL_TEST_FLAGS="--local_test_jobs=${TF_GPU_COUNT} \


### PR DESCRIPTION
@sunway513 please review and merge

This PR is to fix JIRA ticket - http://ontrack-internal.amd.com/browse/SWDEV-254681. It adds ROCm specfic options to the `run_pip_tests.sh` script, so that it works correctly on 8-GPU nodes.

The develop-upstream version of this change is in this PR - https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1135

We will need to cherry-pick this PR/commit into all branches in which QA runs this script.