### PR TITLE
[r2.4-rocm-enhanced] Fix for JIRA ticket 280792

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -70,16 +70,6 @@ RUN apt-get update --allow-insecure-repositories && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# explicitly remove the following subdirs from under $ROCM_PATH/include
-# These dirs will be removed from the ROCm install in a (near) future ROCm release, and 
-# ROCm TF has been updated (via a separate commit in the same PR as this commit) to account
-# for this future change.
-# This explicit removal is required because without it the creation of the "local_config_rocm" repo
-# runs into errors relating to two different copy rules (rocm-include + hiprand-include|rocrand-include)
-# trying to copy a header file to the same location.
-RUN rm -rf ${ROCM_PATH}/include/rocrand ${ROCM_PATH}/include/hiprand
-
-
 # Set up paths
 ENV HCC_HOME=$ROCM_PATH/hcc
 ENV HIP_PATH=$ROCM_PATH/hip

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -577,23 +577,43 @@ def _create_local_rocm_repository(repository_ctx):
         ),
         make_copy_dir_rule(
             repository_ctx,
-            name = "hiprand-include",
-            src_dir = rocm_toolkit_path + "/hiprand/include",
-            out_dir = "rocm/include/hiprand",
-        ),
-        make_copy_dir_rule(
-            repository_ctx,
-            name = "rocrand-include",
-            src_dir = rocm_toolkit_path + "/rocrand/include",
-            out_dir = "rocm/include/rocrand",
-        ),
-        make_copy_dir_rule(
-            repository_ctx,
             name = "hipsparse-include",
             src_dir = rocm_toolkit_path + "/hipsparse/include",
             out_dir = "rocm/include/hipsparse",
         ),
     ]
+
+    # explicitly copy (into the local_config_rocm repo) the $ROCM_PATH/hiprand/include and
+    # $ROCM_PATH/rocrand/include dirs, only once the softlink to them in $ROCM_PATH/include
+    # dir has been removed. This removal will happen in a near-future ROCm release.
+    hiprand_include = ""
+    hiprand_include_softlink = rocm_config.rocm_toolkit_path + "/include/hiprand"
+    softlink_exists = files_exist(repository_ctx, [hiprand_include_softlink], bash_bin)
+    if not softlink_exists[0]:
+        hiprand_include = '":hiprand-include",\n'
+        copy_rules.append(
+            make_copy_dir_rule(
+                repository_ctx,
+                name = "hiprand-include",
+                src_dir = rocm_toolkit_path + "/hiprand/include",
+                out_dir = "rocm/include/hiprand",
+            )
+        )
+
+    rocrand_include = ""
+    rocrand_include_softlink = rocm_config.rocm_toolkit_path + "/include/rocrand"
+    softlink_exists = files_exist(repository_ctx, [rocrand_include_softlink], bash_bin)
+    if not softlink_exists[0]:
+        rocrand_include = '":rocrand-include",\n'
+        copy_rules.append(
+            make_copy_dir_rule(
+                repository_ctx,
+                name = "rocrand-include",
+                src_dir = rocm_toolkit_path + "/rocrand/include",
+                out_dir = "rocm/include/rocrand",
+            )
+        )
+
 
     rocm_libs = _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, bash_bin)
     rocm_lib_srcs = []
@@ -621,6 +641,7 @@ def _create_local_rocm_repository(repository_ctx):
             "rocm/bin/" + "clang-offload-bundler",
         ],
     ))
+
 
     # Set up BUILD file for rocm/
     repository_ctx.template(
@@ -654,8 +675,8 @@ def _create_local_rocm_repository(repository_ctx):
                                 '":rocblas-include",\n' +
                                 '":miopen-include",\n' +
                                 '":rccl-include",\n' +
-                                '":hiprand-include",\n' +
-                                '":rocrand-include",\n' +
+                                hiprand_include +
+                                rocrand_include +
                                 '":hipsparse-include",'),
         },
     )


### PR DESCRIPTION
Updating rocm_configure.bzl to do the right thing based on whether or not the softlinks to <rocm_path>/include/[hiprand|rocrand] exist. Removing the workaroung to handle the same in Dockerfile.rocm, since that is no longer required (as a consequence of the change in rocm_configure.bzl

------------------------------------

/cc @sunway513 

I will merge the PR once the local build I am doing with this change completes