### PR TITLE
[ROCm] Update script install_pip_packages.sh for Python 2.7

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -19,6 +19,8 @@ set -e
 # Get the latest version of pip so it recognize manylinux2010
 wget https://bootstrap.pypa.io/get-pip.py
 python3.6 get-pip.py
+rm -f get-pip.py
+wget https://bootstrap.pypa.io/2.7/get-pip.py
 python get-pip.py
 rm -f get-pip.py
 

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_ci_sanity.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_ci_sanity.sh
@@ -129,7 +129,7 @@ do_pylint() {
   sudo add-apt-repository -y ppa:deadsnakes/ppa
   sudo apt-get update
   sudo apt-get install -y python3.5
-  curl -O https://bootstrap.pypa.io/get-pip.py
+  curl -O https://bootstrap.pypa.io/3.5/get-pip.py
   python3.5 get-pip.py
   python3.5 -m pip install pylint==1.6.4
 


### PR DESCRIPTION
Currently ROCm TF cotnainers use the `install_pip_packages.sh` script to install the Python pip package-manager.
* https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/Dockerfile.rocm#L102
* https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/install/install_pip_packages.sh#L20-L23

Starting 01/23/2021, we started getting the following error while building TF containers for ROCM CI (when calling `get-pip.py` for Python2)

```
Traceback (most recent call last):
  File "get-pip.py", line 24226, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpWkL0gn/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
```

The cause seems to be an update to the `get-pip.py` script, which now picks the version `pip-21.0` (previously it was `pip-20.3.4`).
`pip-21.0` drops support for Python2.7 (as indicated by the following warning message)
```
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020.
Please upgrade your Python as Python 2.7 is no longer maintained.
pip 21.0 will drop support for Python 2.7 in January 2021.
More details about Python 2 support in pip can be found at
https://pip.pypa.io/en/latest/development/release-process/#python-2-support
pip 21.0 will remove support for this functionality.
```

It seems that there is now a Python 2.7 specific version of the `get-pip.py` script that we need to use, and that is what this commit does