### PR TITLE
[DO NOT MERGE] Revert "Have tf.nn.relu of NaN output NaN."

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_Relu.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Relu.pbtxt
@@ -4,7 +4,7 @@ op {
   description: <<END
 See: https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
 Example usage:
->>> tf.nn.relu([-2., 0., 3.]).numpy()
-array([0., 0., 3.], dtype=float32)
+>>> tf.nn.relu([-2., 0., -0., 3.]).numpy()
+array([ 0.,  0., -0.,  3.], dtype=float32)
 END
 }

--- a/tensorflow/core/kernels/relu_op_functor.h
+++ b/tensorflow/core/kernels/relu_op_functor.h
@@ -32,8 +32,7 @@ struct Relu {
   // activations: same shape as "features".
   void operator()(const Device& d, typename TTypes<T>::ConstTensor features,
                   typename TTypes<T>::Tensor activations) {
-    activations.device(d) =
-        features.template cwiseMax<Eigen::PropagateNaN>(static_cast<T>(0));
+    activations.device(d) = features.cwiseMax(static_cast<T>(0));
   }
 };
 
@@ -67,8 +66,7 @@ struct Relu6 {
   void operator()(const Device& d, typename TTypes<T>::ConstTensor features,
                   typename TTypes<T>::Tensor activations) {
     activations.device(d) =
-        features.template cwiseMax<Eigen::PropagateNaN>(static_cast<T>(0))
-            .template cwiseMin<Eigen::PropagateNaN>(static_cast<T>(6));
+        features.cwiseMax(static_cast<T>(0)).cwiseMin(static_cast<T>(6));
   }
 };
 

--- a/tensorflow/python/kernel_tests/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/relu_op_test.py
@@ -104,11 +104,6 @@ class ReluTest(test.TestCase):
   def testNoElement(self):
     self._testRelu(np.array([[], []], dtype=np.float32))
 
-  @test_util.disable_xla("b/157978028: Does not yet pass with XLA")
-  def testNaNPropagation(self):
-    for t in [np.float16, np.float32, np.float64]:
-      self._testRelu(np.array([-1, np.nan, 1, np.nan]).astype(t))
-
   # The gradient test for ReLU is a bit tricky as the derivative is not well
   # defined at around zero and we want to avoid that in terms of input values.
   def testGradientFloat32(self):
@@ -239,11 +234,6 @@ class Relu6Test(test.TestCase):
       self._testRelu6(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t))
 
-  @test_util.disable_xla("b/157978028: Does not yet pass with XLA")
-  def testNaNPropagation(self):
-    for t in [np.float16, np.float32, np.float64]:
-      self._testRelu6(np.array([-1, np.nan, 1, 7, np.nan]).astype(t))
-
   # The gradient test for ReLU6 is a bit tricky as the derivative is
   # not well defined at around zero and six and we want to avoid that
   # in terms of input values.
@@ -303,11 +293,6 @@ class LeakyReluTest(test.TestCase):
       self._testLeakyRelu(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
           alpha=0.1)
-
-  def testNaNPropagation(self):
-    for t in [np.float16, np.float32, np.float64]:
-      self._testLeakyRelu(np.array([-1, np.nan, 1, np.nan]).astype(t),
-                          alpha=0.2)
 
   # The gradient test for Leaky ReLU is a bit tricky as the derivative is not
   # well defined at around zero and we want to avoid that in terms of input
@@ -425,10 +410,6 @@ class EluTest(test.TestCase):
       self.skipTest("No GPU available")
     for t in [np.float16, np.float32, np.float64]:
       self._testElu(np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t))
-
-  def testNaNPropagation(self):
-    for t in [np.float16, np.float32, np.float64]:
-      self._testElu(np.array([-1, np.nan, 1, np.nan]).astype(t))
 
   def testGradientFloat32(self):
     with self.cached_session():


### PR DESCRIPTION
Adding NaN propagation to Relu, causing a huge perf degradation in the Eigen generated kernels for ROCm. This issue is being root-caused and will require hip-clang compiler changes to fix. Those fixes will come in a future ROCm release.

For the time being we need to revert this change to get the performance back.

This reverts commit 14dae44e4050ea3e44d1ca7124fd99899eb24879.

---------------------

@sunway513 I will cherry-pick this PR to `develop-upstream-QA-rocm43` branch once CI runs pass

@ekuznetsov139 just FYI
