### PR TITLE
Disabling the 2 tests in the CPU unit-test suite

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -48,3 +48,5 @@ bazel test \
       -//tensorflow/java/... \
       -//tensorflow/lite/... \
       -//tensorflow/c/eager:c_api_distributed_test \
+      -//tensorflow/python/data/experimental/kernel_tests/service:local_workers_test \
+      -//tensorflow/python/data/experimental/kernel_tests/service:worker_tags_test \


### PR DESCRIPTION
The following two tests are TIMEOUT on some CI test nodes (ones with 128 or more cores, I think)

```
//tensorflow/python/data/experimental/kernel_tests/service:local_workers_test   TIMEOUT in 3 out of 3 in 900.4s
//tensorflow/python/data/experimental/kernel_tests/service:worker_tags_test     TIMEOUT in 3 out of 3 in 902.7s

```

The symptom we see is that those test actually finish all the subtests (well before 900s...typically under 200s), but fail to exit once the subtests are done, thus resulting in the TIMEOUT. There are a couple of subtests that are failing (because the expected assertion is not raised), and that seems to be somehow related to the hang at the end. If I disable those failing subtests, and rerun the test, it PASSes withou any problem.

There is no point in chasing down the cause of the error, because this is not a ROCm issue, and hence very likely to discovered and fixed in the upstream repo. So just removing those two test from testuite for now.