### PR TITLE
Support of gfx90a

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
@@ -112,14 +112,9 @@ class GpuKernelToBlobPass
         return InternalError(
             "Could not parse ROCm architecture prefix (expected gfx)");
       }
-      uint32_t arch;
-      if (!absl::SimpleAtoi(consumable_arch, &arch)) {
-        return InternalError("Could not parse ROCm architecture number");
-      }
-
       std::string libdevice_dir = tensorflow::RocdlRoot();
       auto llvm_module_copy = llvm::CloneModule(*llvmModule);
-      xla::gpu::GpuVersion gpu_version{std::make_pair(arch, arch_str)};
+      xla::gpu::GpuVersion gpu_version{arch_str};
       auto hsaco_or = xla::gpu::amdgpu::CompileToHsaco(
           llvm_module_copy.get(), gpu_version, config, libdevice_dir);
       if (!hsaco_or.ok()) {

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -95,13 +95,6 @@ AMDGPUCompiler::AMDGPUCompiler()
                   amdgpu::kDataLayout) {}
 
 GpuVersion AMDGPUCompiler::GetGpuVersion(se::StreamExecutor* stream_exec) {
-  int isa_version = 0;
-  if (!stream_exec->GetDeviceDescription().rocm_amdgpu_isa_version(
-          &isa_version)) {
-    LOG(WARNING)
-        << "Couldn't get AMDGPU ISA version for device; assuming gfx900.";
-    isa_version = 803;
-  }
   std::string gcn_arch_name =
       stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
   if (gcn_arch_name == stream_exec->GetDeviceDescription().kUndefinedString) {
@@ -109,7 +102,7 @@ GpuVersion AMDGPUCompiler::GetGpuVersion(se::StreamExecutor* stream_exec) {
     gcn_arch_name = "gfx900";
   }
 
-  return std::make_pair(isa_version, gcn_arch_name);
+  return gcn_arch_name;
 }
 
 StatusOr<std::pair<std::string, std::vector<uint8>>>

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.h
@@ -155,7 +155,7 @@ StatusOr<std::unique_ptr<llvm::Module>> CompileModuleToLlvmIr(
     const std::string& target_triple, const std::string& data_layout,
     const std::string& platform_name, GpuDeviceInfo gpu_device_info,
     absl::optional<CudaComputeCapability> cuda_compute_capability,
-    int pointer_size);
+    std::string amdgpu_arch, int pointer_size);
 
 // Compiles the given LMHLO module to an executable.
 // ir_emitter_context should be partially populated: buffer_assignment

