### PR TITLE
Fixing certificate not trusted for docker package installation

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -11,7 +11,7 @@ ARG ROCM_PATH=/opt/rocm-3.9.0
 ENV DEBIAN_FRONTEND noninteractive
 ENV TF_NEED_ROCM 1
 ENV HOME /root/
-RUN apt update && apt install -y wget software-properties-common
+RUN apt-get --allow-unauthenticated update && apt install -y wget software-properties-common
 
 # Add rocm repository
 RUN apt-get clean all


### PR DESCRIPTION
Please refer to this [log](http://ml-ci.amd.com:21096/job/develop-upstream-unit-tests/job/tensorflow-upstream-unit-tests-gpu-multi/28/console) for original failure.