### PR TITLE
Revert experimental bfloat16 support for convolutions

### DIFF
--- a/tensorflow/core/kernels/conv_2d.h
+++ b/tensorflow/core/kernels/conv_2d.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/kernels/eigen_backward_spatial_convolutions.h"
 #include "tensorflow/core/kernels/eigen_spatial_convolutions.h"
-#include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/util/tensor_format.h"
 
 namespace tensorflow {
@@ -400,19 +399,6 @@ struct ReverseTransformFilter {
                   typename TTypes<T, NDIMS>::Tensor out);
 };
 
-template <typename Device, typename T, int NDIMS>
-struct ConvertToBFloat16 {
-  void operator()(const Device& d, typename TTypes<T, NDIMS>::ConstTensor in,
-                  typename TTypes<bfloat16, NDIMS>::Tensor out);
-};
-
-template <typename Device, typename T, int NDIMS>
-struct ConvertFromBFloat16 {
-  void operator()(const Device& d,
-                  typename TTypes<bfloat16, NDIMS>::ConstTensor in,
-                  typename TTypes<T, NDIMS>::Tensor out);
-};
-
 }  // namespace functor
 
 template <class T>
@@ -420,19 +406,6 @@ class ConvAlgorithmMap;
 
 template <>
 class ConvAlgorithmMap<Eigen::ThreadPoolDevice> {};
-
-template <typename T>
-bool TestMIOpenBFloat16Support() {
-  static bool kTestMIOpenBFloat16Support = [] {
-    bool use_bfloat16 = false;
-    TF_CHECK_OK(ReadBoolFromEnvVar("TF_ROCM_USE_BFLOAT16_FOR_CONV", false,
-                                   &use_bfloat16));
-    return use_bfloat16;
-  }();
-
-  return kTestMIOpenBFloat16Support && (DataTypeToEnum<T>::value == DT_FLOAT);
-}
-
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_KERNELS_CONV_2D_H_

--- a/tensorflow/core/kernels/conv_2d_gpu.h
+++ b/tensorflow/core/kernels/conv_2d_gpu.h
@@ -1135,79 +1135,7 @@ struct NCHWToNHWC<GPUDevice, T, NDIMS> {
   }
 };
 
-template <typename T>
-__launch_bounds__(1024)
-__global__ void ConvertToBFloat16Kernel(int nthreads, const T* src,
-                                        bfloat16* dst) {
-  GPU_1D_KERNEL_LOOP(index, nthreads) {
-    dst[index] =  bfloat16(src[index]);
-  }
-}
-
-template <int NDIMS>
-struct ConvertToBFloat16<GPUDevice, float, NDIMS> {
-  void operator()(const GPUDevice& d,
-                  typename TTypes<float, NDIMS>::ConstTensor in,
-                  typename TTypes<bfloat16, NDIMS>::Tensor out) {
-    int total_element_count = 1;
-    for (int i = 0; i < NDIMS; i++) {
-      total_element_count *= in.dimension(i);
-    }
-    GpuLaunchConfig config = GetGpuLaunchConfig(total_element_count, d);
-    TF_CHECK_OK(GpuLaunchKernel(ConvertToBFloat16Kernel<float>,
-                                config.block_count, config.thread_per_block, 0,
-                                d.stream(), config.virtual_thread_count,
-                                in.data(), out.data()));
-  }
-};
-
-template <typename T, int NDIMS>
-struct ConvertToBFloat16<GPUDevice, T, NDIMS> {
-  void operator()(const GPUDevice& d, typename TTypes<T, NDIMS>::ConstTensor in,
-                  typename TTypes<bfloat16, NDIMS>::Tensor out) {
-    LOG(FATAL) << "ConvertToBFloat16 not supported for data type: "
-               << DataTypeToEnum<T>::value;
-  }
-};
-
-template <typename T>
-__launch_bounds__(1024)
-__global__ void ConvertFromBFloat16Kernel(int nthreads, const bfloat16* src,
-                                          T* dst) {
-  GPU_1D_KERNEL_LOOP(index, nthreads) {
-    dst[index] = static_cast<T>(src[index]);
-  }
-}
-
-template <int NDIMS>
-struct ConvertFromBFloat16<GPUDevice, float, NDIMS> {
-  void operator()(const GPUDevice& d,
-                  typename TTypes<bfloat16, NDIMS>::ConstTensor in,
-                  typename TTypes<float, NDIMS>::Tensor out) {
-    int total_element_count = 1;
-    for (int i = 0; i < NDIMS; i++) {
-      total_element_count *= in.dimension(i);
-    }
-    GpuLaunchConfig config = GetGpuLaunchConfig(total_element_count, d);
-    TF_CHECK_OK(GpuLaunchKernel(ConvertFromBFloat16Kernel<float>,
-                                config.block_count, config.thread_per_block, 0,
-                                d.stream(), config.virtual_thread_count,
-                                in.data(), out.data()));
-  }
-};
-
-template <typename T, int NDIMS>
-struct ConvertFromBFloat16<GPUDevice, T, NDIMS> {
-  void operator()(const GPUDevice& d,
-                  typename TTypes<bfloat16, NDIMS>::ConstTensor in,
-                  typename TTypes<T, NDIMS>::Tensor out) {
-    LOG(FATAL) << "ConvertFromBFloat16 not supported for data type: "
-               << DataTypeToEnum<T>::value;
-  }
-};
-
 }  // namespace functor
