### PR TITLE
Revert "Workaround for SWDEV-225502"

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -216,22 +216,11 @@ Status GpuExecutable::ExecuteThunks(
   }
 
   main_stream->ThenWaitFor(&sub_streams);
-
-  std::mutex mx;
-  std::condition_variable cond;
-  bool callback_queued = false;
-
   if (!deferred_host_callbacks.empty()) {
-    callback_queued = true;
-    auto fn = [deferred_host_callbacks{std::move(deferred_host_callbacks)}, &mx, &cond, &callback_queued]() {
+    auto fn = [deferred_host_callbacks{std::move(deferred_host_callbacks)}]() {
       for (auto& callback : deferred_host_callbacks) {
         callback();
       }
-      {
-        std::lock_guard<std::mutex> lk(mx);
-        callback_queued=false;
-      }
-      cond.notify_all();
     };
     if (run_options->run_options().then_execute_function()) {
       (*run_options->run_options().then_execute_function())(main_stream,
@@ -247,8 +236,6 @@ Status GpuExecutable::ExecuteThunks(
   if (do_profile || block_host_until_done) {
     Status block_status = main_stream->BlockHostUntilDone();
     if (!block_status.ok()) {
-      // something went wrong; can't guarantee that callbacks will complete,
-      // so we're not waiting on them
       return InternalError(
           "Failed to complete all kernels launched on stream %p: %s",
           main_stream, block_status.error_message());
@@ -272,10 +259,7 @@ Status GpuExecutable::ExecuteThunks(
           entry_computation_profile_index_));
     }
   }
-  // we need to wait for callbacks explicitly because of a known bug in ROCm
-  // (due to be fixed in 3.4)
-  std::unique_lock<std::mutex> lk(mx);
-  cond.wait(lk, [&callback_queued]{return !callback_queued;});
+
   return Status::OK();
 }
 


### PR DESCRIPTION
This reverts commit 238d2c263bb30e5eff79daaab17134daa739c510.

Its seems that SWDEV-225502 has been fixed for a while, and in theory it should be safe to remove the workaround associated with it. 

http://ontrack-internal.amd.com/browse/SWDEV-225502