### PR TITLE
Break ReLu functionality

### DIFF
--- a/tensorflow/core/kernels/relu_op_functor.h
+++ b/tensorflow/core/kernels/relu_op_functor.h
@@ -33,7 +33,7 @@ struct Relu {
   void operator()(const Device& d, typename TTypes<T>::ConstTensor features,
                   typename TTypes<T>::Tensor activations) {
     activations.device(d) =
-        features.template cwiseMax<Eigen::PropagateNaN>(static_cast<T>(0));
+        features.template cwiseMin<Eigen::PropagateNaN>(static_cast<T>(0));
   }
 };
 


### PR DESCRIPTION
Artificial commits to break ReLu functionality as part of ramp-up task. The previous change didn't deterministically cause tests to fail and this one should.