### PR TITLE
[ROCm] Fix batched triangularSolve in XLA

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -405,7 +405,6 @@ tf_xla_py_test(
     enable_mlir_bridge = True,
     python_version = "PY3",
     tags = [
-	"no_rocm",
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
         "noasan",
         "nomsan",
@@ -429,7 +428,6 @@ tf_xla_py_test(
     enable_mlir_bridge = True,
     python_version = "PY3",
     tags = [
-	"no_rocm",
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
     ],
     deps = [
@@ -449,7 +447,6 @@ tf_xla_py_test(
     enable_mlir_bridge = True,
     python_version = "PY3",
     tags = [
-	"no_rocm",
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
         "optonly",
     ],

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1824,6 +1824,7 @@ cc_library(
         ":reduction_layout_normalizer",
         ":target_constants",
         ":tree_reduction_rewriter",
+	":triangular_solve_rewriter",
         "//tensorflow/compiler/xla:statusor",
         "//tensorflow/compiler/xla/service:algebraic_simplifier",
         "//tensorflow/compiler/xla/service:call_inliner",

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/reduction_layout_normalizer.h"
 #include "tensorflow/compiler/xla/service/gpu/target_constants.h"
 #include "tensorflow/compiler/xla/service/gpu/tree_reduction_rewriter.h"
+#include "tensorflow/compiler/xla/service/gpu/triangular_solve_rewriter.h"
 #include "tensorflow/compiler/xla/service/hlo_constant_folding.h"
 #include "tensorflow/compiler/xla/service/hlo_cse.h"
 #include "tensorflow/compiler/xla/service/hlo_pass_fix.h"
@@ -110,6 +111,27 @@ Status AMDGPUCompiler::OptimizeHloConvolutionCanonicalization(
 
   pipeline.AddPass<HloConstantFolding>();
   TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
+
+  return Status::OK();
+}
+
+Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
+    HloModule* hlo_module, se::StreamExecutor* stream_exec,
+    se::DeviceMemoryAllocator* device_allocator) {
+
+  TF_RETURN_IF_ERROR(GpuCompiler::OptimizeHloPostLayoutAssignment(
+      hlo_module, stream_exec, device_allocator));
+
+  HloPassPipeline post_pipeline("AMDGPU post-layout_assignment");
+
+  // BEF-mode GpuExecutable allocates temp memory, and so the custom-call
+  // implementation for TriangularSolve is not needed.
+#if !BEF_EXECUTABLE
+  // Transform TriangularSolve ops into custom-calls, so we can add temp memory.
+  post_pipeline.AddPass<TriangularSolveRewriter>();
+#endif
+
+  TF_RETURN_IF_ERROR(post_pipeline.Run(hlo_module).status());
 
   return Status::OK();
 }

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
@@ -37,6 +37,10 @@ class AMDGPUCompiler : public GpuCompiler {
       HloModule* hlo_module, se::StreamExecutor* stream_exec,
       se::DeviceMemoryAllocator* device_allocator) override;
 
+  Status OptimizeHloPostLayoutAssignment(
+      HloModule* hlo_module, se::StreamExecutor* stream_exec,
+      se::DeviceMemoryAllocator* device_allocator) override;
+
   GpuVersion GetGpuVersion(se::StreamExecutor* stream_exec) override;
 
   StatusOr<std::pair<std::string, std::vector<uint8_t>>> CompileTargetBinary(

--- a/tensorflow/stream_executor/rocm/rocblas_wrapper.h
+++ b/tensorflow/stream_executor/rocm/rocblas_wrapper.h
@@ -257,6 +257,10 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
   __macro(rocblas_zgemm_strided_batched)        \
   __macro(rocblas_gemm_ex)                      \
   __macro(rocblas_gemm_strided_batched_ex)      \
+  __macro(rocblas_strsm_batched)                \
+  __macro(rocblas_dtrsm_batched)                \
+  __macro(rocblas_ctrsm_batched)                \
+  __macro(rocblas_ztrsm_batched)                \
   __macro(rocblas_create_handle)                \
   __macro(rocblas_destroy_handle)               \
   __macro(rocblas_set_stream)

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -2324,8 +2324,11 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  float alpha, const DeviceMemory<float *> &as,
                                  int lda, DeviceMemory<float *> *bs, int ldb,
                                  int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(wrap::rocblas_strsm_batched, stream,
+                        true /* = pointer_mode_host */, ROCMBlasSide(side),
+                        ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+                        ROCMBlasDiagonal(diag), m, n, &alpha, GpuMemory(as),
+                        lda, GpuMemoryMutable(bs), ldb, batch_count);
 }
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
@@ -2334,8 +2337,11 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  double alpha, const DeviceMemory<double *> &as,
                                  int lda, DeviceMemory<double *> *bs, int ldb,
                                  int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(wrap::rocblas_dtrsm_batched, stream,
+                        true /* = pointer_mode_host */, ROCMBlasSide(side),
+                        ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+                        ROCMBlasDiagonal(diag), m, n, &alpha, GpuMemory(as),
+                        lda, GpuMemoryMutable(bs), ldb, batch_count);
 }
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
@@ -2346,8 +2352,12 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  int lda,
                                  DeviceMemory<std::complex<float> *> *bs,
                                  int ldb, int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(
+      wrap::rocblas_ctrsm_batched, stream, true /* = pointer_mode_host */,
+      ROCMBlasSide(side), ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+      ROCMBlasDiagonal(diag), m, n, complex_cast(alpha),
+      static_cast<const rocblas_float_complex * const *>(as.opaque()), lda,
+      static_cast<rocblas_float_complex * const *>(bs->opaque()), ldb, batch_count);
 }
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
@@ -2358,8 +2368,12 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  int lda,
                                  DeviceMemory<std::complex<double> *> *bs,
                                  int ldb, int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(
+      wrap::rocblas_ztrsm_batched, stream, true /* = pointer_mode_host */,
+      ROCMBlasSide(side), ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+      ROCMBlasDiagonal(diag), m, n, complex_cast(alpha),
+      static_cast<const rocblas_double_complex * const *>(as.opaque()), lda, 
+      static_cast<rocblas_double_complex * const *>(bs->opaque()), ldb, batch_count);
 }
 
 port::Status ROCMBlas::DoBlasGemmStridedBatched(


### PR DESCRIPTION
This PR fixes the TriangularSolve Unit tests. This is accomplished by:
- Adding the interfaces to the appropriate rocBlas calls for the trsm_batched routines.
- Adding a post layout pass in the amdcompiler for XLA for the triangularSolver rewritter
- Enabling the unit tests by removing the `no_rocm` tags.

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1056