### PR TITLE
The select_and_scatter GPU kernel was causing a large performance dro…

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -271,8 +271,10 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
     return false;
   }
 
+  llvm::Triple target_triple = llvm::Triple(module_->getTargetTriple());
+  bool isAMDGPU = target_triple.isAMDGPU();
+
   if (root_opcode == HloOpcode::kAdd) {
-    llvm::Triple target_triple = llvm::Triple(module_->getTargetTriple());
     // NVPTX supports atomicAdd on F32 and integer types.
     if (target_triple.isNVPTX()) {
       // "atom.add.f64 requires sm_60 or higher."
@@ -290,10 +292,8 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
       }
     }
 
-    if (target_triple.isAMDGPU()) {
+    if (isAMDGPU) {
       std::string arch = ir_emitter_context_->amdgpu_arch();
-      bool isGfx908Plus = arch.size()>=6 &&
-          (arch.substr(0,6)=="gfx908" || arch.substr(0,6)=="gfx90a");
       llvm::PointerType* output_address_type =
           llvm::dyn_cast<llvm::PointerType>(output_address->getType());
       CHECK_NE(output_address_type, nullptr);
@@ -311,8 +311,7 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
           AtomicRMW(llvm::AtomicRMWInst::FAdd, cast_output_ptr, source,
                   llvm::MaybeAlign(),
                   llvm::AtomicOrdering::SequentiallyConsistent,
-                  // we really want "agent", but it's not in the enum.
-                  llvm::SyncScope::SingleThread);
+                  b_.getContext().getOrInsertSyncScopeID("agent"));
           return true;
         } else {
           // adds to shared memory are always atomic. Todo: verify that the compiler
@@ -320,7 +319,7 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
           AtomicRMW(llvm::AtomicRMWInst::FAdd, output_address, source,
                   llvm::MaybeAlign(),
                   llvm::AtomicOrdering::SequentiallyConsistent,
-                  llvm::SyncScope::SingleThread);
+                  b_.getContext().getOrInsertSyncScopeID("agent"));
           return true;
         }
       }
@@ -328,9 +327,16 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
 
     if (is_atomic_integral) {
       // integral + integral
-      AtomicRMW(llvm::AtomicRMWInst::Add, output_address, source,
-                llvm::MaybeAlign(),
-                llvm::AtomicOrdering::SequentiallyConsistent);
+      if (isAMDGPU) {
+        AtomicRMW(llvm::AtomicRMWInst::Add, output_address, source,
+            llvm::MaybeAlign(),
+            llvm::AtomicOrdering::SequentiallyConsistent,
+            b_.getContext().getOrInsertSyncScopeID("agent"));
+      } else {
+        AtomicRMW(llvm::AtomicRMWInst::Add, output_address, source,
+            llvm::MaybeAlign(),
+            llvm::AtomicOrdering::SequentiallyConsistent);
+      }
       return true;
     }
   }
@@ -341,8 +347,14 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
     auto opcode = primitive_util::IsSignedIntegralType(element_type)
                       ? llvm::AtomicRMWInst::Max
                       : llvm::AtomicRMWInst::UMax;
-    AtomicRMW(opcode, output_address, source, llvm::MaybeAlign(),
-              llvm::AtomicOrdering::SequentiallyConsistent);
+    if (isAMDGPU) {
+      AtomicRMW(opcode, output_address, source, llvm::MaybeAlign(),
+                llvm::AtomicOrdering::SequentiallyConsistent,
+                b_.getContext().getOrInsertSyncScopeID("agent"));
+    } else {
+      AtomicRMW(opcode, output_address, source, llvm::MaybeAlign(),
+                llvm::AtomicOrdering::SequentiallyConsistent);
+    }
     return true;
   }
 
@@ -351,8 +363,14 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
     auto opcode = primitive_util::IsSignedIntegralType(element_type)
                       ? llvm::AtomicRMWInst::Min
                       : llvm::AtomicRMWInst::UMin;
-    AtomicRMW(opcode, output_address, source, llvm::MaybeAlign(),
-              llvm::AtomicOrdering::SequentiallyConsistent);
+    if (isAMDGPU) {
+      AtomicRMW(opcode, output_address, source, llvm::MaybeAlign(),
+                llvm::AtomicOrdering::SequentiallyConsistent,
+                b_.getContext().getOrInsertSyncScopeID("agent"));
+    } else {
+      AtomicRMW(opcode, output_address, source, llvm::MaybeAlign(),
+                llvm::AtomicOrdering::SequentiallyConsistent);
+    }
     return true;
   }
 
@@ -507,10 +525,21 @@ Status IrEmitter::EmitAtomicOperationUsingCAS(const HloComputation& computation,
   // Emit code to perform the atomicCAS operation
   // (cas_old_output, success) = atomicCAS(memory_address, cas_old_output,
   //                                       cas_new_output);
-  llvm::Value* ret_value = AtomicCmpXchg(
-      atomic_memory_address, cas_old_output, cas_new_output, llvm::MaybeAlign(),
-      llvm::AtomicOrdering::SequentiallyConsistent,
-      llvm::AtomicOrdering::SequentiallyConsistent);
+  llvm::Value* ret_value = [&]() {
+    llvm::Triple target_triple = llvm::Triple(module_->getTargetTriple());
+    if (target_triple.isAMDGPU()) {
+      return AtomicCmpXchg(
+          atomic_memory_address, cas_old_output, cas_new_output, llvm::MaybeAlign(),
+          llvm::AtomicOrdering::SequentiallyConsistent,
+          llvm::AtomicOrdering::SequentiallyConsistent,
+          b_.getContext().getOrInsertSyncScopeID("agent"));
+    } else {
+      return AtomicCmpXchg(
+          atomic_memory_address, cas_old_output, cas_new_output, llvm::MaybeAlign(),
+          llvm::AtomicOrdering::SequentiallyConsistent,
+          llvm::AtomicOrdering::SequentiallyConsistent);
+    }
+  }();
 
   // Extract the memory value returned from atomicCAS and store it as
   // cas_old_output.


### PR DESCRIPTION
…p for the MLPerf Resnet50 model on MI200.

The reason for the performance loss is that the AMD GPU compiler was inserting very high latency instructions into
the critical path of the CAS loop which was generated because atomic add is not supported for fp16.

These high latency instructions are specific to MI200 are emitted by the compiler to ensure system wide cache
coherency on the MI200 architecture.

The fix for the issue is to change the syncscope for the atomicCAS loop from 'system' (which is the default) to
'agent'.

This prevents the compiler from emitting the MI200 specific high latency instructions but still emits instructions which provide
adequate cache coherency guarantees in line with previous AMD GPU architectures.