### PR TITLE
Update XLA LLVM backend to generate code-object-v3 HSACOs for ROCm 4.0.1 and older

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -879,6 +879,14 @@ void AMDGPUBackendInit(const HloModuleConfig& hlo_module_config) {
   LLVMInitializeAMDGPUTargetInfo();
   LLVMInitializeAMDGPUTargetMC();
   LLVMInitializeAMDGPUAsmPrinter();
+
+#if TF_ROCM_VERSION < 40100
+  // Use code-object-v3 for ROCm versions 4.0.1 and lower, since the
+  // HIP runtime for those ROCm versions expects the v3 HSACO objects
+  // Default is now v4 for newer LLVM versions (starting around 210326)
+  FeedLLVMWithFlags({"--amdhsa-code-object-version=3"});
+#endif
+
 #endif
 
   llvm::PassRegistry* registry = llvm::PassRegistry::getPassRegistry();


### PR DESCRIPTION
The following commit breaks the XLA unit-testcases on the ROCm platform

https://github.com/tensorflow/tensorflow/commit/cb3e0b2bb94ec414d709970181259e2f2cbba769#diff-3916e937a690715a62df34b7dae19bbdd92d7c79b9d6712ba3605b8d208c8a7fR7

The above commit updates the LLVM pointer, which in turn picks a lot of changes in the AMDGPU backend implementation in LLVM. One of those changes is to use code-object-v4, by default, for the generated HSACOs (AMDGPU binaries). This is okay if you also use the corresponding HIP runtime, which is ROCm 4.1 or higher. But with ROCm 4.0.1 or older, the newer HSACO files do not get loaded properly by the older HIP runtime, resulting in errors like the following error

```
tensorflow/compiler/xla/service/gpu/tests/reduction_layout_normalizer_test.cc:62: Failure
Value of: RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5})
  Actual: false (Internal: Failed to load HSACO: hipError_t(303))
Expected: true
```

This commit fixes the issue by changing the default code object version to v3, when TF is built with ROCm 4.0.1 or older.

------------------------------

Thanks to @ekuznetsov139 for coming up with the fix.