### PR TITLE
Reorg ci scripts cpu gpu

### DIFF
--- a/tensorflow/compiler/xla/pjrt/BUILD
+++ b/tensorflow/compiler/xla/pjrt/BUILD
@@ -263,6 +263,7 @@ tf_cc_test(
         "no_oss",
         "requires-gpu-nvidia",
         "notap",
+        "gpu",
     ],
     deps = [
         ":nvidia_gpu_device",

--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -75,6 +75,7 @@ py_test(
         "no_oss",
         "no_rocm",
         "requires-gpu-nvidia",
+        "gpu",
     ],  # TODO(phawkins): This test passes, but requires --config=monolithic.
     deps = [
         ":xla_client",

--- a/tensorflow/core/kernels/dropout_op.cc
+++ b/tensorflow/core/kernels/dropout_op.cc
@@ -20,7 +20,6 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/random_op.h"
 #include "tensorflow/core/platform/random.h"
-#include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/util/guarded_philox_random.h"
 #include "tensorflow/core/util/tensor_format.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"

--- a/tensorflow/core/kernels/dropout_op.h
+++ b/tensorflow/core/kernels/dropout_op.h
@@ -46,7 +46,6 @@ struct ApplyDropoutGrad<GPUDevice, T> {
   void operator()(const GPUDevice& d, T* outgrads, const T* grads, const uint8* mask,
                   float rate, uint64 num_elements);
 };
-};
 #endif
-
+}
 #endif

--- a/tensorflow/python/keras/layers/lstm_test.py
+++ b/tensorflow/python/keras/layers/lstm_test.py
@@ -141,9 +141,9 @@ class LSTMLayerTest(keras_parameterized.TestCase):
     self.assertEqual(layer.cell.recurrent_kernel.constraint, r_constraint)
     self.assertEqual(layer.cell.bias.constraint, b_constraint)
 
+  @parameterized.parameters([True, False])
   @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen '
                                       'does not support padded input.')
-  @parameterized.parameters([True, False])
   def test_with_masking_layer_LSTM(self, unroll):
     layer_class = keras.layers.LSTM
     inputs = np.random.random((2, 3, 4))

--- a/tensorflow/python/keras/layers/wrappers_test.py
+++ b/tensorflow/python/keras/layers/wrappers_test.py
@@ -974,10 +974,10 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
       self.assertLen(y, 5)
       self.assertAllClose(y[0], np.concatenate([y[1], y[3]], axis=1))
 
+  @parameterized.parameters([keras.layers.LSTM, keras.layers.GRU])
   @test.disable_for_rocm(skip_message='Skipping the test as ROCm '
                                       'MIOpen does not support '
                                       'padded input yet.')
-  @parameterized.parameters([keras.layers.LSTM, keras.layers.GRU])
   def test_Bidirectional_sequence_output_with_masking(self, rnn):
     samples = 2
     dim = 5
@@ -1179,9 +1179,9 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
         epochs=1,
         batch_size=10)
 
+  @parameterized.parameters(['ave', 'concat', 'mul'])
   @test.disable_for_rocm(skip_message='Skipping the test as ROCm RNN does not '
                                       'support ragged tensors yet.')
-  @parameterized.parameters(['ave', 'concat', 'mul'])
   def test_Bidirectional_ragged_input(self, merge_mode):
     np.random.seed(100)
     rnn = keras.layers.LSTM

--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -2123,13 +2123,13 @@ class SpectralTest(PForTestCase, parameterized.TestCase):
 
     self._test_loop_fn(loop_fn, 2)
 
-  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
-                                      'due to rocfft issues')
   @parameterized.parameters(
       (fft_ops.rfft,),
       (fft_ops.rfft2d,),
       (fft_ops.rfft3d,),
   )
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
+                                      'due to rocfft issues')
   def test_rfft(self, op_func):
     for dtype in (dtypes.float32, dtypes.float64):
       x = random_ops.random_uniform([2, 3, 4, 3, 4], dtype=dtype)
@@ -2143,13 +2143,13 @@ class SpectralTest(PForTestCase, parameterized.TestCase):
 
       self._test_loop_fn(loop_fn, 2)
 
-  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
-                                      'due to rocfft issues')
   @parameterized.parameters(
       (fft_ops.irfft,),
       (fft_ops.irfft2d,),
       (fft_ops.irfft3d,),
   )
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
+                                      'due to rocfft issues')
   def test_irfft(self, op_func):
     if config.list_physical_devices("GPU"):
       # TODO(b/149957923): The test is flaky

