### PR TITLE
[r1.15-rocm-enhanced] Fix for JIRA ticket 281803

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -730,12 +730,6 @@ def _create_local_rocm_repository(repository_ctx):
             src_dir = rocm_toolkit_path + "/rccl/include",
             out_dir = "rocm/include/rccl",
         ),
-        make_copy_dir_rule(
-            repository_ctx,
-            name = "hipsparse-include",
-            src_dir = rocm_toolkit_path + "/hipsparse/include",
-            out_dir = "rocm/include/hipsparse",
-        ),
     ]
 
     # explicitly copy (into the local_config_rocm repo) the $ROCM_PATH/hiprand/include and


### PR DESCRIPTION
One of the previous PRs ( https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1318 ) had an incorrect cherry-pick which resulted in the "hipsparse-include" copy rule getting added to the rocm_configure.bzl. That copy-rule seems to be breaking the manylinux build.

This commit merely removes the "hipsparse-include" copy rule from rocm_configure.bzl

------------------------------------------

http://ontrack-internal.amd.com/browse/SWDEV-281803

/cc @sunway513 

I have already verified the ubuntu build works with this change.  Will merge the PR and request QA to verify the manylinux build