### PR TITLE
[ROCm] Enable gpu unrolling test

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -616,7 +616,7 @@ tf_cc_test(
 tf_cc_test(
     name = "gpu_unrolling_test",
     srcs = ["gpu_unrolling_test.cc"],
-    tags = tf_cuda_tests_tags() + ["no_rocm"],
+    tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
         "//tensorflow/compiler/xla/service:hlo_module_config",


### PR DESCRIPTION
Discovered during an audit of our fork:
The //tensorflow/compiler/xla/service/gpu/tests:gpu_unrolling_test  test was fixed in https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/9d859f5f313ec5a0d9f626d2c0dd78e061fa036d but never enabled.
Enable this test for ROCm to increase coverage.

Other details:
 - the gpu_kernel_tiling_test was also "fixed" in the above commit and remains disabled as well. That test fails and will need some extra attention so I left it off here.
 
Commits to go upstream:
[9d859f5f313ec5a0d9f626d2c0dd78e061fa036d](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/9d859f5f313ec5a0d9f626d2c0dd78e061fa036d)

[234b54661230b9db8169977bd88b1d81aa1cc8c7](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/234b54661230b9db8169977bd88b1d81aa1cc8c7) (this commit)