--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -109,13 +109,13 @@ Status GpuExecutable::CheckCompatibilityWithServiceExecutableRunOptions(
       main_stream->parent()->platform_kind();
   if (platform_kind == stream_executor::PlatformKind::kROCm) {
     int stream_isa_version;
-    main_stream->parent()->GetDeviceDescription().rocm_amdgpu_isa_version(
-        &stream_isa_version);
-    int gpu_exec_isa_version =
-        absl::get<std::pair<int, std::string>>(gpu_version_).first;
-    TF_RET_CHECK(stream_isa_version == gpu_exec_isa_version)
-        << "AMDGPU GCN ISA version mismatch; expected {" << gpu_exec_isa_version
-        << ", but was " << stream_isa_version;
+    std::string stream_arch = 
+        main_stream->parent()->
+            GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+    std::string gpu_exec_arch = absl::get<std::string>(gpu_version_);
+    TF_RET_CHECK(stream_arch == gpu_exec_arch)
+        << "AMDGPU GCN ISA version mismatch; expected {" << gpu_exec_arch
+        << ", but was " << stream_arch;
   } else if (platform_kind == stream_executor::PlatformKind::kCuda) {
     std::pair<int, int> stream_compute_compatibility;
     main_stream->parent()->GetDeviceDescription().cuda_compute_capability(

--- a/tensorflow/compiler/xla/service/gpu/gpu_types.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_types.h
@@ -29,14 +29,12 @@ namespace gpu {
 // On Cuda platform, it comprises of an <int, int> pair
 // denoting major and minor version.
 //
-// On ROCm platform, it comprises of an <int, string> pair
-// the int has the contents of the hipDeviceProp_t::gcnArchValue field.
-// the string has the contents of the hipDeviceProp_t::gcnArchName field.
+// On ROCm platform, the string has the contents of the 
+// hipDeviceProp_t::gcnArchName field.
 // The string contains all the information needed to create an exact LLVM
-// AMDGPUTarget corresopnding the AMDGPU device it represents, the int value
-// by itself is not sufficient for this purpose
+// AMDGPUTarget corresponding the AMDGPU device it represents.
 using GpuVersion =
-    absl::variant<std::pair<int, int>, std::pair<int, std::string>>;
+    absl::variant<std::pair<int, int>, std::string>;
 }  // namespace gpu
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -300,7 +300,7 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
       CHECK_NE(output_address_type, nullptr);
 
       // todo: implement for F16 via global_atomic_fadd_pk2f16
-      bool atomic_add_supported = isGfx908Plus && (element_type == F32);
+      bool atomic_add_supported = (element_type == F32);
       if (atomic_add_supported) {
         if (output_address_type->getPointerAddressSpace() != 3) {
           // the compiler will only generate a global_atomic_fadd if the pointer

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -291,6 +291,42 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
       }
     }
 
+    if (target_triple.isAMDGPU()) {
+      std::string arch = ir_emitter_context_->amdgpu_arch();
+      bool isGfx908Plus = arch.size()>=6 &&
+          (arch.substr(0,6)=="gfx908" || arch.substr(0,6)=="gfx90a");
+      llvm::PointerType* output_address_type =
+          llvm::dyn_cast<llvm::PointerType>(output_address->getType());
+      CHECK_NE(output_address_type, nullptr);
+
+      // todo: implement for F16 via global_atomic_fadd_pk2f16
+      bool atomic_add_supported = isGfx908Plus && (element_type == F32);
+      if (atomic_add_supported) {
+        if (output_address_type->getPointerAddressSpace() != 3) {
+          // the compiler will only generate a global_atomic_fadd if the pointer
+          // is in global addrspace (1)
+          auto cast_output_ptr = b_.CreateAddrSpaceCast(
+             output_address,
+             llvm::PointerType::get(output_address_type->getPointerElementType(),
+                               /*AddressSpace=*/1));
+          AtomicRMW(llvm::AtomicRMWInst::FAdd, cast_output_ptr, source,
+                  llvm::MaybeAlign(),
+                  llvm::AtomicOrdering::SequentiallyConsistent,
+                  // we really want "agent", but it's not in the enum.
+                  llvm::SyncScope::SingleThread);
+          return true;
+        } else {
+          // adds to shared memory are always atomic. Todo: verify that the compiler
+          // produces a ds_add_f32 rather than a CAS loop
+          AtomicRMW(llvm::AtomicRMWInst::FAdd, output_address, source,
+                  llvm::MaybeAlign(),
+                  llvm::AtomicOrdering::SequentiallyConsistent,
+                  llvm::SyncScope::SingleThread);
+          return true;
+        }
+      }
+    }
+
     if (is_atomic_integral) {
       // integral + integral
       AtomicRMW(llvm::AtomicRMWInst::Add, output_address, source,

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_context.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_context.h
@@ -41,6 +41,7 @@ class IrEmitterContext {
       const HloModule* hlo_module, const BufferAssignment* buffer_assignment,
       std::string platform_name, GpuDeviceInfo gpu_device_info,
       absl::optional<CudaComputeCapability> cuda_compute_capability,
+      std::string amdgpu_arch,
       const HloProfileIndexMap* profile_index_map,
       mlir::MLIRContext* mlir_context, llvm::Module* llvm_module)
       : hlo_module_(hlo_module),
@@ -48,6 +49,7 @@ class IrEmitterContext {
         platform_name_(std::move(platform_name)),
         gpu_device_info_(gpu_device_info),
         cuda_compute_capability_(cuda_compute_capability),
+        amdgpu_arch_(amdgpu_arch),
         profile_index_map_(profile_index_map),
         mlir_context_(mlir_context),
         llvm_module_(llvm_module) {}
@@ -64,6 +66,9 @@ class IrEmitterContext {
   GpuDeviceInfo gpu_device_info() const { return gpu_device_info_; }
   absl::optional<CudaComputeCapability> cuda_compute_capability() const {
     return cuda_compute_capability_;
+  }
+  std::string amdgpu_arch() const {
+    return amdgpu_arch_;
   }
   const HloProfileIndexMap* profile_index_map() { return profile_index_map_; }
   mlir::MLIRContext* mlir_context() { return mlir_context_; }
@@ -91,6 +96,7 @@ class IrEmitterContext {
   std::string platform_name_;
   GpuDeviceInfo gpu_device_info_;
   absl::optional<CudaComputeCapability> cuda_compute_capability_;
+  std::string amdgpu_arch_;
   const HloProfileIndexMap* profile_index_map_;
   mlir::MLIRContext* mlir_context_;
   llvm::Module* llvm_module_;

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -565,7 +565,7 @@ StatusOr<string> CompileToPtx(
 namespace {
 
 // Gets the ROCm-Device-Libs filenames for a particular AMDGPU version.
-static std::vector<string> GetROCDLPaths(int amdgpu_version,
+static std::vector<string> GetROCDLPaths(std::string amdgpu_version,
                                          const string& rocdl_dir_path) {
   // AMDGPU version-neutral bitcodes.
 #if TF_ROCM_VERSION >= 30900
@@ -588,6 +588,9 @@ static std::vector<string> GetROCDLPaths(int amdgpu_version,
   }
 
   // Add AMDGPU version-specific bitcodes.
+  std::vector<std::string> tokens = absl::StrSplit(amdgpu_version, ':');
+  if(tokens.size()>=1 && tokens[0].size()>=3)
+    amdgpu_version=tokens[0].substr(3);
   result.push_back(tensorflow::io::JoinPath(
       rocdl_dir_path,
 #if TF_ROCM_VERSION >= 30900
@@ -773,7 +776,7 @@ StatusOr<std::vector<uint8>> EmitModuleToHsaco(
 }
 
 // Links ROCm-Device-Libs into the given module if the module needs it.
-Status LinkROCDLIfNecessary(llvm::Module* module, int amdgpu_version,
+Status LinkROCDLIfNecessary(llvm::Module* module, std::string amdgpu_version,
                             const string& rocdl_dir_path) {
   if (!CouldNeedDeviceBitcode(*module)) {
     return Status::OK();
@@ -787,12 +790,12 @@ Status AMDGPUTargetModuleLinker(llvm::Module* module, GpuVersion gpu_version,
                                 const HloModuleConfig& hlo_module_config,
                                 const string& device_bitcode_dir_path) {
   // Link the input module with ROCDL.
-  auto amdgpu_version = absl::get_if<std::pair<int, std::string>>(&gpu_version);
+  auto amdgpu_version = absl::get_if<std::string>(&gpu_version);
   if (!amdgpu_version) {
     return xla::InternalError(
         "Incompatible AMD GCN ISA version was specified.");
   }
-  TF_RETURN_IF_ERROR(LinkROCDLIfNecessary(module, amdgpu_version->first,
+  TF_RETURN_IF_ERROR(LinkROCDLIfNecessary(module, *amdgpu_version,
                                           device_bitcode_dir_path));
   if (hlo_module_config.debug_options().xla_gpu_ftz()) {
     for (llvm::Function& fn : *module) {
@@ -805,6 +808,12 @@ Status AMDGPUTargetModuleLinker(llvm::Module* module, GpuVersion gpu_version,
     for (llvm::Function& fn : *module) {
       fn.addFnAttr("denormal-fp-math-f32", "preserve-sign");
     }
+  }
+
+  for (llvm::Function& fn : *module) {
+      // may be necessary for the compiler to generate atomics (confirm!)
+      fn.addFnAttr("denormal-fp-math-f32", "preserve-sign,preserve-sign");
+      fn.addFnAttr("amdgpu-unsafe-fp-atomics", "true");
   }
 
   return Status::OK();
@@ -824,18 +833,24 @@ std::string MapGCNArchNameTokenToFeatureStr(const std::string& token) {
   if (token == "sramecc+") {
     return "+sramecc";
   } else if (token == "sramecc-") {
+#if TF_ROCM_VERSION < 40100
+    return "";
+#else
     return "-sramecc";
+#endif
   } else if (token == "xnack+") {
     return "+xnack";
   } else if (token == "xnack-") {
     return "-xnack";
   }
   return "";
+
 }
 
-std::string GetFeatureStrFromGCNArchName(const std::string& gcn_arch_name) {
+std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
+    const std::string& gcn_arch_name) {
   std::string feature_str;
-
+  std::string gfx = gcn_arch_name;
 #if TF_ROCM_VERSION < 30900
   // For ROCm versions older than 3.9, hardcode it to "+code-object-v3"
   // This is simply to preserve how things were...nohing else
@@ -848,6 +863,8 @@ std::string GetFeatureStrFromGCNArchName(const std::string& gcn_arch_name) {
   // feature str, based on the underlying GPU HW to get max performance.
   std::vector<std::string> tokens = absl::StrSplit(gcn_arch_name, ':');
   std::vector<std::string> mapped_tokens;
+  if(tokens.size()>0)
+    gfx=tokens[0];
   for (auto it = tokens.begin(); it != tokens.end(); it++) {
     // Skip the first token, that is the gfxNNN str
     // The rest of the tokens are the feature/targetid strings
@@ -860,19 +877,17 @@ std::string GetFeatureStrFromGCNArchName(const std::string& gcn_arch_name) {
   feature_str = absl::StrJoin(mapped_tokens, ",");
 #endif
 
-  return feature_str;
+  return make_pair(gfx, feature_str);
 }
 
 std::unique_ptr<llvm::TargetMachine> AMDGPUGetTargetMachine(
     llvm::Triple target_triple, GpuVersion gpu_version,
     const HloModuleConfig& hlo_module_config) {
-  auto amdgpu_version = absl::get_if<std::pair<int, std::string>>(&gpu_version);
-  int gcn_arch_value = amdgpu_version->first;
-  std::string gcn_arch_name = amdgpu_version->second;
-  std::string feature_str = GetFeatureStrFromGCNArchName(gcn_arch_name);
-  return GetTargetMachine(std::move(target_triple),
-                          absl::StrCat("gfx", gcn_arch_value),
-                          hlo_module_config, feature_str);
+  auto amdgpu_version = absl::get_if<std::string>(&gpu_version);
+  std::string gcn_arch_name = *amdgpu_version;
+  auto arch = GetFeatureStrFromGCNArchName(gcn_arch_name);
+  return GetTargetMachine(std::move(target_triple), arch.first,
+                          hlo_module_config, arch.second);
 }
 
 void AMDGPUBackendInit(const HloModuleConfig& hlo_module_config) {
@@ -931,14 +946,13 @@ StatusOr<std::vector<uint8>> CompileToHsaco(
         tensorflow::profiler::TraceMeLevel::kInfo);
     XLA_SCOPED_LOGGING_TIMER("Compile module " + module->getName().str());
 
-    auto amdgpu_version =
-        absl::get_if<std::pair<int, std::string>>(&gpu_version);
+    auto amdgpu_version = absl::get_if<std::string>(&gpu_version);
     if (!amdgpu_version) {
       return xla::InternalError(
           "Incompatible AMD GCN ISA version was specified.");
     }
     uint64_t hash;
-    if (HsacoCache::Find(str, hash, amdgpu_version->second, hsaco)) {
+    if (HsacoCache::Find(str, hash, *amdgpu_version, hsaco)) {
       VLOG(1) << "HSACO cache hit";
       return hsaco;
     }
@@ -967,7 +981,7 @@ StatusOr<std::vector<uint8>> CompileToHsaco(
 
     // Lower optimized LLVM module to HSA code object.
     TF_ASSIGN_OR_RETURN(hsaco, EmitModuleToHsaco(module, target_machine.get()));
-    HsacoCache::Add(str, hash, amdgpu_version->second, hsaco);
+    HsacoCache::Add(str, hash, *amdgpu_version, hsaco);
   }
   return hsaco;
 }

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_unrolling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_unrolling_test.cc
@@ -70,9 +70,7 @@ TEST_F(GpuUnrollingTest, UnrollFourTimes) {
   config.set_debug_options(debug_options);
   auto hlo_module =
       ParseAndReturnVerifiedModule(kAddModule, config).ValueOrDie();
-
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  const string pattern1 = R"(
 ; CHECK-LABEL: @fusion
 ; CHECK: fadd
 ; CHECK: fadd
@@ -80,7 +78,18 @@ TEST_F(GpuUnrollingTest, UnrollFourTimes) {
 ; CHECK: fadd
 ; CHECK-NOT: fadd
 ; CHECK: }
-      )",
+      )";
+
+  const string pattern2 = R"(
+; CHECK-LABEL: @fusion
+; CHECK: fadd <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK-NOT: fadd
+; CHECK: }
+      )";
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
                      /*match_optimized_ir=*/true);
 }
 
@@ -90,9 +99,7 @@ TEST_F(GpuUnrollingTest, UnrollDefaultTimes) {
   config.set_debug_options(GetDebugOptionsFromFlags());
   auto hlo_module =
       ParseAndReturnVerifiedModule(kAddModule, config).ValueOrDie();
-
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  const string pattern1 = R"(
 ; CHECK-LABEL: @fusion
 ; CHECK: load <4 x float>
 ; CHECK: fadd
@@ -102,7 +109,18 @@ TEST_F(GpuUnrollingTest, UnrollDefaultTimes) {
 ; CHECK-NOT: fadd
 ; CHECK: store <4 x float>
 ; CHECK: }
-      )",
+      )";
+
+  const string pattern2 = R"(
+; CHECK-LABEL: @fusion
+; CHECK: fadd <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK-NOT: fadd
+; CHECK: store <4 x float>
+; CHECK: }
+      )";
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
                      /*match_optimized_ir=*/true);
 }
 
@@ -122,9 +140,7 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedAdd) {
     })";
   auto hlo_module =
       ParseAndReturnVerifiedModule(kUnfusedAddModule, config).ValueOrDie();
-
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  const string pattern1 = R"(
 ; CHECK-LABEL: @add
 ; CHECK: load <4 x float>
 ; CHECK: fadd
@@ -134,8 +150,20 @@ TEST_F(GpuUnrollingTest, UnrollUnfusedAdd) {
 ; CHECK-NOT: fadd
 ; CHECK: store <4 x float>
 ; CHECK: }
-      )",
-                     /*match_optimized_ir=*/true);
+      )";
+
+  const string pattern2 = R"(
+; CHECK-LABEL: @add
+; CHECK: fadd <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK-NOT: fadd
+; CHECK: store <4 x float>
+; CHECK: }
+      )";
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
+                    /*match_optimized_ir=*/true);
 }
 
 TEST_F(GpuUnrollingTest, DisabledUnrollUnfusedSine) {
@@ -295,8 +323,7 @@ TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
       ParseAndReturnVerifiedModule(kMultiOutputFusionModule, config)
           .ValueOrDie();
 
-  CompileAndVerifyIr(std::move(hlo_module),
-                     R"(
+  string pattern1 = R"(
 ; CHECK-LABEL: @fusion
 ; CHECK: load <2 x float>
 ; CHECK: load <2 x float>
@@ -311,7 +338,25 @@ TEST_F(GpuUnrollingTest, UnrollMultiOutputFusion) {
 ; CHECK-NOT: fadd
 ; CHECK-NOT: fmul
 ; CHECK: }
-      )",
+      )";
+
+  string pattern2 = R"(
+; CHECK-LABEL: @fusion
+; CHECK: load <2 x float>
+; CHECK: load <2 x float>
+; CHECK-NOT: load <2 x float>
+; CHECK: fadd <2 x float>
+; CHECK: fmul <2 x float>
+; CHECK: store <2 x float>
+; CHECK: store <2 x float>
+; CHECK-NOT: store <2 x float>
+; CHECK-NOT: fadd
+; CHECK-NOT: fmul
+; CHECK: }
+      )";
+
+  CompileAndVerifyIr(std::move(hlo_module),
+                     std::vector<string>{pattern1,pattern2},
                      /*match_optimized_ir=*/true);
 }
 

--- a/tensorflow/compiler/xla/service/gpu/tests/hlo_to_llvm_ir.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/hlo_to_llvm_ir.cc
@@ -68,6 +68,7 @@ xla::Status CompileAndPrintLlvmIr(const std::string& hlo_text,
   xla::gpu::CudaComputeCapability cuda_compute_capability;
   cuda_compute_capability.cc_major = sm / 10;
   cuda_compute_capability.cc_minor = sm % 10;
+  std::string amdgpu_arch;
 #if GOOGLE_CUDA
   std::string target_triple = "nvptx64-nvidia-cuda";
   std::string datalayout = "nvptx64-nvidia-cuda";
@@ -76,6 +77,7 @@ xla::Status CompileAndPrintLlvmIr(const std::string& hlo_text,
   std::string target_triple = "amdgcn--amdhsa-amdgiz";
   std::string datalayout = ""; // TODO: correct value?
   std::string platform_name = "ROCm"; // ditto
+  amdgpu_arch = "gfx908";
 #endif
   TF_ASSIGN_OR_RETURN(std::unique_ptr<llvm::Module> llvm_module,
                       xla::gpu::CompileModuleToLlvmIr(
@@ -83,7 +85,8 @@ xla::Status CompileAndPrintLlvmIr(const std::string& hlo_text,
                           /*target_triple=*/xla::gpu::nvptx::kTargetTriple,
                           /*data_layout=*/xla::gpu::nvptx::kDataLayout,
                           /*platform_name=*/platform_name, gpu_device_info,
-                          cuda_compute_capability, /*pointer_size=*/8));
+                          cuda_compute_capability, amdgpu_arch,
+                          /*pointer_size=*/8));
 
   if (!generate_ptx) {
     llvm_module->print(llvm::outs(), nullptr);
@@ -98,10 +101,9 @@ xla::Status CompileAndPrintLlvmIr(const std::string& hlo_text,
                                       hlo_module->config(), libdevice_dir));
     std::cout << ptx << std::endl;
 #else
-    int isa_version = 908;
     std::string arch_str = "gfx908";
     std::string libdevice_dir = tensorflow::RocdlRoot();
-    xla::gpu::GpuVersion gpu_version{std::make_pair(isa_version, arch_str)};
+    xla::gpu::GpuVersion gpu_version{arch_str};
     TF_ASSIGN_OR_RETURN(
       std::vector<uint8_t> ptx,
       xla::gpu::amdgpu::CompileToHsaco(llvm_module.get(), gpu_version,

--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
@@ -65,9 +65,13 @@ StatusOr<std::unique_ptr<Executable>> MlirGpuTestBase::CompileMlirModule(
     return cuda_compute_capability;
   }();
 
+  std::string amdgpu_arch =
+      stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+
   IrEmitterContext ir_emitter_context(
       /*hlo_module=*/nullptr, /*buffer_assignment=*/nullptr,
       backend_->platform()->Name(), gpu_device_info, cuda_compute_capability,
+      amdgpu_arch,
       /*profile_index_map=*/nullptr, /*mlir_context=*/nullptr,
       llvm_module.get());
 

--- a/tensorflow/compiler/xla/tests/llvm_irgen_test_base.h
+++ b/tensorflow/compiler/xla/tests/llvm_irgen_test_base.h
@@ -38,6 +38,11 @@ class LlvmIrGenTestBase : public CodegenTestBase {
   void CompileAndVerifyIr(std::unique_ptr<HloModule> hlo_module,
                           const string& pattern, bool match_optimized_ir);
 
+  // Same as above, to be used if there are multiple valid patterns
+  void CompileAndVerifyIr(std::unique_ptr<HloModule> hlo_module,
+                          const std::vector<string>& patterns,
+                          bool match_optimized_ir);
+
   // A thin wrapper around CompileAndVerifyIr that parses `hlo_text` to create
   // an HLO module.
   void CompileAndVerifyIr(const string& hlo_text,

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -92,8 +92,10 @@ bool HasFastFP16Support(const DeviceProperties& props) {
 #if GOOGLE_CUDA
   return GetDeviceGPUArch(props) >= kMinGPUArch;
 #elif TENSORFLOW_USE_ROCM
-  absl::flat_hash_set<std::string> FP16SupportedDevices = {{"gfx906"},
-                                                           {"gfx908"}};
+  absl::flat_hash_set<std::string> FP16SupportedDevices = {
+      {"gfx906"}, {"gfx908"}, {"gfx90a"}, {"gfx910"}, {"gfx1010"}, {"gfx1012"},
+      {"gfx1030"}
+  };
   std::string gcnArchName = props.environment().at("architecture");
   std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");
   return !gpu_arch.empty() && FP16SupportedDevices.contains(gpu_arch[0]);

--- a/tensorflow/core/kernels/bias_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bias_op_gpu.cu.cc
@@ -138,7 +138,7 @@ __global__ void BiasGradNHWC_SharedAtomics(
   for (int32 index = blockIdx.x * blockDim.x + threadIdx.x; index < nthreads;
        index += blockDim.x * gridDim.x) {
     int32 bias_offset = index % bias_size;
-    GpuAtomicAdd(s_data + bias_offset, AccT(ldg(output_backprop + index)));
+    GpuAtomicAddShared(s_data + bias_offset, AccT(ldg(output_backprop + index)));
   }
   __syncthreads();
 
@@ -178,7 +178,7 @@ __global__ void BiasGradNCHW_SharedAtomics(
   // Write the accumulated sum in this thread to the shared memory. Each thread
   // shifts their write location to avoid bank conflict.
   int bias_offset = threadIdx.x % 32;
-  GpuAtomicAdd(s_data + bias_offset, sum);
+  GpuAtomicAddShared(s_data + bias_offset, sum);
   __syncthreads();
 
   // Accumulate the results in the shared memory into the first element.

--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -174,7 +174,7 @@ __global__ void BincountColReduceSharedKernel(const Tidx* in, const T* weights,
         shared_col_bins[offset] = T(1);
       } else {
         T value = (weights_size == 0) ? T(1) : ldg(weights + index);
-        GpuAtomicAdd(shared_col_bins + offset, value);
+        GpuAtomicAddShared(shared_col_bins + offset, value);
       }
     }
   }

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2990,8 +2990,8 @@ port::Status MIOpenSupport::DoPrepareForConvolution(
              "larger number (e.g. 8192) to increase the max memory limit.\n"
           << "\tIncreasing the max memory limit might help resolve this "
              "error";
-      return port::InternalError(absl::StrCat(
-          "Failed to allocate scratch memory of size: ", scratch_memory_size));
+      return port::Status{port::error::RESOURCE_EXHAUSTED, absl::StrCat(
+          "Failed to allocate scratch memory of size: ", scratch_memory_size)};
     }
   }
 

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -214,6 +214,8 @@ def _amdgpu_targets(repository_ctx, rocm_toolkit_path, bash_bin):
         cmd = "%s/bin/rocm_agent_enumerator" % rocm_toolkit_path
         result = execute(repository_ctx, [bash_bin, "-c", cmd])
         targets = [target for target in result.stdout.strip().split("\n") if target != "gfx000"]
+        targets = {x : None for x in targets}
+        targets = list(targets.keys())
         amdgpu_targets_str = ",".join(targets)
     amdgpu_targets = amdgpu_targets_str.split(",")
     for amdgpu_target in amdgpu_targets:


### PR DESCRIPTION
Correctly handling non-numerical gfx versions
Correctly enabling mixed-precision kernels for gfx90a
Hiding some memory from TF for rocBLAS & rccl
Using native global atomic add for FP32 on gfx90a
Dropping the int from GpuVersion
Patching a unit test to work correctly when llvm does float2 vectorization