### PR TITLE
Revert "This change replaces the original assert for detecting multiple"

### DIFF
--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -178,16 +178,9 @@ struct NcclManager::Collective : public core::RefCounted {
     // or to manage one non-singleton NcclManager instance.
     // For example, the nccl_manager_test will use both paradigms in the same
     // executable, but not running concurrently (which would hang otherwise).
-    // Temporarily backing out the assert in favor of a warning.
-    // TODO: reinstate the assert with a more targeted conditional.
     if (NcclManager::instance_count > 1) {
-      static absl::once_flag once;
-      absl::call_once(once, [] {
-        LOG(WARNING) << "More than one concurrent instance of NCCL manager "
-                        "has been instantiated on the same node.  This can "
-                        "sometimes result in a race condition leading to a "
-                        "system hang.";
-      });
+      status = errors::Internal(
+          "ROCm cannot use multi-node NCCL collectives on a single node");
     }
 #endif
   }


### PR DESCRIPTION
This reverts commit 87430b9121387f1a3736f0f2a443dbfde6050c44.

This commit is no longer needed since the multiple nccl manager issue
was fixed in upstream commit: fc158eb.