### PR TITLE
Prevent the creation of more than 1 NcclCommunicator for an eager con…

### DIFF
--- a/tensorflow/c/eager/c_api.cc
+++ b/tensorflow/c/eager/c_api.cc
@@ -112,7 +112,8 @@ void TFE_ContextOptionsSetDevicePlacementPolicy(
 
 void TFE_DeleteContextOptions(TFE_ContextOptions* options) { delete options; }
 
-TFE_Context* TFE_NewContext(const TFE_ContextOptions* opts, TF_Status* status) {
+TFE_Context* TFE_NewContext(const TFE_ContextOptions* opts, TF_Status* status,
+                            bool enableNcclCommunicator) {
   if (opts->use_tfrt) {
 #if defined(PLATFORM_GOOGLE) && !defined(LIBTPU_ON_GCE)
     tfrt::tf::ContextInterface* tfrt_context = new tfrt::tf::ContextInterface(
@@ -148,7 +149,8 @@ TFE_Context* TFE_NewContext(const TFE_ContextOptions* opts, TF_Status* status) {
       opts->async, device_mgr.release(),
       /*device_mgr_owned*/ true, r,
       /*cluster_flr=*/nullptr,
-      /*run_eager_op_as_function=*/opts->run_eager_op_as_function);
+      /*run_eager_op_as_function=*/opts->run_eager_op_as_function,
+      enableNcclCommunicator);
 #if !defined(IS_MOBILE_PLATFORM)
   eager_context->SetDistributedManager(
       std::make_unique<tensorflow::EagerContextDistributedManager>(

--- a/tensorflow/c/eager/c_api.h
+++ b/tensorflow/c/eager/c_api.h
@@ -97,7 +97,8 @@ TF_CAPI_EXPORT extern void TFE_DeleteContextOptions(TFE_ContextOptions*);
 typedef struct TFE_Context TFE_Context;
 
 TF_CAPI_EXPORT extern TFE_Context* TFE_NewContext(
-    const TFE_ContextOptions* opts, TF_Status* status);
+    const TFE_ContextOptions* opts, TF_Status* status,
+    bool enableNcclCommunicator = true);
 TF_CAPI_EXPORT extern void TFE_DeleteContext(TFE_Context* ctx);
 TF_CAPI_EXPORT extern TF_DeviceList* TFE_ContextListDevices(TFE_Context* ctx,
                                                             TF_Status* status);

--- a/tensorflow/compiler/mlir/tensorflow/transforms/constant_fold.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/constant_fold.cc
@@ -137,7 +137,11 @@ LogicalResult ConstantFoldFallbackHook(
     // policy to fail if no CPU kernels are available for the op.
     TFE_ContextOptionsSetDevicePlacementPolicy(opts,
                                                TFE_DEVICE_PLACEMENT_EXPLICIT);
+#if TENSORFLOW_USE_ROCM
+    auto ctx = TFE_NewContext(opts, status, false);
+#else
     auto ctx = TFE_NewContext(opts, status);
+#endif
     TFE_DeleteContextOptions(opts);
     TF_DeleteStatus(status);
     return ctx;

--- a/tensorflow/core/common_runtime/eager/context.cc
+++ b/tensorflow/core/common_runtime/eager/context.cc
@@ -79,7 +79,7 @@ EagerContext::EagerContext(
     ContextDevicePlacementPolicy default_device_placement_policy, bool async,
     DeviceMgr* device_mgr, bool device_mgr_owned, Rendezvous* rendezvous,
     DistributedFunctionLibraryRuntime* cluster_flr,
-    bool run_eager_op_as_function)
+    bool run_eager_op_as_function, bool enableNcclCommunicator)
     : ImmediateExecutionContext(kEager),
       opts_(opts),
       default_device_placement_policy_(default_device_placement_policy),
@@ -126,7 +126,8 @@ EagerContext::EagerContext(
       "/job:localhost/replica:0/task:0"));
   collective_executor_mgr_.Reset(
       new CollectiveExecutorMgr(opts.config, local_device_mgr(), std::move(drl),
-                                std::move(cprl), MaybeCreateNcclCommunicator()),
+                                std::move(cprl), MaybeCreateNcclCommunicator(
+                                enableNcclCommunicator)),
       /*owned=*/true);
   global_rendezvous_for_functions_ =
       core::RefCountPtr<Rendezvous>(CreateRendezvous(-1));

--- a/tensorflow/core/common_runtime/eager/context.h
+++ b/tensorflow/core/common_runtime/eager/context.h
@@ -100,7 +100,8 @@ class EagerContext : public ImmediateExecutionContext, public core::RefCounted {
                bool async, /*const*/ DeviceMgr* device_mgr,
                bool device_mgr_owned, /*const*/ Rendezvous* rendezvous,
                DistributedFunctionLibraryRuntime* cluster_flr = nullptr,
-               bool run_eager_op_as_function = false);
+               bool run_eager_op_as_function = false,
+               bool enableNcclCommunicator = true);
 
   void Release() override { Unref(); }
 

--- a/tensorflow/core/nccl/collective_communicator.cc
+++ b/tensorflow/core/nccl/collective_communicator.cc
@@ -63,8 +63,9 @@ string NcclCollectiveKey(const string& exec_key, int step_id) {
 }
 }  // namespace
 
-std::unique_ptr<NcclCommunicatorInterface> MaybeCreateNcclCommunicator() {
-  return absl::make_unique<NcclCommunicator>();
+std::unique_ptr<NcclCommunicatorInterface> MaybeCreateNcclCommunicator(
+    bool enable) {
+  return (enable) ? absl::make_unique<NcclCommunicator>(): nullptr;
 }
 
 void NcclCommunicator::Enqueue(std::shared_ptr<CollectiveContext> col_ctx,

--- a/tensorflow/core/nccl/collective_communicator.h
+++ b/tensorflow/core/nccl/collective_communicator.h
@@ -21,8 +21,8 @@ namespace tensorflow {
 
 // Creates a NcclCommunicator if built with NCCL support, otherwise it returns
 // nullptr.
-std::unique_ptr<NcclCommunicatorInterface> MaybeCreateNcclCommunicator();
-
+std::unique_ptr<NcclCommunicatorInterface>
+   MaybeCreateNcclCommunicator(bool enable = true);
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_NCCL_COLECTIVE_COMMUNICATOR_H_


### PR DESCRIPTION
…text because allowing this would allow the creation of more than 1 NcclManager which HIP does not support.