### PR TITLE
The following upstream commits caused a 15% performance degradation o…

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -72,7 +72,11 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
 
   opts.set_xla_allow_excess_precision(true);
   opts.set_xla_force_host_platform_device_count(1);
+#if TENSORFLOW_USE_ROCM
+  opts.set_xla_gpu_deterministic_reductions(false);
+#else
   opts.set_xla_gpu_deterministic_reductions(true);
+#endif
   opts.set_xla_cpu_enable_xprof_traceme(false);
   opts.set_xla_gpu_unsafe_fallback_to_driver_on_ptxas_not_found(false);
   opts.set_xla_multiheap_size_constraint_per_heap(-1);

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -153,7 +153,11 @@ std::array<int64_t, 3> GetReductionTiling(
   if (reduction_dimensions.is_row_reduction) {
     int64_t tile_z = std::min(reduction_dimensions.dimensions[0],
                               kBatchedReductionRaceFreeBound);
+#if TENSORFLOW_USE_ROCM
+    return {tile_z, 1, 16};
+#else
     return {tile_z, 1, 64};
+#endif
   }
 
   // Column reduction.

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -718,6 +718,7 @@ glob_lit_tests(
     tags_override = {
         "reduction_vectorization_sm_all.hlo": ["no_rocm"],
         "element_wise_row_vectorization.hlo": ["no_rocm"],
+        "reduce_unnested.hlo": ["no_rocm"],
     },
     test_file_exts = ["hlo"],
 )


### PR DESCRIPTION
…n the resnet50 model for ROCm:

4193058f98378f6f67db0cc67fb68332f8396d41: increase row tiling to 64
37ddd35d129280e80a847f09264118c7a0cbd894: enable tree reduction by default

The changes were "undone" for ROCm by guarding the previous implementation details with the TENSORFLOW_USE_ROCM macro.

The commit which increased row tiling to 64 made substantial changes to the reduce_unnested.hlo unit test to accomodate the change so the test fails on ROCm with this commit.

Therefore, the reduce_unnested.hlo unit test has been disabled.