### PR TITLE
Adding an explicit error message for unsupported datatype double for ROCm DNN/MIOpen ops

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -1703,6 +1703,9 @@ miopenDataType_t ToMIOpenDataType(
     case dnn::DataType::kHalf:
       return miopenHalf;
     case dnn::DataType::kDouble:
+      LOG(FATAL)
+          << "Unsupported DNN data type: tf.float64 (dnn::DataType::kDouble)";
+      break;
     default:
       LOG(FATAL) << "Invalid DNN data type: " << static_cast<int>(data_type);
   }


### PR DESCRIPTION
Prior this change, attempts to use double datatype for convolution would have resulted in the following error
```
2021-05-10 13:27:41.113700: F tensorflow/stream_executor/rocm/rocm_dnn.cc:1707] Invalid DNN data type: 1
```

After this change, the error message becomes
```
2021-05-10 16:33:45.874371: F tensorflow/stream_executor/rocm/rocm_dnn.cc:1706] Unsupported DNN data type: tf.float64 (dnn::DataType::kDouble)
```

for genesis see - https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/issues/1347