### PR TITLE
Fixing //tensorflow/python:nn_fused_batchnorm_test

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -5321,7 +5321,6 @@ cuda_py_test(
     python_version = "PY3",
     shard_count = 24,
     tfrt_enabled = True,
-    tags = ["no_rocm"],
     deps = [
         ":array_ops",
         ":client_testlib",

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -3711,8 +3711,6 @@ bool MIOpenSupport::DoBatchNormalizationForwardImpl(
 
   auto status = miopenStatusInvalidValue;
   if (is_training) {
-    stream->ThenMemZero(batch_mean, batch_mean->size());
-    stream->ThenMemZero(batch_var, batch_var->size());
     status = wrap::miopenBatchNormalizationForwardTraining(
         miopen.handle(), mode, &one, &zero, x_descriptor.handle(), x.opaque(),
         x_descriptor.handle(), y->opaque(), scale_offset_descriptor.handle(),


### PR DESCRIPTION
This fixes several failing subtests of //tensorflow/python:nn_fused_batchnorm_test by correcting the calculation of batch_mean and batch_var when exponential_average_factor is not set to the default value.