### PR TITLE
remove duplicate include

### DIFF
--- a/tensorflow/core/kernels/linalg/svd_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/svd_op_gpu.cu.cc
@@ -44,7 +44,6 @@ limitations under the License.
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/determinism.h"
-#include "tensorflow/core/util/gpu_solvers.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/gpu_solvers.h"
 


### PR DESCRIPTION
Discovered during an audit of our fork:
We have the same file ("tensorflow/core/util/gpu_solvers.h") included twice.
This was likely the result of a mis-merge when adding the matrix solve op here:
https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/21554c787926625b86abae84a2a6560a6b6645da

This PR cleans this up.