### PR TITLE
Fix for SWDEV 277899 - hipLaunchKernel called with threads per block value greater than launch bounds attribute.

### DIFF
--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -972,8 +972,9 @@ Status LaunchDepthwiseConv2dBackpropInputGPU(OpKernelContext* ctx,
   const int num_in_backprop =
       args.batch * args.in_rows * args.in_cols * args.in_depth;
   auto device = ctx->eigen_gpu_device();
-  GpuLaunchConfig config =
-      GetGpuLaunchConfig(num_in_backprop, device, kernel, 0, 0);
+  int launch_bounds_value = 640;
+  GpuLaunchConfig config = GetGpuLaunchConfig(num_in_backprop, device, kernel,
+                                              0, launch_bounds_value);
   TF_CHECK_OK(GpuLaunchKernel(
       kernel, config.block_count, config.thread_per_block, 0, device.stream(),
       args, out_backprop, filter, in_backprop, num_in_backprop));
@@ -1722,8 +1723,9 @@ Status LaunchDepthwiseConv2dBackpropFilterGPU(
   const int num_out_backprop =
       args.batch * args.out_rows * args.out_cols * args.out_depth;
   auto device = ctx->eigen_gpu_device();
-  GpuLaunchConfig config =
-      GetGpuLaunchConfig(num_out_backprop, device, kernel, 0, 0);
+  int launch_bounds_value = 640;
+  GpuLaunchConfig config = GetGpuLaunchConfig(num_out_backprop, device, kernel,
+                                              0, launch_bounds_value);
   TF_CHECK_OK(GpuLaunchKernel(
       kernel, config.block_count, config.thread_per_block, 0, device.stream(),
       args, out_backprop, input, filter_backprop, num_out_backprop));


### PR DESCRIPTION
Prior to the fix for SWDEV 252801, if the application code launches a GPU kernel with a threads per block value which is greater than the `__launch_bounds__` attribute value for that kernel, HIP runtime only issues a warning for this scenario.

After the fix for SWDEV 252801, HIP runtime issues an error message instead (for this scenario), and reports an error status back to the application code.

This change results in the following four TF unit test failures

```
//tensorflow/compiler/tests:depthwise_conv_op_test_gpu
//tensorflow/compiler/tests:depthwise_conv_op_test_gpu_mlir_bridge_test
//tensorflow/python:nn_grad_test_gpu
//tensorflow/python/keras/distribute:saved_model_mixed_api_test_gpu
//tensorflow/python/kernel_tests/signal:fft_ops_test
```

This commit fixes the failure in the first three of the above tests. It was caused by an incorrect calculation of the "threads per block" value. The upper bound for that value (i.e. the `__launch_bounds__` attribute value) was not getting passed to the `GetGpuLaunchConfig`. Passing that value, results in `GetGpuLaunchConfig` returning the correct "threads per block" value and the unit tests start passing