### PR TITLE
Updating the `run_gpu_multi.sh` script to run 43 tests (instead of the current 1)

### DIFF
--- a/tensorflow/core/nccl/BUILD
+++ b/tensorflow/core/nccl/BUILD
@@ -64,8 +64,6 @@ tf_cuda_cc_test(
         "manual",
         "multi_gpu",
         "no_oss",
-        # TODO(b/147451637): Replace 'no_rocm' with 'rocm_multi_gpu'.
-        "no_rocm",
         "notap",
     ],
     deps = [

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -18,6 +18,7 @@ set -e
 set -x
 
 N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
+N_TEST_JOBS=1 # run tests serially
 
 echo ""
 echo "Bazel will use ${N_BUILD_JOBS} concurrent build job(s) and ${N_TEST_JOBS} concurrent test job(s)."
@@ -41,13 +42,88 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=multi_gpu \
+      --test_tag_filters=-no_gpu,-no_rocm \
       --jobs=${N_BUILD_JOBS} \
-      --local_test_jobs=1 \
+      --local_test_jobs=${N_TEST_JOBS} \
       --test_timeout 600,900,2400,7200 \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \
       --test_size_filters=small,medium,large \
+      --cache_test_results=no \
       -- \
-      //tensorflow/core/nccl:nccl_manager_test
+//tensorflow/core/common_runtime/gpu:gpu_device_unified_memory_test_2gpu \
+//tensorflow/core/kernels:collective_nccl_test_2gpu \
+//tensorflow/core/nccl:nccl_manager_test_2gpu \
+//tensorflow/python/distribute/integration_test:mwms_peer_failure_test_2gpu \
+//tensorflow/python/distribute:checkpoint_utils_test_2gpu \
+//tensorflow/python/distribute:checkpointing_test_2gpu \
+//tensorflow/python/distribute:collective_all_reduce_strategy_test_xla_2gpu \
+//tensorflow/python/distribute:custom_training_loop_gradient_test_2gpu \
+//tensorflow/python/distribute:custom_training_loop_input_test_2gpu \
+//tensorflow/python/distribute:input_lib_test_2gpu \
+//tensorflow/python/distribute:input_lib_type_spec_test_2gpu \
+//tensorflow/python/distribute:metrics_v1_test_2gpu \
+//tensorflow/python/distribute:mirrored_variable_test_2gpu \
+//tensorflow/python/distribute:parameter_server_strategy_test_2gpu \
+//tensorflow/python/distribute:ps_values_test_2gpu \
+//tensorflow/python/distribute:random_generator_test_2gpu \
+//tensorflow/python/distribute:tf_function_test_2gpu \
+//tensorflow/python/distribute:warm_starting_util_test_2gpu \
+//tensorflow/python/keras/distribute:checkpointing_test_2gpu \
+//tensorflow/python/keras/distribute:collective_all_reduce_strategy_test_2gpu \
+//tensorflow/python/keras/distribute:collective_all_reduce_strategy_test_xla_2gpu \
+//tensorflow/python/keras/distribute:ctl_correctness_test_2gpu \
+//tensorflow/python/keras/distribute:custom_training_loop_optimizer_test_2gpu \
+//tensorflow/python/keras/distribute:keras_metrics_test_2gpu \
+//tensorflow/python/keras/distribute:keras_models_test_2gpu \
+//tensorflow/python/keras/distribute:keras_optimizer_v2_test_2gpu \
+//tensorflow/python/keras/distribute:keras_premade_models_test_2gpu \
+//tensorflow/python/keras/distribute:keras_stateful_lstm_model_correctness_test_2gpu \
+//tensorflow/python/keras/distribute:minimize_loss_test_2gpu \
+//tensorflow/python/keras/distribute:mirrored_strategy_test_2gpu \
+//tensorflow/python/keras/distribute:mirrored_variable_test_2gpu \
+//tensorflow/python/keras/distribute:multi_worker_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:category_crossing_distribution_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:category_encoding_distribution_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:discretization_distribution_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:hashing_distribution_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:image_preprocessing_distribution_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:index_lookup_distribution_test_2gpu \
+//tensorflow/python/keras/layers/preprocessing:text_vectorization_distribution_test_2gpu \
+//tensorflow/python/keras/utils:multi_gpu_utils_test_2gpu \
+//tensorflow/python/keras/utils:multi_gpu_utils_test_xla_2gpu \
+//tensorflow/python/kernel_tests:dynamic_partition_op_test_2gpu \
+//tensorflow/python/training:saver_test_2gpu \
+
+
+# no_rocm : //tensorflow/python/distribute:cross_device_ops_test_2gpu \
+# no_rocm : //tensorflow/python/distribute:distribute_utils_test_2gpu \
+# no_rocm : //tensorflow/python/distribute:strategy_common_test_2gpu \
+# no_rocm : //tensorflow/python/distribute:strategy_common_test_xla_2gpu \
+# no_rocm : //tensorflow/python/distribute:strategy_gather_test_2gpu \
+# no_rocm : //tensorflow/python/distribute:strategy_gather_test_xla_2gpu \
+# no_rocm : //tensorflow/python/distribute:test_util_test_2gpu \
+# no_rocm : //tensorflow/python/distribute:values_test_2gpu \
+# no_rocm : //tensorflow/python/distribute:vars_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:custom_training_loop_metrics_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:custom_training_loop_models_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:distribute_strategy_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:keras_dnn_correctness_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:keras_embedding_model_correctness_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:keras_image_model_correctness_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:keras_rnn_model_correctness_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:keras_save_load_test_2gpu \
+# no_rocm : //tensorflow/python/keras/distribute:keras_utils_test_2gpu \
+      
+# TIMEOUT : //tensorflow/python/keras/distribute:saved_model_mixed_api_test_2gpu \
+# TIMEOUT : //tensorflow/python/keras/distribute:saved_model_save_load_test_2gpu \
+
+# FAILED : //tensorflow/python/distribute/v1:cross_device_ops_test_2gpu \
+# FAILED : //tensorflow/python/distribute:mirrored_strategy_test_2gpu \
+# FAILED : //tensorflow/python/kernel_tests:collective_ops_test_2gpu \
+# FAILED : //tensorflow/python:collective_ops_gpu_test_2gpu \
+# FAILED : //tensorflow/python:nccl_ops_test_2gpu \
+
+# FAILED ON CI Node only : //tensorflow/python/distribute:collective_all_reduce_strategy_test_2gpu \
+# See run : http://ml-ci.amd.com:21096/job/tensorflow/job/github-prs-rocmfork-develop-upstream/job/rocm-latest-ubuntu-gpu-multi/216/console

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -44,7 +44,7 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu,-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-rocm_multi_gpu,-v1only \
+      --test_tag_filters=gpu,-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-v1only \
       --jobs=${N_BUILD_JOBS} \
       --local_test_jobs=${N_TEST_JOBS} \
       --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \


### PR DESCRIPTION
TF unit-tests that test multi-gpu support, seem to have one of the following tags on them
* multi_gpu
* multi_and_single_gpu

Just like the "gpu" test target gets a `_gpu` suffix to its name, the "multi gpu" version of the test target gets a `_2gpu` suffix to its name.

Adding those tags to a test, also results in the "manual" tag getting added to that test (see tensorflow.bzl for details)

"manual" is a special tag in bazel, and tests marked with the "manual" tag do not picked up by test target pattern wildcards (i.e., `...`, `:*`, `:all`, etc ), they have to be explicitly specified. Hence the explicit listing of all the test targets in this script.

At this point there are a total of 68 total "multi gpu" unit-tests. They can be found via the following command
```
bazel query "attr(tags, \"multi_gpu|multi_and_single_gpu\", tests(//tensorflow/...))"
```

| Total Tests | 69 |
|:---|---:|
| PASS | 43 |
| FAIL | 6 |
| TIMEOUT | 2 |
| no_rocm | 18 |

We need to root cause the fix the `FAIL` and `TIMEOUT` tests.

The `no_rocm` tests will need be manually enabled, once the no_rocm tag is removed from them