### PR TITLE
[DO NOT MERGE] Enable the use of rocsolver_Xpotrm_batched for the cholesky op in XLA.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cusolver_context.cc
+++ b/tensorflow/compiler/xla/service/gpu/cusolver_context.cc
@@ -394,8 +394,10 @@ Status GpuSolverContext::Potrf(se::blas::UpperLower uplo, int n,
       handle(), GpuBlasUpperLower(uplo), n, ToDevicePointer(as), lda, \
       ToDevicePointer(lapack_info), batch_size));
 #else
-#define CALL_POTRF_BATCHED(T, suffix_lower, suffix_upper) \
-  Unimplemented("potrf_batched not implemented on rocm");
+#define CALL_POTRF_BATCHED(T, suffix_lower, suffix_upper)                  \
+  ConvertStatus(tensorflow::wrap::rocsolver_##suffix_lower##potrf_batched( \
+      handle(), GpuBlasUpperLower(uplo), n, ToDevicePointer(as), lda,      \
+      ToDevicePointer(lapack_info), batch_size));
 #endif
 
 Status GpuSolverContext::PotrfBatched(se::blas::UpperLower uplo, int n,

--- a/tensorflow/compiler/xla/service/gpu/cusolver_context.h
+++ b/tensorflow/compiler/xla/service/gpu/cusolver_context.h
@@ -50,11 +50,7 @@ class GpuSolverContext {
   GpuSolverContext& operator=(GpuSolverContext&&);
 
   bool SupportsPotrfBatched() const {
-#if defined(TENSORFLOW_USE_ROCM)
-    return false;
-#else
     return true;
-#endif
   }
 
   // Computes the Cholesky factorization A = L * L^T for a single matrix.


### PR DESCRIPTION
The CUDA implementation uses a custom precompiled PTX kernel to map the a-data into an array pointers that can be consumed by the batched potrm op.

This will (obviously) not work for ROCm.

Instead, create a buffer on the host with the mapped pointers and copy this to the device prior to calling the batched potrm op.