### PR TITLE
Passing some env vars through MLIR (redux)

### DIFF
--- a/tensorflow/compiler/mlir/runlit.cfg.py
+++ b/tensorflow/compiler/mlir/runlit.cfg.py
@@ -66,6 +66,12 @@ llvm_config.config.substitutions.append(
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
+for key in ['HIP_VISIBLE_DEVICES', 'CUDA_VISIBLE_DEVICES',
+            'TF_PER_DEVICE_MEMORY_LIMIT_MB']:
+  value = os.environ.get(key, None)
+  if value != None:
+    llvm_config.with_environment(key, value)
+
 tool_dirs = config.mlir_tf_tools_dirs + [
     config.mlir_tools_dir, config.llvm_tools_dir
 ]


### PR DESCRIPTION
This reinstitutes the change from PR #973 (passing HIP_VISIBLE_DEVICES and TF_PER_DEVICE_MEMORY_LIMIT_MB through to the MLIR runner). I've observed an OOM caused by the failure to enforce the memory limit lead to total driver failure, breaking all tests after the MLIR test and requiring a reboot.