### PR TITLE
Reenabling tests disabled in the 201026 merge

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1299,7 +1299,7 @@ tf_xla_py_test(
     name = "stateless_random_ops_test",
     size = "medium",
     srcs = ["stateless_random_ops_test.py"],
-    enable_mlir_bridge = False,  # TODO(rocm): no_rocm, need to re-enable this for ROCm
+    enable_mlir_bridge = True,
     python_version = "PY3",
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip


### PR DESCRIPTION
They seem to be passing as of 11/18.