### PR TITLE
resolved the event drop issue for stream synchronize(committer email fixed)

### DIFF
--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
@@ -1836,6 +1836,7 @@ Status CuptiTracer::HandleCallback(CUpti_CallbackDomain domain,
   return Status::OK();
 }
 
+//TODO(rocm-profiler): check unified memory counters in ROCm
 void CuptiTracer::ConfigureActivityUnifiedMemoryCounter(bool enable) {
   CUpti_ActivityUnifiedMemoryCounterConfig config[2];
   // By experiments, currently only measurements from these two activities are

--- a/tensorflow/core/profiler/internal/gpu/device_tracer_rocm.cc
+++ b/tensorflow/core/profiler/internal/gpu/device_tracer_rocm.cc
@@ -115,7 +115,7 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
       }
       num_callback_events_++;
     }
-    if (event.source == RocmTracerEventSource::Activity) {
+    else if (event.source == RocmTracerEventSource::Activity) {
       if (num_activity_events_ > options_.max_activity_api_events) {
         OnEventsDropped("max activity event capacity reached",
                         event.correlation_id);
@@ -133,8 +133,14 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
         case RocmTracerEventDomain::HIP_API:
           switch (event.source) {
             case RocmTracerEventSource::ApiCallback:
+              if (iter->second.type == RocmTracerEventType::StreamSynchronize){
+                iter->second.device_id = event.device_id;
+                }
               break;
             case RocmTracerEventSource::Activity:
+              if (iter->second.type == RocmTracerEventType::StreamSynchronize){
+                iter->second.stream_id = event.stream_id;
+                }
               // Use the start/stop time from the HCC_OPS domain
               // unless this is one of those events for which we do not
               // receive any HCC activity record callback
@@ -155,6 +161,7 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
               iter->second.stream_id = event.stream_id;
               iter->second.start_time_ns = event.start_time_ns;
               iter->second.end_time_ns = event.end_time_ns;
+              //TODO(rocm-profiler): should we find annotation with this?
               // Use the annotation from the HIP_API domain
               // iter->second.annotation = event.annotation;
               break;
@@ -315,6 +322,7 @@ class RocmTraceCollectorImpl : public profiler::RocmTraceCollector {
   bool IsEventTypeWithoutHCCActivityRecordCallback(RocmTracerEventType type) {
     switch (type) {
       case RocmTracerEventType::MemoryAlloc:
+      case RocmTracerEventType::StreamSynchronize:
         return true;
         break;
       default:
@@ -685,6 +693,7 @@ RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
   // clang-format on
 
   options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, hip_api_domain_ops);
+  //options.api_callbacks.emplace(ACTIVITY_DOMAIN_ROCTX, empty_vec);
   // options.api_callbacks.emplace(ACTIVITY_DOMAIN_HIP_API, empty_vec);
 
   // options.activity_tracing.emplace(ACTIVITY_DOMAIN_HIP_API,

--- a/tensorflow/core/profiler/internal/gpu/device_tracer_rocm.cc
+++ b/tensorflow/core/profiler/internal/gpu/device_tracer_rocm.cc
@@ -64,8 +64,13 @@ void GetDeviceCapabilities(int32 device_ordinal, XPlaneBuilder* device_plane) {
 }
 
 bool IsHostEvent(const RocmTracerEvent& event) {
-  // TODO(rocm)
-  // Classify all events as GPU events for now
+  switch (event.type)
+  {
+  case RocmTracerEventType::StreamSynchronize:
+    return true;
+  default:
+    break;
+  }
   return false;
 }
 
@@ -670,6 +675,7 @@ RocmTracerOptions GpuTracer::GetRocmTracerOptions() {
 
   // clang formatting does not preserve one entry per line
   // clang-format off
+  //TODO(rocm-profiler): we should add stream wait API
   std::vector<uint32_t> hip_api_domain_ops{
       HIP_API_ID_hipExtModuleLaunchKernel,
       HIP_API_ID_hipFree,

--- a/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
@@ -65,12 +65,8 @@ const char* GetActivityDomainName(uint32_t domain) {
       return "HSA API";
     case ACTIVITY_DOMAIN_HSA_OPS:
       return "HSA OPS";
-    // case ACTIVITY_DOMAIN_HIP_OPS:
-    //   return "HIP OPS";
-    case ACTIVITY_DOMAIN_HCC_OPS:
-      return "HCC OPS";
-    // case ACTIVITY_DOMAIN_HIP_VDI:
-    //   return "HIP VDI";
+    case ACTIVITY_DOMAIN_HIP_OPS:
+      return "HIP OPS/HCC OPS/HIP VDI";
     case ACTIVITY_DOMAIN_HIP_API:
       return "HIP API";
     case ACTIVITY_DOMAIN_KFD_API:
@@ -178,7 +174,11 @@ inline void DumpApiCallbackData(uint32_t domain, uint32_t cbid,
         DCHECK(false);
         break;
     }
-  } else {
+  }else if (domain == ACTIVITY_DOMAIN_ROCTX){
+    const roctx_api_data_t* data = reinterpret_cast<const roctx_api_data_t*>(cbdata);
+    oss << ", message=" << data->args.message << ", id=" << data->args.id; 
+  }
+  else {
     oss << ": " << cbid;
   }
   VLOG(3) << oss.str();
@@ -187,7 +187,7 @@ inline void DumpApiCallbackData(uint32_t domain, uint32_t cbid,
 void DumpActivityRecord(const roctracer_record_t* record) {
   std::ostringstream oss;
   oss << "Activity callback for " << GetActivityDomainName(record->domain);
-  oss << wrap::roctracer_op_string(record->domain, record->op, record->kind);
+  oss << " "<< wrap::roctracer_op_string(record->domain, record->op, record->kind);
   oss << ", correlation_id=" << record->correlation_id;
   oss << ", begin_ns=" << record->begin_ns;
   oss << ", end_ns=" << record->end_ns;
@@ -197,6 +197,9 @@ void DumpActivityRecord(const roctracer_record_t* record) {
   oss << ", thread_id=" << record->thread_id;
   oss << ", external_id=" << record->external_id;
   oss << ", bytes=" << record->bytes;
+  oss << ", domain=" << record->domain;
+  oss << ", op=" << record->op;
+  oss << ", kind=" << record->kind;
   VLOG(3) << oss.str();
 }
 
@@ -242,6 +245,7 @@ const char* GetRocmTracerEventSourceName(const RocmTracerEventSource& source) {
   return "";
 }
 
+//FIXME(rocm-profiler): These domain names are not consistent with the GetActivityDomainName function
 const char* GetRocmTracerEventDomainName(const RocmTracerEventDomain& domain) {
   switch (domain) {
     case RocmTracerEventDomain::HIP_API:
@@ -584,7 +588,9 @@ class RocmApiCallbackImpl {
     event.name = wrap::roctracer_op_string(ACTIVITY_DOMAIN_HIP_API, cbid, 0);
     event.thread_id = GetCachedTID();
     event.correlation_id = data->correlation_id;
-
+    // We retrieve the DeviceID here for this event type.  
+    const hipStream_t& stream = data->args.hipStreamSynchronize.stream;
+    event.device_id = hipGetStreamDeviceId(stream);
     collector_->AddEvent(std::move(event));
   }
 
@@ -837,7 +843,7 @@ class RocmActivityCallbackImpl {
     event.correlation_id = record->correlation_id;
     event.annotation =
         collector_->annotation_map()->LookUp(event.correlation_id);
-
+    event.stream_id = record->queue_id;
     event.start_time_ns = record->begin_ns;
     event.end_time_ns = record->end_ns;
 
@@ -913,8 +919,9 @@ absl::string_view AnnotationMap::LookUp(uint32 correlation_id) {
   return singleton;
 }
 
+//FIXME(rocm-profiler): we should also check if we have AMD GPUs
 bool RocmTracer::IsAvailable() const {
-  return !activity_tracing_enabled_ && !api_tracing_enabled_;
+  return !activity_tracing_enabled_ && !api_tracing_enabled_; // &&NumGpus()
 }
 
 int RocmTracer::NumGpus() {
@@ -1079,8 +1086,9 @@ Status RocmTracer::EnableActivityTracing() {
       for (auto& op : ops) {
         VLOG(3) << "Enabling Activity tracing for "
                 << GetActivityDomainOpName(domain, op);
+        // roctracer library has not exported "roctracer_enable_op_activity"         
         RETURN_IF_ROCTRACER_ERROR(
-            wrap::roctracer_enable_op_activity(domain, op));
+            wrap::roctracer_enable_op_activity_expl(domain, op, nullptr));
       }
     }
   }
@@ -1111,6 +1119,7 @@ Status RocmTracer::DisableActivityTracing() {
     }
   }
 
+  //TODO(rocm-profiler): this stopping mechanism needs improvement.
   // Flush the activity buffer BEFORE setting the activity_tracing_enable_
   // flag to FALSE. This is because the activity record callback routine is
   // gated by the same flag

--- a/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
@@ -223,6 +223,10 @@ const char* GetRocmTracerEventTypeName(const RocmTracerEventType& type) {
       return "MemoryAlloc";
     case RocmTracerEventType::Generic:
       return "Generic";
+    case RocmTracerEventType::StreamSynchronize:
+      return "StreamSynchronize";
+    case RocmTracerEventType::Memset:
+      return "Memset";
     default:
       DCHECK(false);
       return "";

--- a/tensorflow/core/profiler/internal/gpu/rocm_tracer.h
+++ b/tensorflow/core/profiler/internal/gpu/rocm_tracer.h
@@ -72,6 +72,7 @@ struct KernelDetails {
   uint64 grid_z;
 };
 
+//TODO(rocm-profiler): do we support other event types such as memfree in CUPTI? 
 enum class RocmTracerEventType {
   Unsupported = 0,
   Kernel,
@@ -118,6 +119,7 @@ struct RocmTracerEvent {
   // This points to strings in AnnotationMap, which should outlive the point
   // where serialization happens.
   absl::string_view annotation;
+  absl::string_view roctx_range;
   uint64 start_time_ns;
   uint64 end_time_ns;
   uint32 device_id = kInvalidDeviceId;

--- a/tensorflow/stream_executor/rocm/roctracer_wrapper.h
+++ b/tensorflow/stream_executor/rocm/roctracer_wrapper.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "rocm/include/roctracer/roctracer.h"
 #include "rocm/include/roctracer/roctracer_hcc.h"
 #include "rocm/include/roctracer/roctracer_hip.h"
+#include "rocm/include/roctracer/roctracer_roctx.h"
 #include "tensorflow/stream_executor/lib/env.h"
 #include "tensorflow/stream_executor/platform/dso_loader.h"
 #include "tensorflow/stream_executor/platform/port.h"
@@ -60,6 +61,7 @@ namespace CachedDsoLoader = stream_executor::internal::CachedDsoLoader;
 
 #endif
 
+//BUG(rocm-profiler): roctracer_enable_op_activity does not exist in rocm-4.0.1
 // clang-format off
 #define FOREACH_ROCTRACER_API(__macro)			\
   __macro(roctracer_default_pool_expl)			\
@@ -70,6 +72,7 @@ namespace CachedDsoLoader = stream_executor::internal::CachedDsoLoader;
   __macro(roctracer_enable_domain_activity_expl)	\
   __macro(roctracer_enable_domain_callback)		\
   __macro(roctracer_enable_op_activity)			\
+  __macro(roctracer_enable_op_activity_expl)			\
   __macro(roctracer_enable_op_callback)			\
   __macro(roctracer_error_string)			\
   __macro(roctracer_flush_activity_expl)		\


### PR DESCRIPTION
In this PR, I solved the drop event issue regarding the StreamSynchronize activities. The main issue was that we did not extract the Device ID for these kind of events and it causes them to be dropped due to invalid Device ID condition.