### PR TITLE
Fixing setup for r2.6

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -101,9 +101,10 @@ REQUIRED_PACKAGES = [
     # These need to be in sync with the existing TF version
     # They are updated during the release process
     # When updating these, please also update the nightly versions below
-    'tensorboard ~= 2.6',
-    'tensorflow_estimator ~= 2.6',
-    'keras ~= 2.6',
+    # Kerase ~= installs 2.8
+    'tensorboard == 2.6',
+    'tensorflow_estimator == 2.6',
+    'keras == 2.6',
 ]
 
 


### PR DESCRIPTION
Resolving issues with setup. Keras, tensorboard and tensorflow-estimator installing 2.8 and not 2.6.x.