### PR TITLE
Functions needed for SpMM, introduced in hipsparse-rocm4.2

### DIFF
--- a/tensorflow/core/util/cuda_sparse.h
+++ b/tensorflow/core/util/cuda_sparse.h
@@ -54,7 +54,11 @@ using gpusparseMatDescr_t = hipsparseMatDescr_t;
 using gpusparseAction_t = hipsparseAction_t;
 using gpusparseHandle_t = hipsparseHandle_t;
 using gpuStream_t = hipStream_t;
-
+#if TF_ROCM_VERSION >= 40200
+using gpusparseDnMatDescr_t = hipsparseDnMatDescr_t;
+using gpusparseSpMatDescr_t = hipsparseSpMatDescr_t;
+using gpusparseSpMMAlg_t = hipsparseSpMMAlg_t;
+#endif
 #define GPUSPARSE(postfix) HIPSPARSE_##postfix
 #define gpusparse(postfix) hipsparse##postfix
 
@@ -260,7 +264,7 @@ class GpuSparse {
   // http://docs.nvidia.com/cuda/cusparse/index.html#cusparse-lt-t-gt-coo2csr.
   Status Coo2csr(const int* cooRowInd, int nnz, int m, int* csrRowPtr) const;
 
-#if (GOOGLE_CUDA && (CUDA_VERSION < 10020)) || TENSORFLOW_USE_ROCM
+#if (GOOGLE_CUDA && (CUDA_VERSION < 10020)) || (TENSORFLOW_USE_ROCM && TF_ROCM_VERSION < 40200)
   // Sparse-dense matrix multiplication C = alpha * op(A) * op(B)  + beta * C,
   // where A is a sparse matrix in CSR format, B and C are dense tall
   // matrices.  This routine allows transposition of matrix B, which
@@ -280,7 +284,7 @@ class GpuSparse {
                const int* csrSortedRowPtrA, const int* csrSortedColIndA,
                const Scalar* B, int ldb, const Scalar* beta_host, Scalar* C,
                int ldc) const;
-#else
+#else //CUDA_VERSION >=10200 || TF_ROCM_VERSION >= 40200
   // Workspace size query for sparse-dense matrix multiplication. Helper
   // function for SpMM which computes y = alpha * op(A) * op(B) + beta * C,
   // where A is a sparse matrix in CSR format, B and C are dense matricies in

--- a/tensorflow/core/util/rocm_sparse.cc
+++ b/tensorflow/core/util/rocm_sparse.cc
@@ -240,6 +240,39 @@ static inline Status CsrmmImpl(
 
 TF_CALL_HIP_LAPACK_TYPES(CSRMM_INSTANCE);
 
+#define SPMM_BUFFERSIZE_INSTANCE(Scalar, dtype)                               \
+  template <>                                                                 \
+  Status GpuSparse::SpMMBufferSize<Scalar>(                                   \
+      hipsparseOperation_t transA, hipsparseOperation_t transB,               \
+      const Scalar* alpha, const hipsparseSpMatDescr_t matA,                  \
+      const gpusparseDnMatDescr_t matB, const Scalar* beta,                   \
+      gpusparseDnMatDescr_t matC, hipsparseSpMMAlg_t alg, size_t* bufferSize) \
+      const {                                                                 \
+    DCHECK(initialized_);                                                     \
+    TF_RETURN_IF_GPUSPARSE_ERROR(wrap::hipsparseSpMM_bufferSize(              \
+        *gpusparse_handle_, transA, transB, alpha, matA, matB, beta, matC,    \
+        dtype, alg, bufferSize));                                             \
+    return Status::OK();                                                      \
+  }
+
+TF_CALL_HIP_LAPACK_TYPES(SPMM_BUFFERSIZE_INSTANCE);
+
+#define SPMM_INSTANCE(Scalar, dtype)                                             \
+  template <>                                                                    \
+  Status GpuSparse::SpMM<Scalar>(                                                \
+      hipsparseOperation_t transA, hipsparseOperation_t transB,                  \
+      const Scalar* alpha, const hipsparseSpMatDescr_t matA,                     \
+      const gpusparseDnMatDescr_t matB, const Scalar* beta,                      \
+      gpusparseDnMatDescr_t matC, hipsparseSpMMAlg_t alg, int8* buffer) const {  \
+    DCHECK(initialized_);                                                        \
+    TF_RETURN_IF_GPUSPARSE_ERROR(wrap::hipsparseSpMM(*gpusparse_handle_, transA, \
+                                              transB, alpha, matA, matB, beta,   \
+                                              matC, dtype, alg, buffer));        \
+    return Status::OK();                                                         \
+  }
+
+TF_CALL_HIP_LAPACK_TYPES(SPMM_INSTANCE);
+
 template <typename Scalar, typename SparseFnT>
 static inline Status CsrmvImpl(SparseFnT op, OpKernelContext* context,
                                hipsparseHandle_t hipsparse_handle,

--- a/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
+++ b/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
@@ -102,6 +102,8 @@ namespace wrap {
   __macro(hipsparseSetStream)                   \
   __macro(hipsparseSetMatIndexBase)             \
   __macro(hipsparseSetMatType)                  \
+  __macro(hipsparseSpMM_bufferSize)             \
+  __macro(hipsparseSpMM)                        \
   __macro(hipsparseXcoo2csr)                    \
   __macro(hipsparseXcsr2coo)                    \
   __macro(hipsparseXcsrgeam2Nnz)                \

--- a/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
+++ b/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
@@ -75,9 +75,11 @@ namespace wrap {
 
 #define FOREACH_HIPSPARSE_API(__macro)          \
   __macro(hipsparseCreate)                      \
+  __macro(hipsparseCreateCsr)                   \
+  __macro(hipsparseCreateDnMat)                 \
   __macro(hipsparseCreateMatDescr)              \
   __macro(hipsparseCcsr2csc)                    \
-  __macro(hipsparseCcsrgeam2)		                \
+  __macro(hipsparseCcsrgeam2)                   \
   __macro(hipsparseCcsrgeam2_bufferSizeExt)	    \
   __macro(hipsparseCcsrgemm)                    \
   __macro(hipsparseCcsrmm)                      \

--- a/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
+++ b/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
@@ -75,12 +75,10 @@ namespace wrap {
 
 #define FOREACH_HIPSPARSE_API(__macro)          \
   __macro(hipsparseCreate)                      \
-  __macro(hipsparseCreateCsr)                   \
-  __macro(hipsparseCreateDnMat)                 \
   __macro(hipsparseCreateMatDescr)              \
   __macro(hipsparseCcsr2csc)                    \
   __macro(hipsparseCcsrgeam2)                   \
-  __macro(hipsparseCcsrgeam2_bufferSizeExt)	    \
+  __macro(hipsparseCcsrgeam2_bufferSizeExt)	\
   __macro(hipsparseCcsrgemm)                    \
   __macro(hipsparseCcsrmm)                      \
   __macro(hipsparseCcsrmm2)                     \
@@ -93,9 +91,7 @@ namespace wrap {
   __macro(hipsparseDcsrmm2)                     \
   __macro(hipsparseDcsrmv)                      \
   __macro(hipsparseDestroy)                     \
-  __macro(hipsparseDestroyDnMat)                \
   __macro(hipsparseDestroyMatDescr)             \
-  __macro(hipsparseDestroySpMat)                \
   __macro(hipsparseScsr2csc)                    \
   __macro(hipsparseScsrgeam2)                   \
   __macro(hipsparseScsrgeam2_bufferSizeExt)     \
@@ -106,8 +102,6 @@ namespace wrap {
   __macro(hipsparseSetStream)                   \
   __macro(hipsparseSetMatIndexBase)             \
   __macro(hipsparseSetMatType)                  \
-  __macro(hipsparseSpMM_bufferSize)             \
-  __macro(hipsparseSpMM)                        \
   __macro(hipsparseXcoo2csr)                    \
   __macro(hipsparseXcsr2coo)                    \
   __macro(hipsparseXcsrgeam2Nnz)                \
@@ -119,6 +113,20 @@ namespace wrap {
   __macro(hipsparseZcsrmm)                      \
   __macro(hipsparseZcsrmm2)                     \
   __macro(hipsparseZcsrmv)
+
+#if TF_ROCM_VERSION >= 40200
+#define FOREACH_SpMM_API(__macro)               \
+  __macro(hipsparseCreateCsr)                   \
+  __macro(hipsparseCreateDnMat)                 \
+  __macro(hipsparseDestroyDnMat)                \
+  __macro(hipsparseDestroySpMat)                \
+  __macro(hipsparseSpMM_bufferSize)             \
+  __macro(hipsparseSpMM)                        
+ 
+FOREACH_SpMM_API(HIPSPARSE_API_WRAPPER)
+
+#undef FOREACH_SpMM_API
+#endif
 
 
 // clang-format on

--- a/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
+++ b/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
@@ -93,7 +93,9 @@ namespace wrap {
   __macro(hipsparseDcsrmm2)                     \
   __macro(hipsparseDcsrmv)                      \
   __macro(hipsparseDestroy)                     \
+  __macro(hipsparseDestroyDnMat)                \
   __macro(hipsparseDestroyMatDescr)             \
+  __macro(hipsparseDestroySpMat)                \
   __macro(hipsparseScsr2csc)                    \
   __macro(hipsparseScsrgeam2)                   \
   __macro(hipsparseScsrgeam2_bufferSizeExt)     \


### PR DESCRIPTION
Added SpMM, createCsr, createDnMat, destroyDnMat, destroySpMat for the Sparse Mat Mul function. Replaces hipsparseCsr in ROCm4.2+ . 

Added logic to separate algorithms before rocm 4.2 and after. 