### PR TITLE
Passing arguments into pad_op by reference

### DIFF
--- a/tensorflow/core/kernels/pad_op.cc
+++ b/tensorflow/core/kernels/pad_op.cc
@@ -248,7 +248,8 @@ class PadOp : public OpKernel {
       paddings_array[i] = {paddings(i, 0), paddings(i, 1)};
     }
     functor::Pad<Device, T, Tpadding, Dims> functor;
-    functor(context->eigen_device<Device>(), output->tensor<T, Dims>(), input,
+    auto out = output->tensor<T, Dims>();
+    functor(context->eigen_device<Device>(), out, input,
             paddings_array, pad_value);
   }
 };
@@ -292,15 +293,17 @@ namespace functor {
 #define DECLARE_GPU_SPEC(T, Dims)                                         \
   template <>                                                             \
   void Pad<GPUDevice, T, int32, Dims>::operator()(                        \
-      const GPUDevice& d, typename TTypes<T, Dims>::Tensor output,        \
-      typename TTypes<T, Dims>::ConstTensor input,                        \
-      Eigen::array<Eigen::IndexPair<int32>, Dims> paddings, T pad_value); \
+      const GPUDevice& d, typename TTypes<T, Dims>::Tensor& output,       \
+      typename TTypes<T, Dims>::ConstTensor& input,                       \
+      Eigen::array<Eigen::IndexPair<int32>, Dims>& paddings,              \
+      T& pad_value);                                                      \
   extern template struct Pad<GPUDevice, T, int32, Dims>;                  \
   template <>                                                             \
   void Pad<GPUDevice, T, int64, Dims>::operator()(                        \
-      const GPUDevice& d, typename TTypes<T, Dims>::Tensor output,        \
-      typename TTypes<T, Dims>::ConstTensor input,                        \
-      Eigen::array<Eigen::IndexPair<int64>, Dims> paddings, T pad_value); \
+      const GPUDevice& d, typename TTypes<T, Dims>::Tensor& output,       \
+      typename TTypes<T, Dims>::ConstTensor& input,                       \
+      Eigen::array<Eigen::IndexPair<int64>, Dims>& paddings,              \
+      T& pad_value);                                                      \
   extern template struct Pad<GPUDevice, T, int64, Dims>;
 
 #define DECLARE_GPU_SPECS(T) \

--- a/tensorflow/core/kernels/pad_op.h
+++ b/tensorflow/core/kernels/pad_op.h
@@ -29,10 +29,10 @@ template <typename Device, typename T, typename Tpadding, int Dims>
 struct Pad {
   // Pad "input" into "output", as specified by "paddings" and "pad_value".
   // See pad_op.cc for details.
-  void operator()(const Device& d, typename TTypes<T, Dims>::Tensor output,
-                  typename TTypes<T, Dims>::ConstTensor input,
-                  Eigen::array<Eigen::IndexPair<Tpadding>, Dims> paddings,
-                  T pad_value) {
+  void operator()(const Device& d, typename TTypes<T, Dims>::Tensor& output,
+                  typename TTypes<T, Dims>::ConstTensor& input,
+                  Eigen::array<Eigen::IndexPair<Tpadding>, Dims>& paddings,
+                  T& pad_value) {
     if (Eigen::internal::is_same<Device, Eigen::GpuDevice>::value &&
         (output.size() <= std::numeric_limits<int32>::max())) {
       To32Bit(output).device(d) = To32Bit(input).pad(paddings, pad_value);
@@ -45,9 +45,9 @@ struct Pad {
 template <typename Device, typename T, typename Tpadding>
 struct Pad<Device, T, Tpadding, 0> {
   // In the scalar case we simply copy the input.
-  void operator()(const Device& d, typename TTypes<T, 0>::Tensor output,
-                  typename TTypes<T, 0>::ConstTensor input,
-                  Eigen::array<Eigen::IndexPair<Tpadding>, 0>, T) {
+  void operator()(const Device& d, typename TTypes<T, 0>::Tensor& output,
+                  typename TTypes<T, 0>::ConstTensor& input,
+                  Eigen::array<Eigen::IndexPair<Tpadding>, 0>&, T&) {
     output.device(d) = input;
   }
 };

--- a/tensorflow/python/kernel_tests/pad_op_test.py
+++ b/tensorflow/python/kernel_tests/pad_op_test.py
@@ -111,7 +111,8 @@ class PadOpTest(test.TestCase):
 
     with self.cached_session():
       jacob_t, jacob_n = gradient_checker_v2.compute_gradient(pad, [x])
-      self.assertAllClose(jacob_t, jacob_n, rtol=1e-5, atol=1e-5)
+      tol = 1e-3 if x.dtype==np.float16 else 4e-5
+      self.assertAllClose(jacob_t, jacob_n, rtol=tol, atol=tol)
 
   def _testAll(self, np_inputs, paddings, constant_values):
     for mode in ("CONSTANT", "REFLECT", "SYMMETRIC", "reflect", "symmetric",
@@ -257,10 +258,12 @@ class PadOpTest(test.TestCase):
           [[0, 0], [0, 0], [0, 0], [0, 0]], -123)
 
   def testFloatTypes(self):
-    for t in [np.float32, np.float64]:
+    for t in [np.float16, np.float32, np.float64]:
       self._testAll(np.random.rand(2, 5).astype(t), [[1, 0], [2, 0]], 0.0)
       self._testAll(np.random.rand(2, 3, 4).astype(t),
-                    [[0, 0], [0, 0], [0, 0]], -1234.0)
+                    [[0, 0], [0, 0], [0, 0]], -12.34)
+      self._testAll(np.random.rand(12, 13, 14).astype(t),
+                    [[0, 0], [3, 3], [3, 3]], 1.41)
       self._testAll(np.random.rand(0, 3, 4).astype(t),
                     [[0, 0], [2, 1], [2, 3]], 0.0)
 

--- a/tensorflow/python/kernel_tests/pad_op_test.py
+++ b/tensorflow/python/kernel_tests/pad_op_test.py
@@ -111,7 +111,7 @@ class PadOpTest(test.TestCase):
 
     with self.cached_session():
       jacob_t, jacob_n = gradient_checker_v2.compute_gradient(pad, [x])
-      tol = 1e-3 if x.dtype==np.float16 else 4e-5
+      tol = 1e-3 if x.dtype == np.float16 else 4e-5
       self.assertAllClose(jacob_t, jacob_n, rtol=tol, atol=tol)
 
   def _testAll(self, np_inputs, paddings, constant_values):


### PR DESCRIPTION
There appears to be an ABI mismatch between gcc7 and clang that, in case of functor::Pad<Eigen::half, 3>, results in the pad value being passed incorrectly (we see the correct value of 0 in pad_op.cc, which is compiled with gcc, and a random incorrect value in pad_op.h, which is compiled with clang).

This PR switches functor::Pad to taking all arguments by reference, which works around the problem.

It also adds float16 to tested data types for pad_op_test (the problem was not noticed for a long time because pad_op_test was not testing float16).
