### PR TITLE
Enablement of NHWC FP16 ops (Conv + Batchnorm) on selected AMD GPUs

### DIFF
--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -29,6 +29,9 @@ limitations under the License.
 #include "tensorflow/core/lib/hash/hash.h"
 #include "tensorflow/core/util/autotune_maps/conv_parameters.h"
 #include "tensorflow/core/util/tensor_format.h"
+#if TENSORFLOW_USE_ROCM
+#include "tensorflow/stream_executor/rocm/rocm_dnn.h"
+#endif
 
 namespace tensorflow {
 
@@ -194,6 +197,18 @@ Status LaunchAutotunedConv(const AutotuneEntry<se::dnn::ConvOp>& autotune_entry,
         nullptr);
   }
 }
+
+bool UseNhwcLayoutForConvOnRocm(se::Stream* stream);/* {
+#if TENSORFLOW_USE_ROCM
+   bool is_enabled = se::gpu::UseNhwcLayoutForRocm();
+   auto arch_name = stream->GetGcnArchName();
+   return (arch_name.find("gfx908") != std::string::npos  ||
+           arch_name.find("gfx90a") != std::string::npos) &&
+           is_enabled; 
+#else
+   return false;
+#endif
+}*/
 
 }  // namespace tensorflow
 

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -864,6 +864,13 @@ class MIOpenSupport : public dnn::DnnSupport {
   SE_DISALLOW_COPY_AND_ASSIGN(MIOpenSupport);
 };
 
+// A helper function to decide whether to use
+// NHWC in Convolution/Batchnorm. This mode can be faster in
+// in FP16 workloads on gfx908 and beyond. Requires ROCm 5.0+.
+// TODO(stevenireeves): Use autotune to choose between this mode and
+// NCHW when MIOpen has more optimized kernels. 
+bool UseNhwcLayoutForRocm();
+
 }  // namespace gpu
 }  // namespace stream_executor
 

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -2102,6 +2102,9 @@ class Stream {
     return parent()->GetDeviceDescription().cuda_compute_capability();
   }
 
+  std::string GetGcnArchName() const {
+    return parent()->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+  }
   // Returns the (internal usage) temporary-memory-allocation manager associated
   // with this stream.
   internal::TemporaryMemoryManager *temporary_memory_manager();


### PR DESCRIPTION
Enables FP16 NHWC in XLA and non XLA paths for convolutions and batch normalization. Currently the MIOpen NHWC Batchnorm isn't optimized and we witness an approximate 4x reduction in performance when using it. 

In order to test NHWC in the future, set the environment variable TF_USE_ROCM_NHWC=1 before running your test. 
Some data on a small model (Conv -> BN -> Dense):

NHWC
Name	Calls	Total Duration Ns	Avg Ns
MIOpenBatchNormBwdSpatial.kd	10	4996320	499632
MIOpenBatchNormFwdTrainSpatial.kd	10	2183200	218320

NCHW
Name	Calls	Total Duration Ns	Avg Ns
MIOpenBatchNormBwdSpatial.kd	10	1034400	103440
MIOpenBatchNormFwdTrainSpatial.kd	10	560959	56095

NHWC BN is ~5x slower in Backwards and ~3.9x slower in Forwards pass on MI100.