### PR TITLE
Updates to XLA compiler interface

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
@@ -112,14 +112,9 @@ class GpuKernelToBlobPass
         return InternalError(
             "Could not parse ROCm architecture prefix (expected gfx)");
       }
-      uint32_t arch;
-      if (!absl::SimpleAtoi(consumable_arch, &arch)) {
-        return InternalError("Could not parse ROCm architecture number");
-      }
-
       std::string libdevice_dir = tensorflow::RocdlRoot();
       auto llvm_module_copy = llvm::CloneModule(*llvmModule);
-      xla::gpu::GpuVersion gpu_version{std::make_pair(arch, arch_str)};
+      xla::gpu::GpuVersion gpu_version{arch_str};
       auto hsaco_or = xla::gpu::amdgpu::CompileToHsaco(
           llvm_module_copy.get(), gpu_version, config, libdevice_dir);
       if (!hsaco_or.ok()) {

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -606,6 +606,7 @@ static Status CompileModuleToLlvmIrImpl(
     const std::string& target_triple, const std::string& data_layout,
     const std::string& platform_name, GpuDeviceInfo gpu_device_info,
     absl::optional<CudaComputeCapability> cuda_compute_capability,
+    std::string amdgpu_arch,
     const HloDataflowAnalysis::CanShareBuffer& can_share_buffer_function,
     int pointer_size, const HloProfileIndexMap* profile_index_map,
     CompileModuleResults* results) {
@@ -666,7 +667,7 @@ static Status CompileModuleToLlvmIrImpl(
 
   IrEmitterContext ir_emitter_context(
       /*hlo_module=*/nullptr, /*buffer_assignment=*/nullptr, platform_name,
-      gpu_device_info, cuda_compute_capability, profile_index_map,
+      gpu_device_info, cuda_compute_capability, amdgpu_arch, profile_index_map,
       &mlir_context, results->llvm_module.get());
 
   ir_emitter_context.set_allocations(results->allocations);
@@ -912,6 +913,9 @@ StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
     return cuda_compute_capability;
   }();
 
+  std::string amdgpu_arch =
+      stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+
   std::unique_ptr<HloProfileIndexMap> profile_index_map;
   std::unique_ptr<HloProfilePrinterData> profile_printer;
 
@@ -932,6 +936,7 @@ StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
   TF_RETURN_IF_ERROR(CompileModuleToLlvmIrImpl(
       module.get(), &llvm_context, target_triple_, data_layout_,
       stream_exec->platform()->Name(), gpu_device_info, cuda_compute_capability,
+      amdgpu_arch,
       GetCanShareBuffer(), pointer_size_, profile_index_map.get(),
       &compile_module_results));
 
@@ -1017,11 +1022,12 @@ StatusOr<std::unique_ptr<llvm::Module>> CompileModuleToLlvmIr(
     const std::string& target_triple, const std::string& data_layout,
     const std::string& platform_name, GpuDeviceInfo gpu_device_info,
     absl::optional<CudaComputeCapability> cuda_compute_capability,
-    int pointer_size) {
+    std::string amdgpu_arch, int pointer_size) {
   CompileModuleResults results;
   TF_RETURN_IF_ERROR(CompileModuleToLlvmIrImpl(
       hlo_module, llvm_context, target_triple, data_layout, platform_name,
-      gpu_device_info, cuda_compute_capability, DummyCanShareBufferFunction,
+      gpu_device_info, cuda_compute_capability, amdgpu_arch,
+      DummyCanShareBufferFunction,
       pointer_size, /*profile_index_map=*/nullptr, &results));
   return std::move(results.llvm_module);
 }

--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -109,13 +109,13 @@ Status GpuExecutable::CheckCompatibilityWithServiceExecutableRunOptions(
       main_stream->parent()->platform_kind();
   if (platform_kind == stream_executor::PlatformKind::kROCm) {
     int stream_isa_version;
-    main_stream->parent()->GetDeviceDescription().rocm_amdgpu_isa_version(
-        &stream_isa_version);
-    int gpu_exec_isa_version =
-        absl::get<std::pair<int, std::string>>(gpu_version_).first;
-    TF_RET_CHECK(stream_isa_version == gpu_exec_isa_version)
-        << "AMDGPU GCN ISA version mismatch; expected {" << gpu_exec_isa_version
-        << ", but was " << stream_isa_version;
+    std::string stream_arch = 
+        main_stream->parent()->
+            GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+    std::string gpu_exec_arch = absl::get<std::string>(gpu_version_);
+    TF_RET_CHECK(stream_arch == gpu_exec_arch)
+        << "AMDGPU GCN ISA version mismatch; expected {" << gpu_exec_arch
+        << ", but was " << stream_arch;
   } else if (platform_kind == stream_executor::PlatformKind::kCuda) {
     std::pair<int, int> stream_compute_compatibility;
     main_stream->parent()->GetDeviceDescription().cuda_compute_capability(

--- a/tensorflow/compiler/xla/service/gpu/gpu_types.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_types.h
@@ -29,14 +29,12 @@ namespace gpu {
 // On Cuda platform, it comprises of an <int, int> pair
 // denoting major and minor version.
 //
-// On ROCm platform, it comprises of an <int, string> pair
-// the int has the contents of the hipDeviceProp_t::gcnArchValue field.
-// the string has the contents of the hipDeviceProp_t::gcnArchName field.
+// On ROCm platform, the string has the contents of the 
+// hipDeviceProp_t::gcnArchName field.
 // The string contains all the information needed to create an exact LLVM
-// AMDGPUTarget corresopnding the AMDGPU device it represents, the int value
-// by itself is not sufficient for this purpose
+// AMDGPUTarget corresponding the AMDGPU device it represents.
 using GpuVersion =
-    absl::variant<std::pair<int, int>, std::pair<int, std::string>>;
+    absl::variant<std::pair<int, int>, std::string>;
 }  // namespace gpu
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -305,6 +305,42 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
       }
     }
 
+    if (target_triple.isAMDGPU()) {
+      std::string arch = ir_emitter_context_->amdgpu_arch();
+      VLOG(1) << arch;
+      bool isGfx908Plus = true; // todo: detect the GPU properly
+      llvm::PointerType* output_address_type =
+          llvm::dyn_cast<llvm::PointerType>(output_address->getType());
+      CHECK_NE(output_address_type, nullptr);
+
+      // todo: implement for F16 via global_atomic_fadd_pk2f16
+      bool atomic_add_supported = isGfx908Plus && (element_type == F32);
+      if (atomic_add_supported) {
+        if (output_address_type->getPointerAddressSpace() != 3) {
+          // the compiler will only generate a global_atomic_fadd if the pointer
+          // is in global addrspace (1)
+          auto cast_output_ptr = b_.CreateAddrSpaceCast(
+             output_address,
+             llvm::PointerType::get(output_address_type->getPointerElementType(),
+                               /*AddressSpace=*/1));
+          AtomicRMW(llvm::AtomicRMWInst::FAdd, cast_output_ptr, source,
+                  llvm::MaybeAlign(),
+                  llvm::AtomicOrdering::SequentiallyConsistent,
+                  // we really want "agent", but it's not in the enum.
+                  llvm::SyncScope::SingleThread);
+          return true;
+        } else {
+          // adds to shared memory are always atomic. Todo: verify that the compiler
+          // produces a ds_add_f32 rather than a CAS loop
+          AtomicRMW(llvm::AtomicRMWInst::FAdd, output_address, source,
+                  llvm::MaybeAlign(),
+                  llvm::AtomicOrdering::SequentiallyConsistent,
+                  llvm::SyncScope::SingleThread);
+          return true;
+        }
+      }
+    }
+
     if (is_atomic_integral) {
       // integral + integral
       AtomicRMW(llvm::AtomicRMWInst::Add, output_address, source,

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_context.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_context.h
@@ -41,6 +41,7 @@ class IrEmitterContext {
       const HloModule* hlo_module, const BufferAssignment* buffer_assignment,
       std::string platform_name, GpuDeviceInfo gpu_device_info,
       absl::optional<CudaComputeCapability> cuda_compute_capability,
+      std::string amdgpu_arch,
       const HloProfileIndexMap* profile_index_map,
       mlir::MLIRContext* mlir_context, llvm::Module* llvm_module)
       : hlo_module_(hlo_module),
@@ -48,6 +49,7 @@ class IrEmitterContext {
         platform_name_(std::move(platform_name)),
         gpu_device_info_(gpu_device_info),
         cuda_compute_capability_(cuda_compute_capability),
+        amdgpu_arch_(amdgpu_arch),
         profile_index_map_(profile_index_map),
         mlir_context_(mlir_context),
         llvm_module_(llvm_module) {}
@@ -64,6 +66,9 @@ class IrEmitterContext {
   GpuDeviceInfo gpu_device_info() const { return gpu_device_info_; }
   absl::optional<CudaComputeCapability> cuda_compute_capability() const {
     return cuda_compute_capability_;
+  }
+  std::string amdgpu_arch() const {
+    return amdgpu_arch_;
   }
   const HloProfileIndexMap* profile_index_map() { return profile_index_map_; }
   mlir::MLIRContext* mlir_context() { return mlir_context_; }
@@ -91,6 +96,7 @@ class IrEmitterContext {
   std::string platform_name_;
   GpuDeviceInfo gpu_device_info_;
   absl::optional<CudaComputeCapability> cuda_compute_capability_;
+  std::string amdgpu_arch_;
   const HloProfileIndexMap* profile_index_map_;
   mlir::MLIRContext* mlir_context_;
   llvm::Module* llvm_module_;

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -803,6 +803,11 @@ Status AMDGPUTargetModuleLinker(llvm::Module* module, GpuVersion gpu_version,
     }
   }
 
+  for (llvm::Function& fn : *module) {
+      fn.addFnAttr("denormal-fp-math-f32", "preserve-sign,preserve-sign");
+      fn.addFnAttr("amdgpu-unsafe-fp-atomics", "true");
+  }
+
   return Status::OK();
 }
 
@@ -898,6 +903,7 @@ void AMDGPUBackendInit(const HloModuleConfig& hlo_module_config) {
 #endif
 
 #endif
+  //FeedLLVMWithFlags({"-munsafe-fp-atomics", "-fdenormal-fp-math-f32=preserve-sign,preserve-sign"});
 
   llvm::PassRegistry* registry = llvm::PassRegistry::getPassRegistry();
   InitializePasses(registry);

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -838,11 +838,11 @@ std::string MapGCNArchNameTokenToFeatureStr(const std::string& token) {
   return "";
 
 }
-OA
+
 std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
     const std::string& gcn_arch_name) {
   std::string feature_str;
-  std::string gfx;
+  std::string gfx = gcn_arch_name;
 #if TF_ROCM_VERSION < 30900
   // For ROCm versions older than 3.9, hardcode it to "+code-object-v3"
   // This is simply to preserve how things were...nohing else

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_unrolling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_unrolling_test.cc
@@ -70,9 +70,7 @@ TEST_F(GpuUnrollingTest, UnrollFourTimes) {
   config.set_debug_options(debug_options);
   auto hlo_module =
       ParseAndReturnVerifiedModule(kAddModule, config).ValueOrDie();
-
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  const string pattern1 = R"(
 ; CHECK-LABEL: @fusion
 ; CHECK: fadd
 ; CHECK: fadd
@@ -80,7 +78,18 @@ TEST_F(GpuUnrollingTest, UnrollFourTimes) {
 ; CHECK: fadd
 ; CHECK-NOT: fadd
 ; CHECK: }
-      )",
+      )";
+
+  const string pattern2 = R"(
+; CHECK-LABEL: @fusion
+; CHECK: fadd <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK-NOT: fadd
+; CHECK: }
+      )";
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
                      /*match_optimized_ir=*/true);
 }
 
@@ -90,9 +99,7 @@ TEST_F(GpuUnrollingTest, UnrollDefaultTimes) {
   config.set_debug_options(GetDebugOptionsFromFlags());
   auto hlo_module =
       ParseAndReturnVerifiedModule(kAddModule, config).ValueOrDie();
-
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  const string pattern1 = R"(
 ; CHECK-LABEL: @fusion
 ; CHECK: load <4 x float>
 ; CHECK: fadd
@@ -102,7 +109,18 @@ TEST_F(GpuUnrollingTest, UnrollDefaultTimes) {
 ; CHECK-NOT: fadd
 ; CHECK: store <4 x float>
 ; CHECK: }
-      )",
+      )";
+
+  const string pattern2 = R"(
+; CHECK-LABEL: @fusion
+; CHECK: fadd <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK-NOT: fadd
+; CHECK: store <4 x float>
+; CHECK: }
+      )";
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
                      /*match_optimized_ir=*/true);
 }
 