--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.py
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+set -e
+set -x
+
+N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
+
+echo ""
+echo "Bazel will use ${N_BUILD_JOBS} concurrent build job(s) and ${N_BUILD__JOBS} concurrent test job(s)."
+echo ""
+
+# First positional argument (if any) specifies the ROCM_INSTALL_DIR
+ROCM_INSTALL_DIR=/opt/rocm-3.8.0
+if [[ -n $1 ]]; then
+    ROCM_INSTALL_DIR=$1
+fi
+
+# Run configure.
+export PYTHON_BIN_PATH=`which python3`
+
+# Force CPU
+export TF_NEED_ROCM=0
+
+yes "" | $PYTHON_BIN_PATH configure.py
+
+# Run bazel test command. Double test timeouts to avoid flakes.
+bazel test \
+      -k \
+      --test_tag_filters=-no_oss,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only \
+      --test_lang_filters=py,cc \
+      --jobs=${N_BUILD_JOBS} \
+      --local_test_jobs=${N_BUILD_JOBS} \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium \
+      -- \
+      //tensorflow/... \
+      -//tensorflow/compiler/... \
+      -//tensorflow/python/integration_testing/... \
+      -//tensorflow/core/tpu/... \
+      -//tensorflow/lite/... \
+&& bazel test \
+       --config=xla \
+      -k \
+      --test_tag_filters=-no_oss,-oss_serial,-gpu,-benchmark-test,-v1only \
+      --jobs=${N_BUILD_JOBS} \
+      --local_test_jobs=${N_BUILD_JOBS} \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium \
+      -- \
+      //tensorflow/compiler/... \

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_1.py
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_1.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+set -e
+set -x
+
+N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
+TF_GPU_COUNT=$(lspci|grep 'controller'|grep 'AMD/ATI'|wc -l)
+TF_TESTS_PER_GPU=1
+N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
+
+echo ""
+echo "Bazel will use ${N_BUILD_JOBS} concurrent build job(s) and ${N_TEST_JOBS} concurrent test job(s)."
+echo ""
+
+# First positional argument (if any) specifies the ROCM_INSTALL_DIR
+ROCM_INSTALL_DIR=/opt/rocm-3.8.0
+if [[ -n $1 ]]; then
+    ROCM_INSTALL_DIR=$1
+fi
+
+# Run configure.
+export PYTHON_BIN_PATH=`which python3`
+
+export TF_NEED_ROCM=1
+export ROCM_PATH=$ROCM_INSTALL_DIR
+
+yes "" | $PYTHON_BIN_PATH configure.py
+
+# Run bazel test command. Double test timeouts to avoid flakes.
+bazel test \
+      --config=rocm \
+      -k \
+      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
+      --test_lang_filters=py,cc \
+      --jobs=${N_BUILD_JOBS} \
+      --local_test_jobs=${N_TEST_JOBS} \
+      --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+      --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium \
+      --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
+      -- \
+      //tensorflow/... \
+      -//tensorflow/compiler/... \
+      -//tensorflow/python/integration_testing/... \
+      -//tensorflow/core/tpu/... \
+      -//tensorflow/lite/... \
+&& bazel test \
+      --config=rocm \
+      --config=xla \
+      -k \
+      --test_tag_filters=-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
+      --jobs=${N_BUILD_JOBS} \
+      --local_test_jobs=${N_TEST_JOBS} \
+      --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+      --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium \
+      --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
+      -- \
+      //tensorflow/compiler/... \

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_n.py
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_n.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+set -e
+set -x
+
+N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
+
+echo ""
+echo "Bazel will use ${N_BUILD_JOBS} concurrent build job(s) and ${N_TEST_JOBS} concurrent test job(s)."
+echo ""
+
+# First positional argument (if any) specifies the ROCM_INSTALL_DIR
+ROCM_INSTALL_DIR=/opt/rocm-3.8.0
+if [[ -n $1 ]]; then
+    ROCM_INSTALL_DIR=$1
+fi
+
+# Run configure.
+export PYTHON_BIN_PATH=`which python3`
+
+export TF_NEED_ROCM=1
+export ROCM_PATH=$ROCM_INSTALL_DIR
+
+yes "" | $PYTHON_BIN_PATH configure.py
+
+# Run bazel test command. Double test timeouts to avoid flakes.
+bazel test \
+      --config=rocm \
+      -k \
+      --test_tag_filters=gpu \
+      --jobs=${N_BUILD_JOBS} \
+      --test_timeout 600,900,2400,7200 \
+      --build_tests_only \
+      --test_output=errors \
+      --test_sharding_strategy=disabled \
+      --test_size_filters=small,medium,large \
+      -- \
+      //tensorflow/core/nccl:nccl_manager_test


### PR DESCRIPTION
Reorganize the CI scripts around "CPU" and "GPU" instead of by language and features to be more aligned with upstream.