-
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/conv_2d_gpu_double.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_double.cu.cc
@@ -36,8 +36,6 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, double, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, double, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, double, 4>;
 template struct PadInput<Eigen::GpuDevice, double, int, 4>;
-template struct ConvertToBFloat16<Eigen::GpuDevice, double, 4>;
-template struct ConvertFromBFloat16<Eigen::GpuDevice, double, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, double, int, 5>;

--- a/tensorflow/core/kernels/conv_2d_gpu_float.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_float.cu.cc
@@ -45,8 +45,6 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, float, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, float, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, float, 4>;
 template struct PadInput<Eigen::GpuDevice, float, int, 4>;
-template struct ConvertToBFloat16<Eigen::GpuDevice, float, 4>;
-template struct ConvertFromBFloat16<Eigen::GpuDevice, float, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, float, int, 5>;

--- a/tensorflow/core/kernels/conv_2d_gpu_half.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_half.cu.cc
@@ -37,8 +37,6 @@ template struct ReverseTransformFilter<Eigen::GpuDevice, Eigen::half, 4>;
 template struct NHWCToNCHW<Eigen::GpuDevice, Eigen::half, 4>;
 template struct NCHWToNHWC<Eigen::GpuDevice, Eigen::half, 4>;
 template struct PadInput<Eigen::GpuDevice, Eigen::half, int, 4>;
-template struct ConvertToBFloat16<Eigen::GpuDevice, Eigen::half, 4>;
-template struct ConvertFromBFloat16<Eigen::GpuDevice, Eigen::half, 4>;
 
 // For 3d ops.
 template struct TransformFilter<Eigen::GpuDevice, Eigen::half, int, 5>;

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -949,63 +949,11 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   auto input_ptr = AsDeviceMemory(transformed_input.template flat<T>().data(),
                                   transformed_input.template flat<T>().size());
 
