### PR TITLE
Remove "+code-object-v3" from the target feature_string used during XLA codegen.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -797,8 +797,16 @@ Status AMDGPUTargetModuleLinker(llvm::Module* module, GpuVersion gpu_version,
 std::unique_ptr<llvm::TargetMachine> AMDGPUGetTargetMachine(
     llvm::Triple target_triple, int amdgpu_version,
     const HloModuleConfig& hlo_module_config) {
+  string feature_str = "+code-object-v3";
+#if TF_ROCM_VERSION >= 30900
+  // code-object-v3 is default, so no need to expliticitly specify it
+  // in the feature string. Also, starting with ROCm 4.0, this feature string
+  // is deprecated, and we get a warning to that effect. So removing that
+  // feature string
+  feature_str = "";
+#endif
   return GetTargetMachine(target_triple, absl::StrCat("gfx", amdgpu_version),
-                          hlo_module_config, "+code-object-v3");
+                          hlo_module_config, feature_str);
 }
 
 void AMDGPUBackendInit(const HloModuleConfig& hlo_module_config) {


### PR DESCRIPTION

Starting with ROCm 4.0, "+code-object-v3" is no longer recognized as a valid feature-string from ADGPU targets, and result in the following warning for each HSACO codegen

```
'+code-object-v3' is not a recognized feature for this target (ignoring feature)
```

Since the hipclang compiler generates code-object-v3 objects by default now, we no longer need to the explicitly specify "+code-object-v3" as a feature-string. Removing taht feature string also gets rid of the warning.