### PR TITLE
changing the bazelrc to not use mlir generated kernels.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -248,6 +248,8 @@ build:tensorrt --repo_env TF_NEED_TENSORRT=1
 build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm --define=using_rocm=true --define=using_rocm_hipcc=true
 build:rocm --repo_env TF_NEED_ROCM=1
+# Generated kernels are not yet supported on ROCm.
+build:rocm --//tensorflow/core/kernels/mlir_generated:enable_gpu=false
 
 # Options extracted from configure script
 build:numa --define=with_numa_support=true

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -360,7 +360,8 @@ tf_cuda_cc_test(
     size = "small",
     srcs = ["gpu_unary_ops_test.cc"],
     tags = tf_cuda_tests_tags() + [
-        "no_cuda_asan",  # TODO(b/171341759): re-enable.
+        "no_cuda_asan",  # TODO(b/171341759): re-enable.,
+        "no_rocm"
     ],
     deps = [
         ":base_ops_test",


### PR DESCRIPTION
This PR changed the .bazelrc to avoid TF uses MLIR generated kernels for the r2.5-rocm-enhanced branch.