### PR TITLE
Build and test fixes for CI script reorg around 'GPU' and 'CPU'.

### DIFF
--- a/tensorflow/compiler/xla/pjrt/BUILD
+++ b/tensorflow/compiler/xla/pjrt/BUILD
@@ -263,6 +263,7 @@ tf_cc_test(
         "no_oss",
         "requires-gpu-nvidia",
         "notap",
+        "gpu",
     ],
     deps = [
         ":nvidia_gpu_device",

--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -75,6 +75,7 @@ py_test(
         "no_oss",
         "no_rocm",
         "requires-gpu-nvidia",
+        "gpu",
     ],  # TODO(phawkins): This test passes, but requires --config=monolithic.
     deps = [
         ":xla_client",

--- a/tensorflow/core/kernels/dropout_op.cc
+++ b/tensorflow/core/kernels/dropout_op.cc
@@ -20,7 +20,6 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/random_op.h"
 #include "tensorflow/core/platform/random.h"
-#include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/util/guarded_philox_random.h"
 #include "tensorflow/core/util/tensor_format.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"

--- a/tensorflow/core/kernels/dropout_op.h
+++ b/tensorflow/core/kernels/dropout_op.h
@@ -46,7 +46,6 @@ struct ApplyDropoutGrad<GPUDevice, T> {
   void operator()(const GPUDevice& d, T* outgrads, const T* grads, const uint8* mask,
                   float rate, uint64 num_elements);
 };
-};
 #endif
-
+}
 #endif

--- a/tensorflow/python/keras/layers/lstm_test.py
+++ b/tensorflow/python/keras/layers/lstm_test.py
@@ -141,9 +141,9 @@ class LSTMLayerTest(keras_parameterized.TestCase):
     self.assertEqual(layer.cell.recurrent_kernel.constraint, r_constraint)
     self.assertEqual(layer.cell.bias.constraint, b_constraint)
 
+  @parameterized.parameters([True, False])
   @test.disable_for_rocm(skip_message='Skipping the test as ROCm MIOpen '
                                       'does not support padded input.')
-  @parameterized.parameters([True, False])
   def test_with_masking_layer_LSTM(self, unroll):
     layer_class = keras.layers.LSTM
     inputs = np.random.random((2, 3, 4))

--- a/tensorflow/python/keras/layers/wrappers_test.py
+++ b/tensorflow/python/keras/layers/wrappers_test.py
@@ -974,10 +974,10 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
       self.assertLen(y, 5)
       self.assertAllClose(y[0], np.concatenate([y[1], y[3]], axis=1))
 
+  @parameterized.parameters([keras.layers.LSTM, keras.layers.GRU])
   @test.disable_for_rocm(skip_message='Skipping the test as ROCm '
                                       'MIOpen does not support '
                                       'padded input yet.')
-  @parameterized.parameters([keras.layers.LSTM, keras.layers.GRU])
   def test_Bidirectional_sequence_output_with_masking(self, rnn):
     samples = 2
     dim = 5
@@ -1179,9 +1179,9 @@ class BidirectionalTest(test.TestCase, parameterized.TestCase):
         epochs=1,
         batch_size=10)
 
+  @parameterized.parameters(['ave', 'concat', 'mul'])
   @test.disable_for_rocm(skip_message='Skipping the test as ROCm RNN does not '
                                       'support ragged tensors yet.')
-  @parameterized.parameters(['ave', 'concat', 'mul'])
   def test_Bidirectional_ragged_input(self, merge_mode):
     np.random.seed(100)
     rnn = keras.layers.LSTM

--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -2123,13 +2123,13 @@ class SpectralTest(PForTestCase, parameterized.TestCase):
 
     self._test_loop_fn(loop_fn, 2)
 
-  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
-                                      'due to rocfft issues')
   @parameterized.parameters(
       (fft_ops.rfft,),
       (fft_ops.rfft2d,),
       (fft_ops.rfft3d,),
   )
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
+                                      'due to rocfft issues')
   def test_rfft(self, op_func):
     for dtype in (dtypes.float32, dtypes.float64):
       x = random_ops.random_uniform([2, 3, 4, 3, 4], dtype=dtype)
@@ -2143,13 +2143,13 @@ class SpectralTest(PForTestCase, parameterized.TestCase):
 
       self._test_loop_fn(loop_fn, 2)
 
-  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
-                                      'due to rocfft issues')
   @parameterized.parameters(
       (fft_ops.irfft,),
       (fft_ops.irfft2d,),
       (fft_ops.irfft3d,),
   )
+  @test.disable_for_rocm(skip_message='Disable subtest on ROCm '
+                                      'due to rocfft issues')
   def test_irfft(self, op_func):
     if config.list_physical_devices("GPU"):
       # TODO(b/149957923): The test is flaky

--- a/tensorflow/python/platform/test.py
+++ b/tensorflow/python/platform/test.py
@@ -35,7 +35,7 @@ from tensorflow.python.ops.gradient_checker import compute_gradient_error
 from tensorflow.python.ops.gradient_checker import compute_gradient
 # pylint: enable=unused-import,g-bad-import-order
 
-from tensorflow.python.util import tf_decorator
+import functools
 
 import sys
 from tensorflow.python.util.tf_export import tf_export
@@ -101,12 +101,13 @@ def is_built_with_rocm():
 def disable_for_rocm(skip_message):
   """Disables the test if TensorFlow was built with ROCm (GPU) support."""
   def decorator_disable_for_rocm(func):
+    @functools.wraps(func)
     def wrapper_disable_for_rocm(self, *args, **kwargs):
       if is_built_with_rocm():
         self.skipTest(skip_message)
       else:
         return func(self, *args, **kwargs)
-    return tf_decorator.make_decorator(func, wrapper_disable_for_rocm)
+    return wrapper_disable_for_rocm
   return decorator_disable_for_rocm
 
 @tf_export('test.is_built_with_gpu_support')


### PR DESCRIPTION
These changes are necessary in order to allow CPU only unit tests to build and run.  Also, some python functions whose multiple decorators were specified in an invalid order were fixed.