### PR TITLE
Updating `//tensorflow/python/distribute:distributed_table_test` to have TF_NUM_INTEROP_THREADS=16

### DIFF
--- a/tensorflow/python/distribute/distributed_table_test.py
+++ b/tensorflow/python/distribute/distributed_table_test.py
@@ -18,6 +18,8 @@
 import copy
 import os
 
+os.environ["TF_NUM_INTEROP_THREADS"]="16"
+
 from absl.testing import parameterized
 
 from tensorflow.python.compat import v2_compat


### PR DESCRIPTION

This is the same issue as an earlier one fixed by this commit - https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/a6c10b4e7e572f2218d2cba91f41580e97559251

We see the following error in the `//tensorflow/python/distribute:distributed_table_test` test (when run on nodes with high core count -- 128 or more)

```
...
2022-02-28 17:55:43.662268: F tensorflow/core/platform/default/env.cc:73] Check failed: ret == 0 (11 vs. 0)Thread tf_Compute creation via pthread_create() failed.
Fatal Python error: 2022-02-28 17:55:43.662299: F tensorflow/core/platform/default/env.cc:73] Check failed: ret == 0 (11 vs. 0)Thread tf_Compute creation via pthread_create() failed.
Aborted
...
```

The number of threads created by TF is proportional to the number of CPU cores on the node, and for nodes with high core counts, this can result in creation more threads than the OS can handle. See the commit message for the commit listed above for more setails.

This commit uses the `TF_NUM_INTEROP_THREADS` env var to limit the number of threads created by TF, enabling the test to pass