### PR TITLE
Making C++14 as the default when building TF with --config=rocm

### DIFF
--- a/third_party/gpus/crosstool/BUILD.rocm.tpl
+++ b/third_party/gpus/crosstool/BUILD.rocm.tpl
@@ -82,7 +82,7 @@ cc_toolchain_config(
         "-fdata-sections",
     ],
     dbg_compile_flags = ["-g"],
-    cxx_flags = ["-std=c++11"],
+    cxx_flags = ["-std=c++14"],
     link_flags = [
         "-fuse-ld=gold",
         "-Wl,-no-as-needed",

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -135,7 +135,7 @@ def InvokeHipcc(argv, log=False):
   undefines = GetOptionValue(argv, 'U')
   undefines = ''.join([' -U' + define for define in undefines])
   std_options = GetOptionValue(argv, 'std')
-  hipcc_allowed_std_options = ["c++11"]
+  hipcc_allowed_std_options = ["c++11", "c++14"]
   std_options = ''.join([' -std=' + define
       for define in std_options if define in hipcc_allowed_std_options])
 


### PR DESCRIPTION
Currently when building TF with `--config=rocm`, we default to using C++11 (`-std=c++11` is explicitly added as a `cxx_flag` inthe crosstool wrapper).

Linux CPU builds (i.e. non-ROCm builds) already use C++14 as the default, and hipcc/hipclang will soon update the default to be C++14 as well.

This PR/commit updates the crosstool wrapper to add `-std=c++14` as the `cxx_flag` (instead of the current `-std=c++11`)

-----------------------

/cc @sunway513 @ekuznetsov139 