-  Tensor bfloat16_out_backprop, bfloat16_input, bfloat16_filter_backprop;
-  se::DeviceMemory<bfloat16> bfloat16_out_backprop_ptr, bfloat16_input_ptr,
-      bfloat16_filter_backprop_ptr;
-
-  if (TestMIOpenBFloat16Support<T>()) {
-    TensorShape out_backprop_shape = ShapeFromFormat(
-        FORMAT_NCHW, dims.batch_size, dims.spatial_dims[0].output_size,
-        dims.spatial_dims[1].output_size, dims.out_depth);
-    VLOG(3) << "Allocate temporary memory for bfloat16 out_backprop";
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, out_backprop_shape,
-                                           &bfloat16_out_backprop));
-    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
-        ctx->eigen_device<GPUDevice>(),
-        const_cast<const Tensor&>(transformed_out_backprop).tensor<T, 4>(),
-        bfloat16_out_backprop.tensor<bfloat16, 4>());
-
-    TensorShape input_shape = ShapeFromFormat(
-        compute_data_format, GetTensorDim(compatible_input, data_format, 'N'),
-        GetTensorDim(compatible_input, data_format, 'H'),
-        GetTensorDim(compatible_input, data_format, 'W'),
-        GetTensorDim(compatible_input, data_format, 'C'));
-    VLOG(3) << "Allocate temporary memory for bfloat16 input";
-    OP_REQUIRES_OK(
-        ctx, ctx->allocate_temp(DT_BFLOAT16, input_shape, &bfloat16_input));
-    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
-        ctx->eigen_device<GPUDevice>(),
-        const_cast<const Tensor&>(transformed_input).tensor<T, 4>(),
-        bfloat16_input.tensor<bfloat16, 4>());
-
-    TensorShape filter_backprop_shape =
-        TensorShape({filter_shape.dim_size(3), filter_shape.dim_size(2),
-                     filter_shape.dim_size(0), filter_shape.dim_size(1)});
-    VLOG(3) << "Allocate temporary memory for bfloat16 filter_backprop";
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_BFLOAT16, filter_backprop_shape,
-                                           &bfloat16_filter_backprop));
-
-    bfloat16_out_backprop_ptr =
-        AsDeviceMemory(bfloat16_out_backprop.template flat<bfloat16>().data(),
-                       bfloat16_out_backprop.template flat<bfloat16>().size());
-    bfloat16_filter_backprop_ptr = AsDeviceMemory(
-        bfloat16_filter_backprop.template flat<bfloat16>().data(),
-        bfloat16_filter_backprop.template flat<bfloat16>().size());
-    bfloat16_input_ptr =
-        AsDeviceMemory(bfloat16_input.template flat<bfloat16>().data(),
-                       bfloat16_input.template flat<bfloat16>().size());
-  }
-
   static int64 ConvolveBackwardFilterScratchSize = GetDnnWorkspaceLimit(
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB by default
   );
   int device_id = stream->parent()->device_ordinal();
   DataType dtype = input.dtype();
-#if TENSORFLOW_USE_ROCM
-  if (TestMIOpenBFloat16Support<T>()) {
-    dtype = DT_BFLOAT16;
-  }
-#endif
   ConvParameters conv_parameters = {
       dims.batch_size,                     // batch
       dims.in_depth,                       // in_depths
@@ -1091,32 +1039,18 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
                                           ctx);
 
     std::vector<ProfileResult> algorithms;
