### PR TITLE
 Setting the amdgpu-flat-work-group-size attribute to 1024 for MLIR generated kernels.

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/kernel_creator.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/kernel_creator.cc
@@ -403,6 +403,21 @@ Status LowerKernelBodiesToLowLevelIr(mlir::ModuleOp module) {
       "Neither TENSORFLOW_USE_ROCM nor GOOGLE_CUDA are defined."
       " Did you specify either --config=rocm or --config=cuda ?");
 #endif
+
+#if TENSORFLOW_USE_ROCM
+  auto gpu_modules = module.getOps<::mlir::gpu::GPUModuleOp>();
+  for (::mlir::gpu::GPUModuleOp gpu_module : gpu_modules) {
+    gpu_module.walk([&](mlir::gpu::GPUFuncOp gpu_kernel) {
+      if (gpu_kernel->getAttr(mlir::gpu::GPUDialect::getKernelFuncAttrName())) {
+        gpu_kernel->setAttr(
+            "rocdl.max_flat_work_group_size",
+            mlir::IntegerAttr::get(
+                mlir::IntegerType::get(module.getContext(), 32), 1024));
+      }
+    });
+  }
+#endif
+
   mlir::PassManager pm(module.getContext());
   // We cannot verify as the signature of the kernel is rewritten.
   // pm.enableVerifier(false);

--- a/third_party/llvm/macos_build_fix.patch
+++ b/third_party/llvm/macos_build_fix.patch
@@ -42,18 +42,5 @@ index ff64df694048..c9c35b01711c 100644
      "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
      "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
  }) + [
-diff --git a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
-index 09519aebfbfa..4698669bc8aa 100644
---- a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
-+++ b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
-@@ -80,7 +80,7 @@ public:
-           moduleTranslation.lookupFunction(func.getName());
-       llvmFunc->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
-       if (!llvmFunc->hasFnAttribute("amdgpu-flat-work-group-size")) {
--        llvmFunc->addFnAttr("amdgpu-flat-work-group-size", "1, 256");
-+        llvmFunc->addFnAttr("amdgpu-flat-work-group-size", "1, 1024");
-       }
-       llvmFunc->addFnAttr("amdgpu-implicitarg-num-bytes", "56");
-     }
 -- 
 2.30.1 (Apple Git-130)


### PR DESCRIPTION
As a consequence of the 211213 weekly-sync, we picked up an upstream change (LLVM change really) that resulted in 100+ unit test failures. See the commit message for below workaround for details on the breakage + how we worked around it.

[8a1ee38](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/8a1ee3890c63507a64dd5b837d08ccf56c3ffdff)

The proper fix for this breakage (as opposed to the above workaround) requires changes on the both the TF side and LLVM side

On the LLVM side, we need to add the ability to configure/overwrite the default value (256) of the `amdgpu-flat-work-group-size` attribute for MLIR generated GPU kernels. This is done via the addition of the `rocdl.max_flat_work_group_size` attribute, which when set on the `mlir::GPUFuncOp` will override the default value (256) when `mlir::GPUFuncOp` gets translated to `llvm::FuncOp`. See the following LLVM PR for details

https://reviews.llvm.org/D115741

On the TF side, we need to explicitly specify the `rocdl.max_flat_work_group_size` attribute with value set to 1024 for MLIR generated kernels...which is what this commit does.

