### PR TITLE
[r2.3-rocm-enhanced] Switching ROCm TF to use the new hipfft library (instead of rocfft)

### DIFF
--- a/tensorflow/stream_executor/platform/default/dlopen_checker.cc
+++ b/tensorflow/stream_executor/platform/default/dlopen_checker.cc
@@ -42,7 +42,7 @@ port::Status TryDlopenCUDALibraries() {
 port::Status TryDlopenROCmLibraries() {
   auto rocblas_status = GetRocblasDsoHandle();
   auto miopen_status = GetMiopenDsoHandle();
-  auto rocfft_status = GetRocfftDsoHandle();
+  auto rocfft_status = GetHipfftDsoHandle();
   auto rocrand_status = GetRocrandDsoHandle();
   if (!rocblas_status.status().ok() || !miopen_status.status().ok() ||
       !rocfft_status.status().ok() || !rocrand_status.status().ok()) {

--- a/tensorflow/stream_executor/platform/default/dso_loader.cc
+++ b/tensorflow/stream_executor/platform/default/dso_loader.cc
@@ -128,8 +128,8 @@ port::StatusOr<void*> GetMiopenDsoHandle() {
   return GetDsoHandle("MIOpen", "");
 }
 
-port::StatusOr<void*> GetRocfftDsoHandle() {
-  return GetDsoHandle("rocfft", "");
+port::StatusOr<void*> GetHipfftDsoHandle() {
+  return GetDsoHandle("hipfft", "");
 }
 
 port::StatusOr<void*> GetRocrandDsoHandle() {
@@ -200,8 +200,8 @@ port::StatusOr<void*> GetMiopenDsoHandle() {
   return *result;
 }
 
-port::StatusOr<void*> GetRocfftDsoHandle() {
-  static auto result = new auto(DsoLoader::GetRocfftDsoHandle());
+port::StatusOr<void*> GetHipfftDsoHandle() {
+  static auto result = new auto(DsoLoader::GetHipfftDsoHandle());
   return *result;
 }
 

--- a/tensorflow/stream_executor/platform/default/dso_loader.h
+++ b/tensorflow/stream_executor/platform/default/dso_loader.h
@@ -48,7 +48,7 @@ port::StatusOr<void*> GetNvInferPluginDsoHandle();
 
 port::StatusOr<void*> GetRocblasDsoHandle();
 port::StatusOr<void*> GetMiopenDsoHandle();
-port::StatusOr<void*> GetRocfftDsoHandle();
+port::StatusOr<void*> GetHipfftDsoHandle();
 port::StatusOr<void*> GetRocrandDsoHandle();
 port::StatusOr<void*> GetRoctracerDsoHandle();
 port::StatusOr<void*> GetHipDsoHandle();
@@ -81,7 +81,7 @@ port::StatusOr<void*> GetCudnnDsoHandle();
 
 port::StatusOr<void*> GetRocblasDsoHandle();
 port::StatusOr<void*> GetMiopenDsoHandle();
-port::StatusOr<void*> GetRocfftDsoHandle();
+port::StatusOr<void*> GetHipfftDsoHandle();
 port::StatusOr<void*> GetRocrandDsoHandle();
 port::StatusOr<void*> GetRoctracerDsoHandle();
 port::StatusOr<void*> GetHipDsoHandle();

--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -209,7 +209,7 @@ cc_library(
         "//tensorflow/stream_executor/platform:dso_loader",
         "@local_config_rocm//rocm:rocm_headers",
     ] + if_static([
-        "@local_config_rocm//rocm:rocfft",
+        "@local_config_rocm//rocm:hipfft",
     ])),
     alwayslink = True,
 )

--- a/tensorflow/stream_executor/rocm/rocm_fft.cc
+++ b/tensorflow/stream_executor/rocm/rocm_fft.cc
@@ -61,7 +61,7 @@ namespace wrap {
     static const char *kName;                                             \
     using FuncPtrT = std::add_pointer<decltype(::__name)>::type;          \
     static void *GetDsoHandle() {                                         \
-      auto s = internal::CachedDsoLoader::GetRocfftDsoHandle();           \
+      auto s = internal::CachedDsoLoader::GetHipfftDsoHandle();           \
       return s.ValueOrDie();                                              \
     }                                                                     \
     static FuncPtrT LoadOrDie() {                                         \

--- a/tensorflow/stream_executor/rocm/rocm_fft.h
+++ b/tensorflow/stream_executor/rocm/rocm_fft.h
@@ -20,7 +20,7 @@ limitations under the License.
 #ifndef TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_FFT_H_
 #define TENSORFLOW_STREAM_EXECUTOR_ROCM_ROCM_FFT_H_
 
-#include "rocm/include/rocfft/hipfft.h"
+#include "rocm/include/hipfft/hipfft.h"
 #include "tensorflow/stream_executor/fft.h"
 #include "tensorflow/stream_executor/platform/port.h"
 #include "tensorflow/stream_executor/plugin_registry.h"

--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -51,9 +51,9 @@ cc_library(
 )
 
 cc_library(
-    name = "rocfft",
-    srcs = ["rocm/lib/%{rocfft_lib}"],
-    data = ["rocm/lib/%{rocfft_lib}"],
+    name = "hipfft",
+    srcs = ["rocm/lib/%{hipfft_lib}"],
+    data = ["rocm/lib/%{hipfft_lib}"],
     includes = [
         ".",
         "rocm/include",
@@ -106,7 +106,7 @@ cc_library(
         ":rocm_headers",
         ":hip",
         ":rocblas",
-        ":rocfft",
+        ":hipfft",
         ":hiprand",
         ":miopen",
         ":roctracer",

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -386,7 +386,7 @@ def _find_libs(repository_ctx, rocm_config, bash_bin):
         for name, path in [
             ("amdhip64", rocm_config.rocm_toolkit_path),
             ("rocblas", rocm_config.rocm_toolkit_path + "/rocblas"),
-            ("rocfft", rocm_config.rocm_toolkit_path + "/rocfft"),
+            ("hipfft", rocm_config.rocm_toolkit_path + "/hipfft"),
             ("hiprand", rocm_config.rocm_toolkit_path + "/hiprand"),
             ("MIOpen", rocm_config.rocm_toolkit_path + "/miopen"),
             ("rccl", rocm_config.rocm_toolkit_path + "/rccl"),
@@ -470,7 +470,7 @@ def _create_dummy_repository(repository_ctx):
             "%{rocblas_lib}": _lib_name("rocblas"),
             "%{miopen_lib}": _lib_name("miopen"),
             "%{rccl_lib}": _lib_name("rccl"),
-            "%{rocfft_lib}": _lib_name("rocfft"),
+            "%{hipfft_lib}": _lib_name("hipfft"),
             "%{hiprand_lib}": _lib_name("hiprand"),
             "%{hipsparse_lib}": _lib_name("hipsparse"),
             "%{roctracer_lib}": _lib_name("roctracer64"),
@@ -565,9 +565,9 @@ def _create_local_rocm_repository(repository_ctx):
         ),
         make_copy_dir_rule(
             repository_ctx,
-            name = "rocfft-include",
-            src_dir = rocm_toolkit_path + "/rocfft/include",
-            out_dir = "rocm/include/rocfft",
+            name = "hipfft-include",
+            src_dir = rocm_toolkit_path + "/hipfft/include",
+            out_dir = "rocm/include/hipfft",
         ),
         make_copy_dir_rule(
             repository_ctx,
@@ -626,7 +626,7 @@ def _create_local_rocm_repository(repository_ctx):
         {
             "%{hip_lib}": rocm_libs["amdhip64"].file_name,
             "%{rocblas_lib}": rocm_libs["rocblas"].file_name,
-            "%{rocfft_lib}": rocm_libs["rocfft"].file_name,
+            "%{hipfft_lib}": rocm_libs["hipfft"].file_name,
             "%{hiprand_lib}": rocm_libs["hiprand"].file_name,
             "%{miopen_lib}": rocm_libs["MIOpen"].file_name,
             "%{rccl_lib}": rocm_libs["rccl"].file_name,
@@ -634,7 +634,7 @@ def _create_local_rocm_repository(repository_ctx):
             "%{roctracer_lib}": rocm_libs["roctracer64"].file_name,
             "%{copy_rules}": "\n".join(copy_rules),
             "%{rocm_headers}": ('":rocm-include",\n' +
-                                '":rocfft-include",\n' +
+                                '":hipfft-include",\n' +
                                 '":rocblas-include",\n' +
                                 '":miopen-include",\n' +
                                 '":rccl-include",\n' +


### PR DESCRIPTION


## Note that this is ROCm backward compatibility breaking change.
## After this commit, you will need to use ROCm 4.1 or higher

For ROCm 4.0 and prior, hipfft was a header-only "library" that was shipped along with the rocfft library. ROCm TF code uses the hipfft APIs defined in the "hipfft.h" header file, which was part of the package for rocfft library. ROCm TF would dynamically load the "rocfft" library at runtime.

From ROCm 4.1 onwards, it seems hipfft is a separate library from rocfft, and ROCm TF needs to use the "hipfft" library insteaf of the "rocfft" library. Specifcally, ROCm TF needs to
* pick up the "hipfft.h" header from the hipfft install area (instead of the rocfft install area).
* dynamically load the the "hipfft" library instead of the "rocfft" library
This commit has the two above changes

This change is required because without this change, the unit-tests that called the hipfft API ( `hipfftSetWorkArea` ) were failing when run with ROCm 4.1 (and without the changes in this commit).

unit-tests known to call the `hipfftSetWorkArea` API

```
//tensorflow/python/kernel_tests/linalg:linear_operator_circulant_test_gpu
//tensorflow/python/kernel_tests/signal:dct_ops_test
//tensorflow/python/kernel_tests/signal:mel_ops_test
//tensorflow/python/kernel_tests/signal:mfcc_ops_test
//tensorflow/python/kernel_tests/signal:spectral_ops_test
//tensorflow/python/ops/parallel_for:control_flow_ops_test_gpu
```