### PR TITLE
Removing --action_env=ROCM_ROOT... when building with --config=rocm

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1333,7 +1333,6 @@ def main():
 
   if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('ROCM_PATH')):
     write_action_env_to_bazelrc('ROCM_PATH', environ_cp.get('ROCM_PATH'))
-    write_action_env_to_bazelrc('ROCM_ROOT', environ_cp.get('ROCM_PATH'))
 
   if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('HIP_PLATFORM')):
     write_action_env_to_bazelrc('HIP_PLATFORM', environ_cp.get('HIP_PLATFORM'))


### PR DESCRIPTION
When we switched to ROCm 3.3 (first ROCm release with "relocatable ROCm install" support), some parts of the ROCm toolchain relied upon the value of env var ROCM_ROOT to determine the location of the ROCm install dir. This has been fixed, and all of the ROCM toolchain now only uses the ROCM_PATH value.

This commit updates `configure.py` to no longer set ROCM_ROOT, when building with --config=rocm

Related JIRA ticket - http://ontrack-internal.amd.com/browse/SWDEV-226744