### PR TITLE
Fix duplicate macro definition

### DIFF
--- a/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
+++ b/tensorflow/stream_executor/rocm/hipsparse_wrapper.h
@@ -123,10 +123,8 @@ namespace wrap {
   __macro(hipsparseDestroySpMat)                \
   __macro(hipsparseDcsru2csr_bufferSizeExt)     \
   __macro(hipsparseDcsru2csr)                   \
-  __macro(hipsparseSpMM_bufferSize)             \
-  __macro(hipsparseSpMM)                        \
   __macro(hipsparseScsru2csr_bufferSizeExt)     \
-  __macro(hipsparseScsru2csr)                   \  
+  __macro(hipsparseScsru2csr)                   \
   __macro(hipsparseSpMM_bufferSize)             \
   __macro(hipsparseSpMM)                        \
   __macro(hipsparseZcsru2csr_bufferSizeExt)     \


### PR DESCRIPTION
Discovered during an audit of our fork:
We have the following defined twice in the hipsparse_wrapper.

```
__macro(hipsparseSpMM_bufferSize) \
__macro(hipsparseSpMM) \
```

This was likely the artifact of a mis-merge.
This PR removes the duplicate macro defines and fixes some white space lint.