### PR TITLE
Reenable gru_v2_test_gpu since the upstream PR that caused the breaka…

### DIFF
--- a/tensorflow/python/keras/layers/BUILD
+++ b/tensorflow/python/keras/layers/BUILD
@@ -852,7 +852,6 @@ cuda_py_test(
     srcs = ["gru_v2_test.py"],
     python_version = "PY3",
     shard_count = 12,
-    tags = ["no_rocm"],
     deps = [
         "//tensorflow/python:client_testlib",
         "//tensorflow/python/keras",


### PR DESCRIPTION
…ge was rolled back.