### PR TITLE
Enhance the ROCM specific dockerfile to add kmod to the list of packa…

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -37,6 +37,7 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
   pkg-config \
   g++-multilib \
   git \
+  kmod \
   libunwind-dev \
   libfftw3-dev \
   libelf-dev \


### PR DESCRIPTION
…ges to install.

The kmod package seems to be required in order to successfully run rocminfo.

This requirement started with rocm-4.1.0.

Without the kmod package, the following error message appears when rocminfo is run:

ROCk module is NOT loaded, possibly no GPU devices