@@ -122,9 +140,7 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedAdd) {
     })";
   auto hlo_module =
       ParseAndReturnVerifiedModule(kUnfusedAddModule, config).ValueOrDie();
-
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  const string pattern1 = R"(
 ; CHECK-LABEL: @add
 ; CHECK: load <4 x float>
 ; CHECK: fadd
@@ -134,8 +150,20 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedAdd) {
 ; CHECK-NOT: fadd
 ; CHECK: store <4 x float>
 ; CHECK: }
-      )",
-                     /*match_optimized_ir=*/true);
+      )";
+
+  const string pattern2 = R"(
+; CHECK-LABEL: @add
+; CHECK: fadd <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK-NOT: fadd
+; CHECK: store <4 x float>
+; CHECK: }
+      )";
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
+                    /*match_optimized_ir=*/true);
 }
 
 TEST_F(GpuUnrollingTest, DisabledUnrollUnfusedSine) {
@@ -295,8 +323,7 @@ TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
       ParseAndReturnVerifiedModule(kMultiOutputFusionModule, config)
           .ValueOrDie();
 
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  string pattern1 = R"(
 ; CHECK-LABEL: @fusion
 ; CHECK: load <2 x float>
 ; CHECK: load <2 x float>
@@ -311,7 +338,25 @@ TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
 ; CHECK-NOT: fadd
 ; CHECK-NOT: fmul
 ; CHECK: }
