### PR TITLE
Removing no_rocm tag from //tensorflow/python/kernel_tests:extract_image_patches_grad_test_gpu

### DIFF
--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -3335,7 +3335,6 @@ cuda_py_test(
     srcs = ["extract_image_patches_grad_test.py"],
     shard_count = 15,
     tags = [
-        "no_rocm",
         "nomac",  # b/181799478
         "notap",  # b/31080670
     ],


### PR DESCRIPTION
This test was disabled on rocm when we switched to ROCM 4.1 (because it started faiing with the switch to ROCm 4.1)

We never root caused the reason of failure, but it seems to be passing again (as of develop-upstream 210823 + ROCm 4.2). So re-enabling it.

Related commit and JIRA ticket
* https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/a6a5e70db85fa147791b525cc09759dc2734af68
* https://ontrack-internal.amd.com/browse/SWDEV-276502