### PR TITLE
Updated python 3.6.1 to python 3.6.8

### DIFF
--- a/tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh
@@ -41,9 +41,9 @@ apt-get install libsqlite3-dev
 set -e
 
 # Install Python 3.6 and dev library
-wget https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz
-tar xvf Python-3.6.1.tar.xz
-cd Python-3.6.1
+wget https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz
+tar xvf Python-3.6.8.tar.xz
+cd Python-3.6.8
 
 ./configure
 make altinstall


### PR DESCRIPTION
Changed the Python3.6 version in tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh, so QA test environments will build for manylinux2014. 