-      )",
+      )";
+
+  string pattern2 = R"(
+; CHECK-LABEL: @fusion
+; CHECK: load <2 x float>
+; CHECK: load <2 x float>
+; CHECK-NOT: load <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK: fmul <2 x float>
+; CHECK: store <2 x float>
+; CHECK: store <2 x float>
+; CHECK-NOT: store <2 x float>
+; CHECK-NOT: fadd
+; CHECK-NOT: fmul
+; CHECK: }
+      )";
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
                      /*match_optimized_ir=*/true);
 }
 

--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
@@ -65,9 +65,13 @@ StatusOr<std::unique_ptr<Executable>> MlirGpuTestBase::CompileMlirModule(
     return cuda_compute_capability;
   }();
 
+  std::string amdgpu_arch =
+      stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+
   IrEmitterContext ir_emitter_context(
       /*hlo_module=*/nullptr, /*buffer_assignment=*/nullptr,
       backend_->platform()->Name(), gpu_device_info, cuda_compute_capability,
+      amdgpu_arch,
       /*profile_index_map=*/nullptr, /*mlir_context=*/nullptr,
       llvm_module.get());
 

--- a/tensorflow/compiler/xla/tests/llvm_irgen_test_base.h
+++ b/tensorflow/compiler/xla/tests/llvm_irgen_test_base.h
@@ -38,6 +38,11 @@ class LlvmIrGenTestBase : public CodegenTestBase {
   void CompileAndVerifyIr(std::unique_ptr<HloModule> hlo_module,
                           const string& pattern, bool match_optimized_ir);
 
+  // Same as above, to be used if there are multiple valid patterns
+  void CompileAndVerifyIr(std::unique_ptr<HloModule> hlo_module,
+                          const std::vector<string>& patterns,
+                          bool match_optimized_ir);
+
   // A thin wrapper around CompileAndVerifyIr that parses `hlo_text` to create
   // an HLO module.
   void CompileAndVerifyIr(const string& hlo_text,

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -93,8 +93,10 @@ bool HasFastFP16Support(const DeviceProperties& props) {
 #if GOOGLE_CUDA
   return GetDeviceGPUArch(props) >= kMinGPUArch;
 #elif TENSORFLOW_USE_ROCM
-  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"},
-                                                           {"gfx908"}};
+  absl::flat_hash_set<std::string> FP16SupportedDevices = {
+      {"gfx906"}, {"gfx908"}, {"gfx90a"}, {"gfx910"}, {"gfx1010"}, {"gfx1012"},
+      {"gfx1030"}
+  };
   std::string gcnArchName = props.environment().at("architecture");
   std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
   return !gpu_arch.empty() && FP16SupportedDevices.contains(gpu_arch[0]);

--- a/tensorflow/core/kernels/bias_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bias_op_gpu.cu.cc
@@ -138,7 +138,7 @@ __global__ void BiasGradNHWC_SharedAtomics(
   for (int32 index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
        index += blockDim.x * gridDim.x) {
     int32 bias_offset = index % bias_size;
-    GpuAtomicAdd(s_data + bias_offset, AccT(ldg(output_backprop + index)));
+    GpuAtomicAddShared(s_data + bias_offset, AccT(ldg(output_backprop + index)));
   }
   __syncthreads();
 
@@ -178,7 +178,7 @@ __global__ void BiasGradNCHW_SharedAtomics(
   // Write the accumulated sum in this thread to the shared memory. Each thread
   // shifts their write location to avoid bank conflict.
   int bias_offset = threadIdx.x % 32;
-  GpuAtomicAdd(s_data + bias_offset, sum);
+  GpuAtomicAddShared(s_data + bias_offset, sum);
   __syncthreads();
 
   // Accumulate the results in the shared memory into the first element.

--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -174,7 +174,7 @@ __global__ void BincountColReduceSharedKernel(const Tidx* in, const T* weights,
         shared_col_bins[offset] = T(1);
       } else {
         T value = (weights_size == 0) ? T(1) : ldg(weights + index);
-        GpuAtomicAdd(shared_col_bins + offset, value);
+        GpuAtomicAddShared(shared_col_bins + offset, value);
       }
     }
   }


### PR DESCRIPTION
This updates the gfx version parsing to allow strings like "gfx90a" to be passed to the compiler, and updates the token mapping to work correctly with the current version of the LLVM compiler.