### PR TITLE
Change ld.lld log message if it is missing.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -730,7 +730,7 @@ StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
   std::string lld_path = tensorflow::io::JoinPath("/opt/rocm", "llvm/bin");
   auto lld_program = llvm::sys::findProgramByName("ld.lld", {lld_path});
   if (!lld_program) {
-    return xla::InternalError("unable to find ld.lld in PATH: %s",
+    return xla::InternalError("unable to find ld.lld in %s: %s", lld_path,
                               lld_program.getError().message());
   }
   std::vector<llvm::StringRef> lld_args{


### PR DESCRIPTION
The older log message was not clear. In some ROCm containers, the softlink from /opt/rocm to opt/rocm-x.x.x does not exist. The error message in this situation was ambiguous. 