### PR TITLE
Adding $ROCM_PATH/llvm/lib/clang/14.0.0/include to the list of include dirs

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -188,6 +188,7 @@ def _rocm_include_path(repository_ctx, rocm_config, bash_bin):
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/11.0.0/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/12.0.0/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/13.0.0/include")
+    inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/14.0.0/include")
 
     # Support hcc based off clang 10.0.0 (for ROCm 3.3)
     inc_dirs.append(rocm_toolkit_path + "/hcc/compiler/lib/clang/10.0.0/include/")


### PR DESCRIPTION
Adding $ROCM_PATH/llvm/lib/clang/14.0.0/include to the list of include dirs for the hipcc command. ROCm 4.4 mainline builds (starting with build 7694?) need this update