### PR TITLE
FFT fixes

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3391,8 +3391,9 @@ tf_kernel_library(
 tf_kernel_library(
     name = "fft_ops",
     prefix = "fft_ops",
-    deps = MATH_DEPS + [
-    ] + if_cuda([
+    deps = MATH_DEPS + if_cuda_or_rocm([
+        ":gpu_utils",
+    ]) + if_cuda([
         "//tensorflow/core/platform/default/build_config:cufft_plugin",
     ]),
 )

--- a/tensorflow/python/kernel_tests/signal/BUILD
+++ b/tensorflow/python/kernel_tests/signal/BUILD
@@ -41,7 +41,6 @@ cuda_py_tests(
     python_version = "PY3",
     shard_count = 8,
     tags = [
-        "no_rocm",
         "optonly",
     ],
     # TODO(timshen): re-enable after resolving flakiness (b/149426657).

--- a/tensorflow/stream_executor/rocm/rocm_fft.h
+++ b/tensorflow/stream_executor/rocm/rocm_fft.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/platform/port.h"
 #include "tensorflow/stream_executor/plugin_registry.h"
 #include "tensorflow/stream_executor/scratch_allocator.h"
+#include "tensorflow/stream_executor/stream.h"
 
 namespace stream_executor {
 
@@ -79,8 +80,10 @@ class ROCMFftPlan : public fft::Plan {
   port::Status UpdateScratchAllocator(Stream* stream,
                                       ScratchAllocator* scratch_allocator);
 
+  ScratchAllocator* GetScratchAllocator() const { return scratch_allocator_; }
  protected:
   bool IsInitialized() const { return is_initialized_; }
+  ScratchAllocator* scratch_allocator_;
 
  private:
   GpuExecutor *parent_;


### PR DESCRIPTION
* The PR reenables //tensorflow/python/kernel_tests/signal:fft_ops_test for ROCm. Several subtests remain disabled because they require more subtle workarounds. (The fundamental cause behind all this complexity is that rocFFT assumes that inputs to inverse R2C FFT always originate as outputs of a forward R2C FFT, which induces certain symmetries in the data. Unit tests break when TF tries to use data that lacks these symmetries.)

* The PR fixes https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/issues/1150 (rfft corrupting the input buffer), by  duplicating the workaround for an identical issue from the cuFFT side.