### PR TITLE
Commenting out the call to `apt-key` as it times out on nodes behind a firewall.

### DIFF
--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -28,7 +28,7 @@ if [[ "$1" != "" ]] && [[ "$1" != "--without_cmake" ]]; then
 fi
 
 # Install dependencies from ubuntu deb repository.
-apt-key adv --keyserver keyserver.ubuntu.com --recv 084ECFC5828AB726
+# apt-key adv --keyserver keyserver.ubuntu.com --recv 084ECFC5828AB726
 apt-get update
 
 if [[ "$ubuntu_version" == "14" ]]; then


### PR DESCRIPTION

The call to `apt-key` in the file `tensorflow/tools/ci_build/install/install_deb_packages.sh` times out on nodes that are behind a firewall. For e.g.

```
root@x1001c6s2b0n0:/# apt-key adv --keyserver keyserver.ubuntu.com --recv 084ECFC5828AB726
Executing: /tmp/apt-key-gpghome.FcvTJBkYhY/gpg.1.sh --keyserver keyserver.ubuntu.com --recv 084ECFC5828AB726
gpg: keyserver receive failed: Connection timed out
```

We now have nightly CI jobs that run on nodes that are behind a http-proxy / firewall, and the above command fails on those nodes, causing the CI run to error out. Attempts to google a solution to this problem yielded answers that were "node + firewall" specific, but nothing generic that will work on all CI nodes.

Commenting out the call apt-key altogether does not seem to affect any of the subsequent `install` calls, so going with this solution for now.