-    if (TestMIOpenBFloat16Support<T>()) {
-      OP_REQUIRES(
-          ctx,
-          stream->parent()->GetMIOpenConvolveAlgorithms(
-              se::dnn::ConvolutionKind::BACKWARD_FILTER,
-              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
-              bfloat16_input_ptr, filter_desc, bfloat16_filter_backprop_ptr,
-              output_desc, bfloat16_out_backprop_ptr, conv_desc,
-              &scratch_allocator, &algorithms),
-          errors::Unknown(
-              "Failed to get convolution algorithm. This is probably "
-              "because MIOpen failed to initialize, so try looking to "
-              "see if a warning log message was printed above."));
-    } else {
-      OP_REQUIRES(
-          ctx,
-          stream->parent()->GetMIOpenConvolveAlgorithms(
-              se::dnn::ConvolutionKind::BACKWARD_FILTER,
-              se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
-              filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
-              conv_desc, &scratch_allocator, &algorithms),
-          errors::Unknown(
-              "Failed to get convolution algorithm. This is probably "
-              "because MIOpen failed to initialize, so try looking to "
-              "see if a warning log message was printed above."));
-    }
+    OP_REQUIRES(
+        ctx,
+        stream->parent()->GetMIOpenConvolveAlgorithms(
+            se::dnn::ConvolutionKind::BACKWARD_FILTER,
+            se::dnn::ToDataType<T>::value, stream, input_desc, input_ptr,
+            filter_desc, filter_backprop_ptr, output_desc, out_backprop_ptr,
+            conv_desc, &scratch_allocator, &algorithms),
+        errors::Unknown(
+            "Failed to get convolution algorithm. This is probably "
+            "because MIOpen failed to initialize, so try looking to "
+            "see if a warning log message was printed above."));
+
     std::vector<tensorflow::AutotuneResult> results;
     if (algorithms.size() == 1) {
       auto profile_result = algorithms[0];
@@ -1134,28 +1068,12 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
         ProfileResult profile_result;
-        Status miopen_launch_status;
-        if (TestMIOpenBFloat16Support<T>()) {
-          miopen_launch_status =
-              stream
-                  ->ConvolveBackwardFilterWithAlgorithm(
-                      input_desc, bfloat16_input_ptr, output_desc,
-                      bfloat16_out_backprop_ptr, conv_desc, filter_desc,
-                      &bfloat16_filter_backprop_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm,
-                                      miopen_algorithm.scratch_size()),
-                      &profile_result);
-        } else {
-          miopen_launch_status =
-              stream
-                  ->ConvolveBackwardFilterWithAlgorithm(
-                      input_desc, input_ptr, output_desc, out_backprop_ptr,
-                      conv_desc, filter_desc, &filter_backprop_ptr,
-                      &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm,
-                                      miopen_algorithm.scratch_size()),
-                      &profile_result);
-        }
+        auto miopen_launch_status = stream->ConvolveBackwardFilterWithAlgorithm(
+            input_desc, input_ptr, output_desc, out_backprop_ptr, conv_desc,
+            filter_desc, &filter_backprop_ptr, &scratch_allocator,
+            AlgorithmConfig(profile_algorithm, miopen_algorithm.scratch_size()),
+            &profile_result);
+
         if (miopen_launch_status.ok() && profile_result.is_valid()) {
           results.emplace_back();
           auto& result = results.back();
@@ -1187,16 +1105,6 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
   if (!cudnn_launch_status.ok()) {
     ctx->SetStatus(cudnn_launch_status);
     return;
-  }
-
-  if (TestMIOpenBFloat16Support<T>()) {
-    VLOG(3)
-        << "Convert the filter_backprop tensor back from bfloat16 to float.";
-    functor::ConvertFromBFloat16<GPUDevice, T, 4>()(
-        ctx->eigen_device<GPUDevice>(),
-        const_cast<const Tensor&>(bfloat16_filter_backprop)
-            .tensor<bfloat16, 4>(),
-        pre_transformed_filter_backprop.tensor<T, 4>());
   }
 
   FilterTensorFormat src_filter_format =

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -957,49 +957,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       AsDeviceMemory(transformed_output.template flat<T>().data(),
                      transformed_output.template flat<T>().size());
 
-  Tensor bfloat16_input, bfloat16_filter, bfloat16_output;
-  se::DeviceMemory<bfloat16> bfloat16_input_ptr, bfloat16_filter_ptr,
-      bfloat16_output_ptr;
-
-  if (TestMIOpenBFloat16Support<T>()) {
-    TensorShape input_shape =
-        ShapeFromFormat(FORMAT_NCHW, in_batch, in_rows, in_cols, in_depths);
-    VLOG(3) << "Allocate temporary memory for bfloat16 input";
-    OP_REQUIRES_OK(
-        ctx, ctx->allocate_temp(DT_BFLOAT16, input_shape, &bfloat16_input));
-    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
-        ctx->eigen_device<GPUDevice>(),
-        const_cast<const Tensor&>(input).tensor<T, 4>(),
-        bfloat16_input.tensor<bfloat16, 4>());
-
-    TensorShape filter_shape =
-        TensorShape({filter.dim_size(3), filter.dim_size(2), filter.dim_size(0),
-                     filter.dim_size(1)});
-    VLOG(3) << "Allocate temporary memory for bfloat16 filter";
-    OP_REQUIRES_OK(
-        ctx, ctx->allocate_temp(DT_BFLOAT16, filter_shape, &bfloat16_filter));
-    functor::ConvertToBFloat16<GPUDevice, T, 4>()(
-        ctx->eigen_device<GPUDevice>(),
-        const_cast<const Tensor&>(transformed_filter).tensor<T, 4>(),
-        bfloat16_filter.tensor<bfloat16, 4>());
-
-    TensorShape output_shape =
-        ShapeFromFormat(FORMAT_NCHW, out_batch, out_rows, out_cols, out_depths);
-    VLOG(3) << "Allocate temporary memory for bfloat16 output";
-    OP_REQUIRES_OK(
-        ctx, ctx->allocate_temp(DT_BFLOAT16, output_shape, &bfloat16_output));
-
-    bfloat16_input_ptr =
-        AsDeviceMemory(bfloat16_input.template flat<bfloat16>().data(),
-                       bfloat16_input.template flat<bfloat16>().size());
-    bfloat16_filter_ptr =
-        AsDeviceMemory(bfloat16_filter.template flat<bfloat16>().data(),
-                       bfloat16_filter.template flat<bfloat16>().size());
-    bfloat16_output_ptr =
-        AsDeviceMemory(bfloat16_output.template flat<bfloat16>().data(),
-                       bfloat16_output.template flat<bfloat16>().size());
-  }
-
   static int64 ConvolveScratchSize = GetDnnWorkspaceLimit(
       // default value is in bytes despite the name of the environment variable
       "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 32  // 4GB
@@ -1007,11 +964,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
 
   int device_id = stream->parent()->device_ordinal();
   DataType dtype = input.dtype();
-#if TENSORFLOW_USE_ROCM
-  if (TestMIOpenBFloat16Support<T>()) {
-    dtype = DT_BFLOAT16;
-  }
-#endif
   ConvParameters conv_parameters = {in_batch,             // batch
                                     in_depths,            // in_depths
                                     {{in_rows,            // in_rows
@@ -1099,30 +1051,16 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
     DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
 
     std::vector<ProfileResult> algorithms;
-    if (TestMIOpenBFloat16Support<T>()) {
-      OP_REQUIRES(
-          ctx,
-          stream->parent()->GetMIOpenConvolveAlgorithms(
-              se::dnn::ConvolutionKind::FORWARD,
-              se::dnn::ToDataType<bfloat16>::value, stream, input_desc,
-              bfloat16_input_ptr, filter_desc, bfloat16_filter_ptr, output_desc,
-              bfloat16_output_ptr, conv_desc, &scratch_allocator, &algorithms),
-          errors::Unknown(
-              "Failed to get convolution algorithm. This is probably "
-              "because MIOpen failed to initialize, so try looking to "
-              "see if a warning log message was printed above."));
-    } else {
-      OP_REQUIRES(ctx,
-                  stream->parent()->GetMIOpenConvolveAlgorithms(
-                      se::dnn::ConvolutionKind::FORWARD,
-                      se::dnn::ToDataType<T>::value, stream, input_desc,
-                      input_ptr, filter_desc, filter_ptr, output_desc,
-                      output_ptr, conv_desc, &scratch_allocator, &algorithms),
-                  errors::Unknown(
-                      "Failed to get convolution algorithm. This is probably "
-                      "because MIOpen failed to initialize, so try looking to "
-                      "see if a warning log message was printed above."));
-    }
+    OP_REQUIRES(
+        ctx,
+        stream->parent()->GetMIOpenConvolveAlgorithms(
+            se::dnn::ConvolutionKind::FORWARD, se::dnn::ToDataType<T>::value,
+            stream, input_desc, input_ptr, filter_desc, filter_ptr, output_desc,
+            output_ptr, conv_desc, &scratch_allocator, &algorithms),
+        errors::Unknown(
+            "Failed to get convolution algorithm. This is probably "
+            "because MIOpen failed to initialize, so try looking to "
+            "see if a warning log message was printed above."));
     se::DeviceMemory<T> output_tensor = output_ptr;
 
     std::vector<tensorflow::AutotuneResult> results;
@@ -1142,27 +1080,11 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
       for (auto miopen_algorithm : algorithms) {
         auto profile_algorithm = miopen_algorithm.algorithm();
         ProfileResult profile_result;
-        Status miopen_launch_status;
-        if (TestMIOpenBFloat16Support<T>()) {
-          miopen_launch_status =
-              stream
-                  ->ConvolveWithAlgorithm(
-                      input_desc, bfloat16_input_ptr, filter_desc,
-                      bfloat16_filter_ptr, conv_desc, output_desc,
-                      &bfloat16_output_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm,
-                                      miopen_algorithm.scratch_size()),
-                      &profile_result);
-        } else {
-          miopen_launch_status =
-              stream
-                  ->ConvolveWithAlgorithm(
-                      input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
-                      output_desc, &output_ptr, &scratch_allocator,
-                      AlgorithmConfig(profile_algorithm,
-                                      miopen_algorithm.scratch_size()),
-                      &profile_result);
-        }
+        auto miopen_launch_status = stream->ConvolveWithAlgorithm(
+            input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
+            output_desc, &output_ptr, &scratch_allocator,
+            AlgorithmConfig(profile_algorithm, miopen_algorithm.scratch_size()),
+            &profile_result);
         if (miopen_launch_status.ok() && profile_result.is_valid()) {
           results.emplace_back();
           auto& result = results.back();
@@ -1197,14 +1119,6 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
 
   if (!cudnn_launch_status.ok()) {
     ctx->SetStatus(cudnn_launch_status);
-  }
-
-  if (TestMIOpenBFloat16Support<T>()) {
-    VLOG(3) << "Convert the output tensor back from bfloat16 to float.";
-    functor::ConvertFromBFloat16<GPUDevice, T, 4>()(
-        ctx->eigen_device<GPUDevice>(),
-        const_cast<const Tensor&>(bfloat16_output).tensor<bfloat16, 4>(),
-        transformed_output.tensor<T, 4>());
   }
 
   if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {

--- a/tensorflow/stream_executor/data_type.h
+++ b/tensorflow/stream_executor/data_type.h
@@ -18,7 +18,6 @@ limitations under the License.
 
 #include <complex>
 
-#include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/stream_executor/dnn.pb.h"
 #include "tensorflow/stream_executor/platform/port.h"
 
@@ -59,10 +58,6 @@ struct ToDataType<std::complex<float>> {
 template <>
 struct ToDataType<std::complex<double>> {
   static constexpr DataType value = DataType::kComplexDouble;
-};
-template <>
-struct ToDataType<tensorflow::bfloat16> {
-  static constexpr DataType value = DataType::kBFloat16;
 };
 
 }  // namespace dnn

--- a/tensorflow/stream_executor/dnn.proto
+++ b/tensorflow/stream_executor/dnn.proto
@@ -14,7 +14,6 @@ enum DataType {
   kInt32 = 4;
   kComplexFloat = 5;
   kComplexDouble = 6;
-  kBFloat16 = 7;
 }
 
 // Describes how a convolution input or output layer's data is formatted.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -1717,8 +1717,6 @@ miopenDataType_t ToMIOpenDataType(
   switch (data_type) {
     case dnn::DataType::kFloat:
       return miopenFloat;
-    case dnn::DataType::kBFloat16:
-      return miopenBFloat16;
     case dnn::DataType::kHalf:
       return miopenHalf;
     case dnn::DataType::kDouble:

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -26,7 +26,6 @@ limitations under the License.
 #include <memory>
 
 #include "absl/synchronization/mutex.h"
-#include "tensorflow/core/lib/bfloat16/bfloat16.h"
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/stream_executor/blas.h"


### PR DESCRIPTION
The original changes were introduced by this PR https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/628.

Removing this support from `develop-upstream` since it is not used/tested, and is essentially dead code. It can be easily resurrected in the future should the need arise