### PR TITLE
Drop `hc.bc` from the list of device libs pulled in by the XLA AMDGPU compiler backend

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -571,7 +571,7 @@ std::vector<string> GetROCDLPaths(std::string amdgpu_version,
                                   const string& rocdl_dir_path) {
   // AMDGPU version-neutral bitcodes.
   static std::vector<string>* rocdl_filenames = new std::vector<string>(
-      {"hc.bc", "opencl.bc", "ocml.bc", "ockl.bc", "oclc_finite_only_off.bc",
+      {"opencl.bc", "ocml.bc", "ockl.bc", "oclc_finite_only_off.bc",
        "oclc_daz_opt_off.bc", "oclc_correctly_rounded_sqrt_on.bc",
        "oclc_unsafe_math_off.bc", "oclc_wavefrontsize64_on.bc"});
 


### PR DESCRIPTION

related JIRA ticket - https://ontrack-internal.amd.com/browse/SWDEV-314685

Starting with ROCm 5.0, the device library file `hc.bc` will no longer be included in the ROCm install. This file/library contained device funtions in the HCC namespace, that are no longer referenced. So droppping this file should be ok.