### PR TITLE
Add NHWC layout support when creating miopenTensorDescriptor for conv filter

### DIFF
--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -226,8 +226,69 @@ std::tuple<int, int, int> GetDimIndices(const DataLayout& layout,
   return std::make_tuple(depth_idx, batch_idx, spatial_idx);
 }
 
+std::tuple<int, int, int> GetDimIndices(const FilterLayout& layout,
+                                        const int data_dims) {
+  int output_idx, input_idx, spatial_idx;
+  switch (layout) {
+    case FilterLayout::kOutputInputYX:
+    case FilterLayout::kOutputInputYX4:
+      input_idx = 1;
+      output_idx = 0;
+      spatial_idx = 2;
+      break;
+
+    case FilterLayout::kOutputYXInput:
+      input_idx = data_dims - 1;
+      output_idx = 0;
+      spatial_idx = 1;
+      break;
+
+    case FilterLayout::kInputYXOutput:
+      input_idx = 0;
+      output_idx = data_dims - 1;
+      spatial_idx = 1;
+      break;
+
+    case FilterLayout::kYXInputOutput:
+      input_idx = data_dims - 2;
+      output_idx = data_dims - 1;
+      spatial_idx = 0;
+      break;
+
+    default:
+      LOG(FATAL) << "Unknown layout " << layout;
+  }
+
+  return std::make_tuple(output_idx, input_idx, spatial_idx);
+}
+
 std::vector<int64> ReorderDims(const std::vector<int64>& input,
                                const DataLayout& from, const DataLayout& to) {
+  if (from == to) return input;
+
+  int d_idx_from, b_idx_from, spatial_idx_from;
+  int d_idx_to, b_idx_to, spatial_idx_to;
+
+  std::tie(d_idx_from, b_idx_from, spatial_idx_from) =
+      GetDimIndices(from, input.size());
+  std::tie(d_idx_to, b_idx_to, spatial_idx_to) =
+      GetDimIndices(to, input.size());
+
+  std::vector<int64> reordered(input.size());
+  reordered[b_idx_to] = input[b_idx_from];
+  reordered[d_idx_to] = input[d_idx_from];
+
+  for (size_t i = 0; i < input.size() - 2;
+       i++, spatial_idx_from++, spatial_idx_to++) {
+    reordered[spatial_idx_to] = input[spatial_idx_from];
+  }
+
+  return reordered;
+}
+
+std::vector<int64> ReorderDims(const std::vector<int64>& input,
+                               const FilterLayout& from,
+                               const FilterLayout& to) {
   if (from == to) return input;
 
   int d_idx_from, b_idx_from, spatial_idx_from;
@@ -473,6 +534,31 @@ int64 FilterDescriptor::ComputeWeightCount() const {
     ret *= input_filter_dims()[i];
   }
   return ret;
+}
+
+std::vector<int64> FilterDescriptor::full_dims(
+    const FilterLayout& layout) const {
+  std::vector<int64> oiyx_dims(ndims() + 2);
+  oiyx_dims[0] = output_feature_map_count();
+  oiyx_dims[1] = input_feature_map_count();
+  std::copy(input_filter_dims().begin(), input_filter_dims().end(),
+            oiyx_dims.begin() + 2);
+  return ReorderDims(oiyx_dims, FilterLayout::kOutputInputYX, layout);
+}
+
+std::vector<int64> FilterDescriptor::full_strides(
+    const FilterLayout& layout) const {
+  if (this->layout() == FilterLayout::kOutputInputYX4) {
+    LOG(FATAL) << "Cannot compute full strides for filter descriptor "
+               << ToString();
+  }
+  std::vector<int64> phys_dims = full_dims(this->layout());
+  std::vector<int64> phys_strides(phys_dims.size());
+  phys_strides[ndims() + 1] = 1;
+  for (int i = ndims(); i >= 0; i--) {
+    phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
+  }
+  return ReorderDims(phys_strides, this->layout(), layout);
 }
 
 TensorDescriptorProto FilterDescriptor::ToProto(DataType data_type) const {

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -446,6 +446,14 @@ class FilterDescriptor {
     return AsInt64Slice(tensor_.dimensions()).subspan(2);
   }
 
+  // Full dimensions of the underlying filter,
+  // ordered according to a specific layout.
+  std::vector<int64> full_dims(const FilterLayout& layout) const;
+
+  // Full strides of the underlying filter,
+  // ordered according to a specific layout.
+  std::vector<int64> full_strides(const FilterLayout& layout) const;
+
  private:
   absl::Span<int64> input_filter_dims() {
     return AsInt64Slice(tensor_.mutable_dimensions()).subspan(2);

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -708,7 +708,6 @@ class ScopedTensorDescriptor {
 class ScopedFilterDescriptor {
  public:
   ScopedFilterDescriptor(const FilterDescriptor& filter_descriptor,
-                         const BatchDescriptor& batch_descriptor,
                          miopenDataType_t elem_type)
       : handle_(nullptr) {
     auto status = wrap::miopenCreateTensorDescriptor(&handle_);
@@ -717,19 +716,70 @@ class ScopedFilterDescriptor {
                  << ToString(status);
     }
 
-    const int nd = batch_descriptor.ndims() + 2;
+    // We need to pass two vectors to the miopenSetTensorDescriptor routine
+    // "dims" (length == number of dims, elem value == dimension size)
+    // "strides" (length == number of dims, elem value == stride size)
+    //
+    // Irrespective of the actual filter layout, the indexing of both those
+    // vectors must be the following (coz that is what MIOpen expects)
+    // dims[0] = strides[0] = N or output
+    // dims[1] = strides[1] = C or input
+    // dims[2] = strides[2] = H or spatial dim 0
+    // dims[3] = strides[3] = W or spatial dim 1
+    //
+    // assume you have a tensor with dimensions
+    // batch descriptor name    filter descriptor name    value
+    //   N (batch size)            O (output features)    256
+    //   C (channels)              I (input features)       3
+    //   H (height)                H (height)               7
+    //   W (width)                 W (width)                5
+    //
+    // The content of "dims" will be the same irrespective of layout
+    // layout (NCHW or NHWC), and MIOpen expects it should be
+    //                           NCHW layout   NHWC layout
+    // dims[0] = size of N dim =    256           256
+    // dims[1] = size of C dim =      3             3
+    // dims[2] = size of H dim =      7             7
+    // dims[3] = size of W dim =      5             5
+    //
+    // The content of "strides" will be different based on layout
+    //                                  NCHW layout   NHWC layout
+    //  strides[0] = stride of N dim =     7x5x3       7x5x3
+    //  strides[1] = stride of C dim =     7x5         1
+    //  strides[2] = stride of H dim =     5           5x3
+    //  strides[3] = stride of W dim =     1           3
 
-    std::vector<int> dims(2 + filter_descriptor.ndims());
-    dims[0] = filter_descriptor.output_feature_map_count();
-    dims[1] = filter_descriptor.input_feature_map_count();
-    const auto& spatial_dims = filter_descriptor.input_filter_dims();
-    std::copy(spatial_dims.begin(), spatial_dims.end(), dims.begin() + 2);
+    switch (filter_descriptor.layout()) {
+      case dnn::FilterLayout::kOutputYXInput:
+      case dnn::FilterLayout::kOutputInputYX: {
+        const int nd = filter_descriptor.ndims() + 2;
 
-    status = wrap::miopenSetTensorDescriptor(handle_, elem_type, nd,
-                                             dims.data(), nullptr);
-    if (status != miopenStatusSuccess) {
-      LOG(FATAL) << "could not set miopen filter descriptor: "
-                 << ToString(status);
+        // MIOpen requires the strides and dims to be ordered as BDYX.
+        std::vector<int64> strides64 =
+            filter_descriptor.full_strides(dnn::FilterLayout::kOutputInputYX);
+        std::vector<int64> dims64 =
+            filter_descriptor.full_dims(dnn::FilterLayout::kOutputInputYX);
+
+        // MIOpen requires arrays of ints.
+        std::vector<int> strides(nd);
+        std::vector<int> dims(nd);
+        std::transform(strides64.cbegin(), strides64.cend(), strides.begin(),
+                       &CheckedNarrowing<int64, int>);
+        std::transform(dims64.cbegin(), dims64.cend(), dims.begin(),
+                       &CheckedNarrowing<int64, int>);
+        status = wrap::miopenSetTensorDescriptor(handle_, elem_type, nd,
+                                                 dims.data(), strides.data());
+
+        if (status != miopenStatusSuccess) {
+          LOG(FATAL) << "could not convert FilterDescriptor "
+                     << filter_descriptor.ToString()
+                     << " to miopen tensor descriptor: " << ToString(status);
+        }
+      } break;
+      default:
+        LOG(FATAL) << "Unsupported tensor format "
+                   << FilterLayoutString(filter_descriptor.layout());
+        break;
     }
   }
 
@@ -3000,7 +3050,7 @@ port::Status MIOpenSupport::DoConvolve(
                                   ToMIOpenDataType(element_type)};
   ScopedTensorDescriptor output_nd{output_descriptor,
                                    ToMIOpenDataType(element_type)};
-  ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
+  ScopedFilterDescriptor filter{filter_descriptor,
                                 ToMIOpenDataType(element_type)};
   ScopedConvolutionDescriptor conv{convolution_descriptor,
                                    ToMIOpenDataType(element_type)};
@@ -3181,7 +3231,7 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithmsImmediateMode(
                                   ToMIOpenDataType(element_type)};
   ScopedTensorDescriptor output_nd{output_descriptor,
                                    ToMIOpenDataType(element_type)};
-  ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
+  ScopedFilterDescriptor filter{filter_descriptor,
                                 ToMIOpenDataType(element_type)};
   ScopedConvolutionDescriptor conv{convolution_descriptor,
                                    ToMIOpenDataType(element_type)};
@@ -3390,7 +3440,7 @@ bool MIOpenSupport::GetMIOpenConvolveAlgorithmsFindMode(
                                   ToMIOpenDataType(element_type)};
   ScopedTensorDescriptor output_nd{output_descriptor,
                                    ToMIOpenDataType(element_type)};
-  ScopedFilterDescriptor filter{filter_descriptor, input_descriptor,
+  ScopedFilterDescriptor filter{filter_descriptor,
                                 ToMIOpenDataType(element_type)};
   ScopedConvolutionDescriptor conv{convolution_descriptor,
                                    ToMIOpenDataType(element_type)};
@@ -4645,8 +4695,7 @@ bool MIOpenSupport::DeriveOutputBatchDescriptor(
     const dnn::ConvolutionDescriptor& convolution_descriptor,
     dnn::BatchDescriptor* output_batch_descriptor) {
   ScopedTensorDescriptor input_nd{batch_descriptor, miopenFloat};
-  ScopedFilterDescriptor filter{filter_descriptor, batch_descriptor,
-                                miopenFloat};
+  ScopedFilterDescriptor filter{filter_descriptor, miopenFloat};
   ScopedConvolutionDescriptor conv{convolution_descriptor, miopenFloat};
 
   int dn = batch_descriptor.ndims() + 2;
@@ -4698,7 +4747,7 @@ bool MIOpenSupport::DoFusedConvolutionBiasActivationImpl(
   ScopedConvolutionDescriptor conv{convolution_descriptor,
                                    static_cast<miopenDataType_t>(miopen_type)};
 
-  ScopedFilterDescriptor filter{filter_descriptor, conv_input_descriptor,
+  ScopedFilterDescriptor filter{filter_descriptor,
                                 static_cast<miopenDataType_t>(miopen_type)};
 
   ScopedActivationDescriptor activation_desc{activation_mode};

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2988,53 +2988,6 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
   return port::Status::OK();
 }
 
-// NOTE(keveman): Temporary data layout transformation until MIOpen supports
-// kBatchYXDepth for backward pass. This function allocates temporary memory,
-// lays out the source data into the temporary but in the kBatchDepthXY
-// layout, and returns the temporary memory. The caller is responsible for
-// deallocating the temporary. Since the allocation is done using Stream's
-// AllocateTemporaryMemory, a later BlockHostUntilDone could be used for
-// deallocation.
-//
-// transform_scratch is populated with a legitimate temporary allocation iff
-// the original output data needs to be transformed.
-static DeviceMemoryBase MaybeTransformLayout(
-    Stream* stream, miopenHandle_t handle_,
-    int miopen_type,  // Actually miopenDataType_t.
-    BatchDescriptor* output_descriptor, DeviceMemoryBase backward_output_data,
-    std::unique_ptr<TemporaryDeviceMemory<uint8>>* transform_scratch) {
-  if (output_descriptor->layout() == dnn::DataLayout::kBatchDepthYX) {
-    return backward_output_data;
-  }
-  CHECK(output_descriptor->layout() == dnn::DataLayout::kBatchYXDepth);
-  *transform_scratch =
-      stream->AllocateTemporaryArray<uint8>(backward_output_data.size())
-          .ConsumeValueOrDie();
-  BatchDescriptor transformed_output_descriptor;
-  transformed_output_descriptor.CloneFrom(*output_descriptor);
-  transformed_output_descriptor.set_layout(dnn::DataLayout::kBatchDepthYX);
-  ScopedTensorDescriptor orig_out_back_nd{
-      *output_descriptor, static_cast<miopenDataType_t>(miopen_type)};
-  ScopedTensorDescriptor transformed_out_back_nd{
-      transformed_output_descriptor,
-      static_cast<miopenDataType_t>(miopen_type)};
-
-  float alpha1 = 1.0f;
-  float alpha2 = 0.0f;
-  float beta = 0.0f;
-  auto status = wrap::miopenOpTensor(
-      handle_, miopenTensorOpAdd, &alpha1, orig_out_back_nd.handle(),
-      backward_output_data.opaque(), &alpha2, orig_out_back_nd.handle(),
-      backward_output_data.opaque(), &beta, transformed_out_back_nd.handle(),
-      (*transform_scratch)->mutable_device_memory()->opaque());
-
-  if (status != miopenStatusSuccess) {
-    LOG(FATAL) << "Failed to transform the data layout.";
-  }
-  output_descriptor->set_layout(dnn::DataLayout::kBatchDepthYX);
-  return (*transform_scratch)->device_memory();
-}
-
 port::Status MIOpenSupport::DoConvolve(
     dnn::ConvolutionKind kind, dnn::DataType element_type,
     dnn::DataType output_type, Stream* stream,
@@ -3099,14 +3052,6 @@ port::Status MIOpenSupport::DoConvolve(
       break;
     }
     case dnn::ConvolutionKind::BACKWARD_DATA: {
-      // TBD: remove once MIOpen supports kBatchYXDepth for backward pass.
-      BatchDescriptor output_back_descriptor;
-      output_back_descriptor.CloneFrom(output_descriptor);
-      std::unique_ptr<TemporaryDeviceMemory<uint8>> transform_scratch;
-      output_data = MaybeTransformLayout(
-          stream, miopen.handle(), ToMIOpenDataType(element_type),
-          &output_back_descriptor, output_data, &transform_scratch);
-
       if (use_immediate_mode_) {
         status = wrap::miopenConvolutionBackwardDataImmediate(
             miopen.handle(), output_nd.handle(), output_data.opaque(),
@@ -3125,14 +3070,6 @@ port::Status MIOpenSupport::DoConvolve(
       break;
     }
     case dnn::ConvolutionKind::BACKWARD_FILTER: {
-      // TBD: remove once MIOpen supports kBatchYXDepth for backward pass.
-      BatchDescriptor output_back_descriptor;
-      output_back_descriptor.CloneFrom(output_descriptor);
-      std::unique_ptr<TemporaryDeviceMemory<uint8>> transform_scratch;
-      output_data = MaybeTransformLayout(
-          stream, miopen.handle(), ToMIOpenDataType(element_type),
-          &output_back_descriptor, output_data, &transform_scratch);
-
       if (use_immediate_mode_) {
         status = wrap::miopenConvolutionBackwardWeightsImmediate(
             miopen.handle(), output_nd.handle(), output_data.opaque(),


### PR DESCRIPTION
Prior to this commit the code in `rocm_dnn.cc` which creates `miopenTensorDescriptor` for the convolution filter worked only for NCHW layout. Making it work for NHWC layout requires passing the correct tensor "stride" format in a manner expected by MIOpen.

Copy-pasting a comment from this commit which explains the data + format that MIOpen expects in the call to `miopenSetTensorDescriptor`

```
    // We need to pass two vectors to the miopenSetTensorDescriptor routine
    // "dims" (length == number of dims, elem value == dimension size)
    // "strides" (length == number of dims, elem value == stride size)
    //
    // Irrespective of the actual filter layout, the indexing of both those
    // vectors must be the following (coz that is what MIOpen expects)
    // dims[0] = strides[0] = N or output
    // dims[1] = strides[1] = C or input
    // dims[2] = strides[2] = H or spatial dim 0
    // dims[3] = strides[3] = W or spatial dim 1
    //
    // assume you have a tensor with dimensions
    // batch descriptor name    filter descriptor name    value
    //   N (batch size)            O (output features)    256
    //   C (channels)              I (input features)       3
    //   H (height)                H (height)               7
    //   W (width)                 W (width)                5
    //
    // The content of "dims" will be the same irrespective of layout
    // layout (NCHW or NHWC), and MIOpen expects it should be
    //                           NCHW layout   NHWC layout
    // dims[0] = size of N dim =    256           256
    // dims[1] = size of C dim =      3             3
    // dims[2] = size of H dim =      7             7
    // dims[3] = size of W dim =      5             5
    //
    // The content of "strides" will be different based on layout
    //                                  NCHW layout   NHWC layout
    //  strides[0] = stride of N dim =     7x5x3       7x5x3
    //  strides[1] = stride of C dim =     7x5         1
    //  strides[2] = stride of H dim =     5           5x3
    //  strides[3] = stride of W dim =     1           3
```


----------------------------

/cc @whchung @jerryyin @ekuznetsov139 