### PR TITLE
Moving NHWC from ROCm 5.0 to ROCm5.1.

### DIFF
--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -1171,7 +1171,7 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
         workspace_allocator;
     DeviceMemory<uint8>* reserve_space_data_ptr = nullptr;
     DeviceMemory<uint8> reserve_space_data;
-#if CUDNN_VERSION >= 7402 || TF_ROCM_VERSION >= 50000
+#if CUDNN_VERSION >= 7402 || TF_ROCM_VERSION >= 50100
     if (use_reserved_space) {
       const Tensor& reserve_space = context->input(5);
       workspace_allocator.reset(
@@ -1185,7 +1185,7 @@ struct FusedBatchNormGrad<GPUDevice, T, U> {
         reserve_space_data_ptr = &reserve_space_data;
       }
     }
-#endif  // CUDNN_VERSION >= 7402 || TF_ROCM_VERSION >= 50000
+#endif  // CUDNN_VERSION >= 7402 || TF_ROCM_VERSION >= 50100
     bool cudnn_launch_status =
         stream
             ->ThenBatchNormalizationBackward(

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -5155,7 +5155,7 @@ bool MIOpenSupport::DoFusedBatchNormActivationBackward(
 // TODO(stevenireeves): Use autotune to choose between this mode and
 // NCHW when MIOpen has more optimized kernels. 
 bool UseNhwcLayoutForRocm() {
-#if TF_ROCM_VERSION >= 50000
+#if TF_ROCM_VERSION >= 50100
   static bool is_enabled = [] {
     bool is_enabled = false;
     TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar(


### PR DESCRIPTION
 As MIOpen NHWC Bn comes in ROCm 5.1. So we cannot test in ROCm 5.0. 