### PR TITLE
Revised run_pip_tests to be inline with nightly builds.

### DIFF
--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -421,6 +421,7 @@ cc_library(
 
 py_test(
     name = "ram_file_system_test",
+    tags = ["no_rocm"],
     srcs = ["ram_file_system_test.py"],
     python_version = "PY3",
     deps = [

--- a/tensorflow/python/compiler/xla/BUILD
+++ b/tensorflow/python/compiler/xla/BUILD
@@ -74,6 +74,7 @@ cuda_py_test(
     tags = [
         "no_mac",
         "no_windows",
+	"no_rocm",
     ],
     xla_enabled = True,
     deps = [

--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -76,6 +76,7 @@ tf_py_test(
 tf_py_test(
     name = "checkpoint_input_pipeline_hook_test",
     size = "small",
+    tags = ["no_rocm"],
     srcs = ["checkpoint_input_pipeline_hook_test.py"],
     deps = [
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -1644,6 +1644,7 @@ cuda_py_test(
     python_version = "PY3",
     tags = [
         "multi_and_single_gpu",
+	"no_rocm",
     ],
     # b/141096229: Non-atomic AssignAdd
     xla_enable_strict_auto_jit = False,
@@ -1912,6 +1913,7 @@ distribute_py_test(
     tags = [
         "multi_and_single_gpu",
         "no_oss",  # TODO(b/171349346, b/181878817): Frequent timeouts. Do not re-enable until rewritten
+	"no_rocm",
     ],
     deps = [
         ":multi_worker_test_base",

--- a/tensorflow/tools/ci_build/builds/run_pip_tests.sh
+++ b/tensorflow/tools/ci_build/builds/run_pip_tests.sh
@@ -96,7 +96,7 @@ if [[ ${IS_GPU} == "1" ]] || [[ ${IS_ROCM} == "1" ]]; then
   PIP_TEST_FILTER_TAG="-no_gpu,-no_pip_gpu,${PIP_TEST_FILTER_TAG}"
 fi
 if [[ ${IS_ROCM} == "1" ]]; then
-  PIP_TEST_FILTER_TAG="-no_rocm,-no_pip_rocm,${PIP_TEST_FILTER_TAG}"
+  PIP_TEST_FILTER_TAG="gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py36,-no_rocm,${PIP_TEST_FILTER_TAG}"
 fi
 if [[ ${IS_MAC} == "1" ]]; then
   # TODO(b/122370901): Fix nomac, no_mac inconsistency.


### PR DESCRIPTION
Revised the tags to eliminate unnecessary tests in QA CI builds. This brings the number of tests inline with our nightly tensorflow builds. I will be making the same PR for develop-upstream and r2.6-rocm-enhanced. 