### PR TITLE
Trimming the ROCm package install list down to just rocm-dev, rocm-libs and rccl.

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -64,8 +64,7 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs hipcub rocm-utils rocm-cmake \
-    rocfft miopen-hip miopengemm rocblas hipblas rocrand rccl && \
+    rocm-dev rocm-libs rccl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is because the rocm-dev and rocm-libs are meta-packages that now encompass all the other ROCm libs, so we do not need to specify them explicitly. The "rccl" lib will also become a part of the rocm-libs package with ROCm 4.1, and can be removed from the install list once we switch to ROCm 4.1