### PR TITLE
Warpsize setting for gfx10

### DIFF
--- a/tensorflow/core/kernels/reduction_ops_gpu_double.cu.cc
+++ b/tensorflow/core/kernels/reduction_ops_gpu_double.cu.cc
@@ -73,3 +73,4 @@ DEFINE_FOR_ALL_REDUCERS(double);
 }  // end namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -28,7 +28,8 @@ limitations under the License.
 #if GOOGLE_CUDA
 #define TF_RED_WARPSIZE 32
 #elif TENSORFLOW_USE_ROCM
-#define TF_RED_WARPSIZE 64
+// We don't define TF_RED_WARPSIZE here, because it can be either 32 or 64
+// and the value is not known at compile time.
 #endif
 
 // Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.


### PR DESCRIPTION
This change sets TF_RED_WARPSIZE correctly (if crudely) for some gfx10 architectures.