### PR TITLE
Updated for ROCm 3.9

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -45,7 +45,11 @@ namespace tensorflow {
 namespace grappler {
 
 #if TENSORFLOW_USE_ROCM
+#if TF_ROCM_VERSION < 30900
 const std::array<std::string, 2> FP16SupportedDevices = {"906", "908"}; 
+#else
+const std::array<std::string, 2> FP16SupportedDevices = {"gfx906", "gfx908"}; 
+#endif // ROCM_VERSION < 30900 
 
 bool HasEnhancedFP16ComputeSupport(std::pair<int, int> gpu_arch){
     std::string arch = std::to_string(gpu_arch.first); 
@@ -61,7 +65,6 @@ namespace {
 const std::pair<int, int> kMinGPUArch = {7, 0};
 #elif TENSORFLOW_USE_ROCM
 const std::pair<int, int> kMinGPUArch = {906,0}; 
-// TODO change this to handle strings for ROCm 3.7
 #else
 const std::pair<int, int> kMinGPUArch = {0, 0};
 #endif


### PR DESCRIPTION
Updated AMP selection based on GPU Arch, to work with ROCm 3.9, and the string based gcn_arch. 

Update from https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/9544f1095f73050d44ed4757411ea6a0d92dde28