### PR TITLE
Tensorflow-Upstream Python3.9

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -96,11 +96,8 @@ RUN touch ${ROCM_PATH}/.info/version
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 ARG DEBIAN_FRONTEND=noninteractive
-#RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-#RUN /install/install_bazel.sh
-#RUN /install/install_golang.sh
 COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/
 SHELL ["/bin/bash", "-c"] 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -104,6 +104,7 @@ COPY release/* tensorflow/tools/ci_build/release/
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
+RUN python3 -m pip install -r tensorflow/tools/ci_build/release/requirements_ubuntu.txt
 #COPY /root//.local/lib/python3.9 /usr/local/lib/python3
 
 SHELL ["/bin/bash", "-c"]

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -107,10 +107,9 @@ SHELL ["/bin/bash", "-c"]
 ENV PATH="/root//bin:$PATH"
 RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 && update_bazel_linux
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
-#RUN ln -s /root//bin/bazel /usr/bin/bazel
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
-
+RUN echo "source /root//.bazel/bin/bazel-complete.bash" >> ~/.bashrc
 # Configure the build for our ROCm configuration.
 ENV TF_NEED_ROCM 1
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -95,18 +95,14 @@ RUN touch ${ROCM_PATH}/.info/version
 
 # Copy and run the install scripts.
 COPY install/*.sh /install/
+COPY release/common.sh /install/common.sh
+COPY release/* tensorflow/tools/ci_build/release/
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-COPY release/common.sh /install/common.sh
-COPY release/* tensorflow/tools/ci_build/release/
 ENV PATH="/root//bin:$PATH"
 SHELL ["/bin/bash", "-c"]
-RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 \
-    && ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
-#RUN ln -sf /root//.local/lib/python3.9/site-packages /usr/lib/python3/dist-packages
-RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
-ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
+#ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
 RUN /install/install_bazel.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -61,6 +61,9 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+# Add to get ppa
+RUN apt-get update
+RUN apt-get install -y software-properties-common
 # Install rocm pkgs
 RUN apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
@@ -93,6 +96,7 @@ RUN bash -c 'echo -e "gfx900\ngfx906\ngfx908" >> ${ROCM_PATH}/bin/target.lst'
 # Filed https://github.com/bazelbuild/bazel/issues/11163 for tracking this
 RUN touch ${ROCM_PATH}/.info/version
 
+ENV PATH="/root//bin:/root/.local/bin:$PATH"
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 COPY release/common.sh /install/common.sh
@@ -100,7 +104,8 @@ COPY release/* tensorflow/tools/ci_build/release/
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-ENV PATH="/root//bin:$PATH"
+#COPY /root//.local/lib/python3.9 /usr/local/lib/python3
+
 SHELL ["/bin/bash", "-c"]
 #ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
 RUN /install/install_bazel.sh

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -102,11 +102,10 @@ COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/
 ENV PATH="/root//bin:$PATH"
 SHELL ["/bin/bash", "-c"]
-RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9
+RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 \
+    && ln -sf /root//.local/lib/python3.9/dist-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
-SHELL ["/bin/sh", "-c"]
 ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
-RUN ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy
 RUN /install/install_bazel.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -103,7 +103,8 @@ COPY release/* tensorflow/tools/ci_build/release/
 ENV PATH="/root//bin:$PATH"
 SHELL ["/bin/bash", "-c"]
 RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 \
-    && ln -sf /root//.local/lib/python3.9/dist-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
+    && ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
+#RUN ln -sf /root//.local/lib/python3.9/site-packages /usr/lib/python3/dist-packages
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
 ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
 RUN /install/install_bazel.sh

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -106,6 +106,7 @@ RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
 SHELL ["/bin/sh", "-c"]
 ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
+RUN ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy
 RUN /install/install_bazel.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -105,6 +105,7 @@ SHELL ["/bin/bash", "-c"]
 RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
 SHELL ["/bin/sh", "-c"]
+ENV PYTHONPATH="/root//.local/lib/python3.9/site-packages/"
 RUN /install/install_bazel.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -102,11 +102,11 @@ COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/
 SHELL ["/bin/bash", "-c"] 
 ENV PATH="/root//bin:$PATH"
-RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 && update_bazel_linux
+RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9
+RUN /install/install_bazel.sh
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
-RUN echo "source /root//.bazel/bin/bazel-complete.bash" >> ~/.bashrc
 # Configure the build for our ROCm configuration.
 ENV TF_NEED_ROCM 1
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -97,7 +97,7 @@ RUN bash -c 'echo -e "gfx900\ngfx906\ngfx908" >> ${ROCM_PATH}/bin/target.lst'
 RUN touch ${ROCM_PATH}/.info/version
 
 ENV PATH="/root//bin:/root/.local/bin:$PATH"
-ENV PYTHON_BIN_PATH="/usr/local/bin/python3.9"
+#ENV PYTHON_BIN_PATH="/usr/local/bin/python3.9"
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 COPY release/common.sh /install/common.sh
@@ -105,7 +105,7 @@ COPY release/* tensorflow/tools/ci_build/release/
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-RUN python3 -m pip install -r tensorflow/tools/ci_build/release/requirements_ubuntu.txt
+#RUN python3 -m pip install -r tensorflow/tools/ci_build/release/requirements_ubuntu.txt
 #COPY /root//.local/lib/python3.9 /usr/local/lib/python3
 
 SHELL ["/bin/bash", "-c"]

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -55,7 +55,6 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
   pciutils \
   virtualenv \
   python-pip \
-  python3-pip \
   libxml2 \
   libxml2-dev \
   wget && \
@@ -99,10 +98,10 @@ COPY install/*.sh /install/
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_deb_packages.sh
-RUN /install/install_pip_packages.sh
+RUN /install/install_pi_python3.9_toolchain.sh
 RUN /install/install_bazel.sh
 RUN /install/install_golang.sh
-
+RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -96,15 +96,20 @@ RUN touch ${ROCM_PATH}/.info/version
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 ARG DEBIAN_FRONTEND=noninteractive
-RUN /install/install_bootstrap_deb_packages.sh
+#RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-RUN /install/install_bazel.sh
-RUN /install/install_golang.sh
+#RUN /install/install_bazel.sh
+#RUN /install/install_golang.sh
+COPY release/common.sh /install/common.sh
+COPY release/* tensorflow/tools/ci_build/release/
+SHELL ["/bin/bash", "-c"] 
+ENV PATH="/root//bin:$PATH"
+RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 && update_bazel_linux
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
-
+RUN echo "source /usr/local/lib/bazel/bazel-complete.bash" >> ~/.bashrc
 # Configure the build for our ROCm configuration.
 ENV TF_NEED_ROCM 1
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -97,6 +97,7 @@ RUN bash -c 'echo -e "gfx900\ngfx906\ngfx908" >> ${ROCM_PATH}/bin/target.lst'
 RUN touch ${ROCM_PATH}/.info/version
 
 ENV PATH="/root//bin:/root/.local/bin:$PATH"
+ENV PYTHON_BIN_PATH="/usr/local/bin/python3.9"
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 COPY release/common.sh /install/common.sh

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -96,12 +96,17 @@ RUN touch ${ROCM_PATH}/.info/version
 # Copy and run the install scripts.
 COPY install/*.sh /install/
 ARG DEBIAN_FRONTEND=noninteractive
-RUN /install/install_bootstrap_deb_packages.sh
+#RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-RUN /install/install_bazel.sh
-RUN /install/install_golang.sh
+#RUN /install/install_bazel.sh
+#RUN /install/install_golang.sh
+COPY release/common.sh /install/common.sh
+COPY release/* tensorflow/tools/ci_build/release/
+SHELL ["/bin/bash", "-c"] 
+RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 && export PATH="/root//bin:$PATH" && update_bazel_linux
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
+RUN ln -s /root//bin/bazel /usr/bin/bazel
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -100,11 +100,12 @@ RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
 COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/
-SHELL ["/bin/bash", "-c"] 
 ENV PATH="/root//bin:$PATH"
+SHELL ["/bin/bash", "-c"]
 RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9
-RUN /install/install_bazel.sh
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
+SHELL ["/bin/sh", "-c"]
+RUN /install/install_bazel.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
 # Configure the build for our ROCm configuration.

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -104,9 +104,10 @@ RUN /install/install_pi_python3.9_toolchain.sh
 COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/
 SHELL ["/bin/bash", "-c"] 
-RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 && export PATH="/root//bin:$PATH" && update_bazel_linux
+ENV PATH="/root//bin:$PATH"
+RUN source /install/common.sh && install_ubuntu_16_python_pip_deps python3.9 && update_bazel_linux
 RUN rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
-RUN ln -s /root//bin/bazel /usr/bin/bazel
+#RUN ln -s /root//bin/bazel /usr/bin/bazel
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -99,7 +99,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 #RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
-#RUN /install/install_bazel.sh
+RUN /install/install_bazel.sh
 #RUN /install/install_golang.sh
 COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -20,9 +20,11 @@ apt-get install -y python3.9 python3.9-dev
 apt-get install -y python3-pip 
 ln -sf /usr/bin/python3.9 /usr/local/bin/python3.9
 apt-get install -y python3.9-distutils
-python3.9 -m pip install --upgrade pip
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+update-alternatives --set python3 /usr/bin/python3.9
+pip3 install --upgrade pip
+# python3.9 -m pip install --upgrade pip
 source /install/common.sh
 install_ubuntu_16_python_pip_deps python3.9
-cp -r /root//.local/lib/python3.9 /usr/local/lib/python3
-ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
+ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3/numpy 
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -21,4 +21,3 @@ apt-get install -y python3-pip
 ln -sf /usr/bin/python3.9 /usr/local/bin/python3.9
 apt-get install -y python3.9-distutils
 python3.9 -m pip install --upgrade pip
-ln -sf /usr/local/lib/python3.9/dist-packages/numpy/core/include/numpy /usr/include/python3.9/numpy

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -14,22 +14,10 @@
 # limitations under the License.
 # ==============================================================================
 
-dpkg --add-architecture armhf
-dpkg --add-architecture arm64
-echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
-echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
-echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial-security main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
-echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
-sed -i 's#deb http://archive.ubuntu.com/ubuntu/#deb [arch=amd64] http://archive.ubuntu.com/ubuntu/#g' /etc/apt/sources.list
 yes | add-apt-repository ppa:deadsnakes/ppa
 apt-get update
 apt-get install -y python3.9 python3.9-dev
 apt-get install -y python3-pip 
 ln -sf /usr/bin/python3.9 /usr/local/bin/python3.9
-apt-get install -y libpython3.9-dev:armhf
-apt-get install -y libpython3.9-dev:arm64
 apt-get install -y python3.9-distutils
 python3.9 -m pip install --upgrade pip
-/install/install_pip3.9_packages.sh 
-
-ln -sf /usr/local/lib/python3.9/dist-packages/numpy/core/include/numpy /usr/include/python3.9/numpy

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -21,3 +21,4 @@ apt-get install -y python3-pip
 ln -sf /usr/bin/python3.9 /usr/local/bin/python3.9
 apt-get install -y python3.9-distutils
 python3.9 -m pip install --upgrade pip
+ln -sf /usr/local/lib/python3.9/dist-packages/numpy/core/include/numpy /usr/include/python3.9/numpy

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -23,5 +23,6 @@ apt-get install -y python3.9-distutils
 python3.9 -m pip install --upgrade pip
 source /install/common.sh
 install_ubuntu_16_python_pip_deps python3.9
+cp -r /root//.local/lib/python3.9/site-packages /usr/local/lib/python3.9/.
 ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+dpkg --add-architecture armhf
+dpkg --add-architecture arm64
+echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
+echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial-updates main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
+echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial-security main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
+echo 'deb [arch=arm64,armhf] http://ports.ubuntu.com/ xenial-backports main restricted universe multiverse' >> /etc/apt/sources.list.d/armhf.list
+sed -i 's#deb http://archive.ubuntu.com/ubuntu/#deb [arch=amd64] http://archive.ubuntu.com/ubuntu/#g' /etc/apt/sources.list
+yes | add-apt-repository ppa:deadsnakes/ppa
+apt-get update
+apt-get install -y python3.9 python3.9-dev
+apt-get install -y python3-pip 
+ln -sf /usr/bin/python3.9 /usr/local/bin/python3.9
+apt-get install -y libpython3.9-dev:armhf
+apt-get install -y libpython3.9-dev:arm64
+apt-get install -y python3.9-distutils
+python3.9 -m pip install --upgrade pip
+/install/install_pip3.9_packages.sh 
+
+ln -sf /usr/local/lib/python3.9/dist-packages/numpy/core/include/numpy /usr/include/python3.9/numpy

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -26,6 +26,6 @@ pip3 install --upgrade pip
 # python3.9 -m pip install --upgrade pip
 source /install/common.sh
 install_ubuntu_16_python_pip_deps python3.9
-cp -r /root//.local/lib/python3.9/site-packages /usr/lib/python3/.
+cp -r /root//.local/lib/python3.9/site-packages/* /usr/lib/python3/dist-packages/.
 ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -23,5 +23,6 @@ apt-get install -y python3.9-distutils
 python3.9 -m pip install --upgrade pip
 source /install/common.sh
 install_ubuntu_16_python_pip_deps python3.9
+cp -r /root//.local/lib/python3.9 /usr/local/lib/python3
 ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -26,6 +26,6 @@ pip3 install --upgrade pip
 # python3.9 -m pip install --upgrade pip
 source /install/common.sh
 install_ubuntu_16_python_pip_deps python3.9
-cp -r /root//.local/lib/python3.9/site-packages /usr/local/lib/python3.9/.
+cp -r /root//.local/lib/python3.9/site-packages /usr/lib/python3/.
 ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
 rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3.9_toolchain.sh
@@ -21,3 +21,7 @@ apt-get install -y python3-pip
 ln -sf /usr/bin/python3.9 /usr/local/bin/python3.9
 apt-get install -y python3.9-distutils
 python3.9 -m pip install --upgrade pip
+source /install/common.sh
+install_ubuntu_16_python_pip_deps python3.9
+ln -sf /root//.local/lib/python3.9/site-packages/numpy/core/include/numpy /usr/include/python3.9/numpy 
+rm -f /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3

--- a/tensorflow/tools/ci_build/install/install_pip3.9_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip3.9_packages.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+set -e
+
+# Get the latest version of pip so it recognize manylinux2010
+#wget https://bootstrap.pypa.io/get-pip.py
+#python3.6 get-pip.py
+#rm -f get-pip.py
+
+# Install pip packages from whl files to avoid the time-consuming process of
+# building from source.
+
+# Pin wheel==0.31.1 to work around issue
+# https://github.com/pypa/auditwheel/issues/102
+pip3 install --upgrade pip
+pip3 install --upgrade setuptools==57.4.0
+pip3 install --upgrade distlib
+pip3 install wheel==0.31.1
+
+# Install last working version of setuptools. This must happen before we install
+# absl-py, which uses install_requires notation introduced in setuptools 20.5.
+
+pip3 install virtualenv
+
+# Install six and future.
+pip3 install --upgrade six==1.12.0
+#pip3 install --upgrade future==3.3.0 #>=0.17.1"
+
+# Install absl-py.
+pip3 install --upgrade absl-py
+
+# Install werkzeug.
+pip3 install --upgrade werkzeug==0.11.10
+
+# Install bleach. html5lib will be picked up as a dependency.
+pip3 install --upgrade bleach==2.0.0
+
+# Install markdown.
+#pip3 install --upgrade markdown==2.6.8
+
+# Install protobuf.
+pip3 install --upgrade protobuf==3.16.0
+
+# Remove obsolete version of six, which can sometimes confuse virtualenv.
+rm -rf /usr/lib/python3/dist-packages/six*
+
+# numpy needs to be installed from source to fix segfaults. See:
+# https://github.com/tensorflow/tensorflow/issues/6968
+# This workaround isn't needed for Ubuntu 16.04 or later.
+if $(cat /etc/*-release | grep -q 14.04); then
+  pip3 install --upgrade numpy==1.14.5
+else
+  pip3 install --upgrade numpy~=1.19.2
+fi
+
+pip3 install scipy #==1.4.1
+
+pip3 install scikit-learn #==0.18.1
+
+# pandas required by `inflow`
+pip3 install pandas #==0.19.2
+
+# Benchmark tests require the following:
+pip3 install psutil
+pip3 install py-cpuinfo
+
+# pylint tests require the following version. pylint==1.6.4 hangs erratically,
+# thus using the updated version of 2.5.3 only for python3 as python2 is EOL
+# and this version is not available.
+pip3 install pylint pylint #==2.7.4
+
+# pycodestyle tests require the following:
+pip3 install pycodestyle
+
+pip3 install portpicker
+
+# TensorFlow Serving integration tests require the following:
+pip3 install grpcio
+
+# Eager-to-graph execution needs astor, gast and termcolor:
+pip3 install --upgrade astor
+pip3 install --upgrade gast
+pip3 install --upgrade termcolor
+
+# Keras
+pip3 install keras-nightly --no-deps
+pip3 install keras_preprocessing --no-deps
+pip3 install --upgrade h5py==3.1.0
+
+# Estimator
+pip3 install tf-estimator-nightly --no-deps
+
+# Tensorboard
+pip3 install tb-nightly --no-deps
+
+# Argparse
+pip3 install --upgrade argparse
+
+# tree
+pip3 install dm-tree
+
+# tf.distribute multi worker tests require the following:
+# Those tests are Python3 only.
+pip3 install --upgrade dill
+pip3 install --upgrade tblib


### PR DESCRIPTION
Updating Dockerfile.rocm to use python3.9. Added additional python3.9 specific scripts as existing scripts were incompatible.