### PR TITLE
Explicitly adding a "-lstdc++" as the last option to the linker command

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -240,6 +240,7 @@ def main():
     gpu_linker_flags.append('-Wl,-rpath=' + HIP_RUNTIME_PATH)
     gpu_linker_flags.append('-l' + HIP_RUNTIME_LIBRARY)
     gpu_linker_flags.append("-lrt")
+    gpu_linker_flags.append("-lstdc++")
 
     if VERBOSE: print(' '.join([CPU_COMPILER] + gpu_linker_flags))
     return subprocess.call([CPU_COMPILER] + gpu_linker_flags)


### PR DESCRIPTION
When using a manylinux complaint GCC from (devtoolset7/8/9), we were running into the link time errors similar the following

```

bazel build @flatbuffers//:flatc
...
...
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/util.o:util.cpp:function flatbuffers::GetExtension(std::string const&): error: undefined reference to 'std::__throw_out_of_range_fmt(char const*, ...)'
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/util.o:util.cpp:function flatbuffers::StripPath(std::string const&): error: undefined reference to 'std::__throw_out_of_range_fmt(char const*, ...)'
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/idl_gen_swift.o:idl_gen_swift.cpp:function flatbuffers::BaseGenerator::~BaseGenerator(): error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/idl_gen_swift.o:idl_gen_swift.cpp:function std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::~basic_stringbuf(): error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/idl_gen_swift.o:idl_gen_swift.cpp:function flatbuffers::swift::SwiftGenerator::~SwiftGenerator(): error: undefined reference to 'operator delete(void*, unsigned long)'
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/idl_gen_swift.o:idl_gen_swift.cpp:function flatbuffers::swift::SwiftGenerator::Name(flatbuffers::Definition const&) const: error: undefined reference to 'std::_Hash_bytes(void const*, unsigned long, unsigned long)'
bazel-out/k8-opt/bin/external/flatbuffers/src/_objs/flatc/idl_gen_swift.o:idl_gen_swift.cpp:function flatbuffers::swift::SwiftGenerator::GenerateStructArgs(flatbuffers::StructDef const&, std::string*, std::string const&): error: undefined reference to 'std::_Hash_bytes(void const*, unsigned long, unsigned long)'
...
...
```

This can be fixed by ensuring that we have "-lstdc++" at the end of the linker options.

The following is a description of what seems to be the root cause of the error above, not sure whether it is a completely accruate anaylsis.

* manylinux201X compliant binaries are required to use (dynamically link to) a libstdc++.so that is pegged to some old version
  * manylinux2010 spec - https://www.python.org/dev/peps/pep-0571/
  * manylinux2014 spec - https://www.python.org/dev/peps/pep-0599/
* To meet this requirement, the user has to use an equally old version of GCC. This is because newer GCC versions, which support newer C++ features, also require newer libstdc++ implementations.

devtoolset7/8/9 toolsets provide newer GCC versions, which produce manylinux201X compliant binaries. They do so by splitting the libstdc++.so into two parts
* a shared library part which is manylinux compliant
* a static library part which implements the newer C++ features supported by the newer GCC version

For example

```
[root@prj47-rack-15 tensorflow]# ls -l /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libstdc++*
-rw-r--r-- 1 root root 5844898 May 27  2020 /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libstdc++.a
-rw-r--r-- 1 root root  716680 May 27  2020 /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libstdc++fs.a
-rw-r--r-- 1 root root 2892744 May 27  2020 /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libstdc++_nonshared.a
-rw-r--r-- 1 root root     210 May 27  2020 /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libstdc++.so

[root@prj47-rack-15 tensorflow]# cat /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libstdc++.so
/* GNU ld script
   Use the shared library, but some functions are only in
   the static library, so try that secondarily.  */
OUTPUT_FORMAT(elf64-x86-64)
INPUT ( /usr/lib64/libstdc++.so.6 -lstdc++_nonshared )
```

In order for this linker script to work as expected, the `.o` files that refer to the symbols within the static library part of libstdc++ (i.e. `libstdc+_nonshared` above in the example above) must come before the `-lstdc++` argument on the linker command line. When this is not the case, the linker thinks that none of the symbols within the static library part of libstdc++ are needed and hence will not pull it in, leading to linker errors for symbols defined within the static libary part.

This linker behaviour can be verified using the following example

```cpp
// static_library.cc
#include <iostream>

void shared_library_func_1() {
  std::cout << "shared_library_func_1" << std::endl;
}
```

```cpp
// shared_library.cc
#include <iostream>

void static_library_func_1() {
  std::cout << "static_library_func_1" << std::endl;
}
```

```cpp
// main.cc
#include <iostream>

extern void shared_library_func_1();
extern void static_library_func_1();

int main() {
  shared_library_func_1();
  static_library_func_1();
  return 0;
}
```

```make
# Makefile
all : link_failure

libshared_library.so : shared_library.cc
	gcc -c -Wall -Werror -fpic shared_library.cc
	gcc -shared -o libshared_library.so shared_library.o

libstatic_library.a : static_library.cc
	gcc -c -Wall -Werror static_library.cc
	ar rcs libstatic_library.a static_library.o

main.o : main.cc
	gcc -c -Wall -Werror main.cc

link_failure : libstatic_library.a libshared_library.so main.o
	gcc -L. -Wl,-rpath=. -lstdc++ -fuse-ld=gold -lshared_library -lstatic_library main.o -o test_runner
	./test_runner

link_success : libstatic_library.a libshared_library.so main.o
	gcc -L. -Wl,-rpath=. -lstdc++ -fuse-ld=gold -lshared_library main.o -lstatic_library  -o test_runner
	./test_runner

clean :
	rm -rf test_runner *.o *.so *.a
```

The only difference in the `link_failure` and `link_success` targets in the relative order of `main.o` and `-lstatic_library`

`link_failure` gives us linker error, which is in essence the same error we get on the `@flatbuffers//:flatc` target at the top.


-----------------------------------


/cc @sunway513 @ekuznetsov139 @mvermeulen @stevenireeves 