### PR TITLE
enable lu_op

### DIFF
--- a/tensorflow/core/kernels/linalg/BUILD
+++ b/tensorflow/core/kernels/linalg/BUILD
@@ -268,9 +268,12 @@ tf_kernel_library(
 tf_kernel_library(
     name = "lu_op",
     prefix = "lu_op",
-    deps = if_cuda([
-        "//tensorflow/core/util:cuda_solvers",
+    deps = if_cuda_or_rocm([
         "//tensorflow/core/kernels:transpose_functor",
+    ]) + if_cuda([
+        "//tensorflow/core/util:cuda_solvers",
+    ]) + if_rocm([
+        "//tensorflow/core/util:rocm_solvers",
     ]) + [
         "//third_party/eigen3",
         "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/linalg/lu_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/lu_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 
 #include <algorithm>
@@ -182,9 +182,16 @@ class LuOpGpu : public AsyncOpKernel {
       auto packed_triangular_factors_ptrs = solver->GetScratchSpace<uint8>(
           sizeof(Scalar*) * batch_size, "packed_triangular_factors_ptrs",
           /* on_host */ true);
+#if GOOGLE_CUDA
       const Scalar** packed_triangular_factors_ptrs_base =
           reinterpret_cast<const Scalar**>(
               packed_triangular_factors_ptrs.mutable_data());
+#else //TENSORFLOW_USE_ROCM
+       Scalar** packed_triangular_factors_ptrs_base =
+          reinterpret_cast< Scalar**>(
+              packed_triangular_factors_ptrs.mutable_data());
+#endif
+
       for (int batch = 0; batch < batch_size; ++batch) {
         packed_triangular_factors_ptrs_base[batch] =
             &packed_triangular_factors_transpose_reshaped(batch, 0, 0);

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -44,7 +44,7 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-v1only \
+      --test_tag_filters=gpu,-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-v1only \
       --jobs=${N_BUILD_JOBS} \
       --local_test_jobs=${N_TEST_JOBS} \
       --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
@@ -61,4 +61,5 @@ bazel test \
       -//tensorflow/core/tpu/... \
       -//tensorflow/lite/... \
       -//tensorflow/compiler/tf2tensorrt/... \
+      -//tensorflow/python/kernel_tests:lu_op_test \
 

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -61,5 +61,4 @@ bazel test \
       -//tensorflow/core/tpu/... \
       -//tensorflow/lite/... \
       -//tensorflow/compiler/tf2tensorrt/... \
-      -//tensorflow/python/kernel_tests:lu_op_test \
 

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -44,7 +44,7 @@ yes "" | $PYTHON_BIN_PATH configure.py
 bazel test \
       --config=rocm \
       -k \
-      --test_tag_filters=gpu,-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-v1only \
+      --test_tag_filters=-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-v1only \
       --jobs=${N_BUILD_JOBS} \
       --local_test_jobs=${N_TEST_JOBS} \
       --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \


### PR DESCRIPTION
This enables the LU op for rocm. It tests it during the single gpu tests. Credit to @stevenireeves for code to compile the op.