### PR TITLE
Adding a `rocm_compute_capacbility` field to the `DeviceDescription` class

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/tf_framework_c_interface.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/tf_framework_c_interface.cc
@@ -264,11 +264,9 @@ extern "C" void* _mlir_ciface_tf_jit_compile(
       ctx->op_device_context()->stream()->GetCudaComputeCapability();
   architectures.push_back(absl::StrCat("sm_", cc.major, cc.minor));
 #elif defined(TENSORFLOW_USE_ROCM)
-  architectures.push_back(ctx->op_device_context()
-                              ->stream()
-                              ->parent()
-                              ->GetDeviceDescription()
-                              .rocm_amdgpu_gcn_arch_name());
+  stream_executor::RocmComputeCapability cc =
+      ctx->op_device_context()->stream()->GetRocmComputeCapability();
+  architectures.push_back(cc.gcn_arch_name());
 #endif
 
   // Construct `SmallVector`s from arguments.

--- a/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/transforms/gpu_kernel_to_blob_pass.cc
@@ -108,9 +108,10 @@ class GpuKernelToBlobPass
       }
       std::string libdevice_dir = tensorflow::RocdlRoot();
       auto llvm_module_copy = llvm::CloneModule(*llvmModule);
-      xla::gpu::GpuVersion gpu_version{arch_str};
       auto hsaco_or = xla::gpu::amdgpu::CompileToHsaco(
-          llvm_module_copy.get(), gpu_version, config, libdevice_dir);
+          llvm_module_copy.get(),
+          tensorflow::se::RocmComputeCapability{arch_str}, config,
+          libdevice_dir);
       if (!hsaco_or.ok()) {
         return tensorflow::errors::Internal("Failure when generating HSACO");
       }

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -141,8 +141,9 @@ AMDGPUCompiler::AMDGPUCompiler()
                   amdgpu::TargetTriple(), amdgpu::DataLayout()) {}
 
 GpuVersion AMDGPUCompiler::GetGpuVersion(se::StreamExecutor* stream_exec) {
-  std::string gcn_arch_name =
-      stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+  std::string gcn_arch_name = stream_exec->GetDeviceDescription()
+                                  .rocm_compute_capability()
+                                  .gcn_arch_name();
   if (gcn_arch_name == stream_exec->GetDeviceDescription().kUndefinedString) {
     LOG(WARNING) << "Couldn't get AMDGPU GCN Arch for device; assuming gfx900.";
     gcn_arch_name = "gfx900";

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -141,15 +141,7 @@ AMDGPUCompiler::AMDGPUCompiler()
                   amdgpu::TargetTriple(), amdgpu::DataLayout()) {}
 
 GpuVersion AMDGPUCompiler::GetGpuVersion(se::StreamExecutor* stream_exec) {
-  std::string gcn_arch_name = stream_exec->GetDeviceDescription()
-                                  .rocm_compute_capability()
-                                  .gcn_arch_name();
-  if (gcn_arch_name == stream_exec->GetDeviceDescription().kUndefinedString) {
-    LOG(WARNING) << "Couldn't get AMDGPU GCN Arch for device; assuming gfx900.";
-    gcn_arch_name = "gfx900";
-  }
-
-  return gcn_arch_name;
+  return stream_exec->GetDeviceDescription().rocm_compute_capability();
 }
 
 StatusOr<std::pair<std::string, std::vector<uint8_t>>>

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -239,9 +239,9 @@ class GpuBfloat16Support : public BFloat16Support {
                  .IsAtLeast(se::CudaComputeCapability::AMPERE);
     }
 #elif TENSORFLOW_USE_ROCM && TF_ROCM_VERSION>=50000
-    auto amd_gcn = stream_exec_->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
-    return ((amd_gcn.find("gfx908") != std::string::npos) ||
-	    (amd_gcn.find("gfx90a") != std::string::npos));
+    auto rocm_compute_capability =
+        stream_exec_->GetDeviceDescription().rocm_compute_capability();
+    return rocm_compute_capability.has_bf16_dtype_support();
 #endif
     return false;
   }
@@ -1242,8 +1242,9 @@ StatusOr<std::unique_ptr<Executable>> GpuCompiler::RunBackend(
 
   GpuDeviceInfo gpu_device_info = GetGpuDeviceInfo(stream_exec);
 
-  std::string amdgpu_arch =
-      stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+  std::string amdgpu_arch = stream_exec->GetDeviceDescription()
+                                .rocm_compute_capability()
+                                .gcn_arch_name();
 
   if (module->config().hlo_profiling_enabled() || VLOG_IS_ON(1)) {
     HloCostAnalysis::Options options{ShapeSizeBytesFunction()};

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.h
@@ -179,7 +179,7 @@ StatusOr<std::unique_ptr<llvm::Module>> CompileModuleToLlvmIr(
     const std::string& platform_name, const se::Platform::Id platform_id,
     GpuDeviceInfo gpu_device_info,
     se::CudaComputeCapability cuda_compute_capability,
-    std::string amdgpu_arch, int pointer_size);
+    se::RocmComputeCapability rocm_compute_capability, int pointer_size);
 
 // Compiles the given LMHLO module to an executable.
 // ir_emitter_context should be partially populated: buffer_assignment

--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -293,7 +293,8 @@ Status GpuExecutable::CheckCompatibilityWithServiceExecutableRunOptions(
   if (platform_kind == stream_executor::PlatformKind::kROCm) {
     std::string stream_arch = main_stream->parent()
                                   ->GetDeviceDescription()
-                                  .rocm_amdgpu_gcn_arch_name();
+                                  .rocm_compute_capability()
+                                  .gcn_arch_name();
     std::string gpu_exec_arch = absl::get<std::string>(gpu_version_);
     TF_RET_CHECK(stream_arch == gpu_exec_arch)
         << "AMDGPU GCN ISA version mismatch; expected {" << gpu_exec_arch

--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -291,11 +291,10 @@ Status GpuExecutable::CheckCompatibilityWithServiceExecutableRunOptions(
   stream_executor::PlatformKind platform_kind =
       main_stream->parent()->platform_kind();
   if (platform_kind == stream_executor::PlatformKind::kROCm) {
-    std::string stream_arch = main_stream->parent()
-                                  ->GetDeviceDescription()
-                                  .rocm_compute_capability()
-                                  .gcn_arch_name();
-    std::string gpu_exec_arch = absl::get<std::string>(gpu_version_);
+    auto cc = main_stream->GetRocmComputeCapability();
+    std::string stream_arch = cc.gcn_arch_name();
+    std::string gpu_exec_arch =
+        absl::get<se::RocmComputeCapability>(gpu_version_).gcn_arch_name();
     TF_RET_CHECK(stream_arch == gpu_exec_arch)
         << "AMDGPU GCN ISA version mismatch; expected {" << gpu_exec_arch
         << ", but was " << stream_arch;

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
@@ -111,16 +111,14 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
     return kAllNCHW;
   }
 #elif TENSORFLOW_USE_ROCM
-  auto amd_gcn = stream_executor->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
   bool is_enabled = false;
   TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar(
       "TF_USE_ROCM_NHWC",
       /*default_val=*/false, &is_enabled));
-  if (input_ty != F16 ||
-        (amd_gcn.find("gfx908") == std::string::npos &&
-         amd_gcn.find("gfx90a") == std::string::npos) ||
-      instr->shape().tuple_shapes(0).dimensions_size() != 4 ||
-      !is_enabled) {
+  auto rocm_compute_capability =
+      stream_executor->GetDeviceDescription().rocm_compute_capability();
+  if (input_ty != F16 || (!rocm_compute_capability.has_nhwc_layout_support()) ||
+      instr->shape().tuple_shapes(0).dimensions_size() != 4 || !is_enabled) {
     return kAllNCHW;
   }
 #endif

--- a/tensorflow/compiler/xla/service/gpu/gpu_types.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_types.h
@@ -30,11 +30,9 @@ namespace gpu {
 //
 // On Cuda platform, it comprises of se::CudaComputeCapability.
 //
-// On ROCm platform, the string has the contents of the
-// hipDeviceProp_t::gcnArchName field.
-// The string contains all the information needed to create an exact LLVM
-// AMDGPUTarget corresponding the AMDGPU device it represents.
-using GpuVersion = absl::variant<se::CudaComputeCapability, std::string>;
+// On ROCm platform, it comprises of se::RocmComputeCapability.
+using GpuVersion =
+    absl::variant<se::CudaComputeCapability, se::RocmComputeCapability>;
 }  // namespace gpu
 }  // namespace xla
 

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -233,9 +233,10 @@ bool IrEmitter::MaybeEmitDirectAtomicOperation(
     }
 
     if (IsEmittingForAMDGPU() &&
-        (element_type == F32
-        || (element_type == F16 && ir_emitter_context_->amdgpu_arch().substr(0,6)=="gfx90a"))
-        ) /* is atomic add supported? */ {
+        (element_type == F32 ||
+         (element_type == F16 &&
+          ir_emitter_context_->rocm_compute_capability()
+              .has_fp16_atomics_support()))) /* is atomic add supported? */ {
       EmitAMDGPUAtomicAdd(output_address, source);
       return true;
     }

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_context.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_context.h
@@ -40,14 +40,14 @@ class IrEmitterContext {
                    const BufferAssignment* buffer_assignment,
                    std::string platform_name, GpuDeviceInfo gpu_device_info,
                    se::CudaComputeCapability cuda_compute_capability,
-                   std::string amdgpu_arch,
+                   se::RocmComputeCapability rocm_compute_capability,
                    mlir::MLIRContext* mlir_context, llvm::Module* llvm_module)
       : hlo_module_(hlo_module),
         buffer_assignment_(buffer_assignment),
         platform_name_(std::move(platform_name)),
         gpu_device_info_(gpu_device_info),
         cuda_compute_capability_(cuda_compute_capability),
-        amdgpu_arch_(amdgpu_arch),
+        rocm_compute_capability_(rocm_compute_capability),
         mlir_context_(mlir_context),
         llvm_module_(llvm_module) {}
   // Disallow copy and assign.
@@ -64,8 +64,8 @@ class IrEmitterContext {
   se::CudaComputeCapability cuda_compute_capability() const {
     return cuda_compute_capability_;
   }
-  std::string amdgpu_arch() const {
-    return amdgpu_arch_;
+  se::RocmComputeCapability rocm_compute_capability() const {
+    return rocm_compute_capability_;
   }
   mlir::MLIRContext* mlir_context() { return mlir_context_; }
   llvm::Module* llvm_module() { return llvm_module_; }
@@ -92,7 +92,7 @@ class IrEmitterContext {
   std::string platform_name_;
   GpuDeviceInfo gpu_device_info_;
   se::CudaComputeCapability cuda_compute_capability_;
-  std::string amdgpu_arch_;
+  se::RocmComputeCapability rocm_compute_capability_;
   mlir::MLIRContext* mlir_context_;
   llvm::Module* llvm_module_;
   NameUniquer name_uniquer_;

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -579,7 +579,7 @@ StatusOr<std::string> CompileToPtx(
 namespace {
 
 // Gets the ROCm-Device-Libs filenames for a particular AMDGPU version.
-std::vector<std::string> GetROCDLPaths(std::string amdgpu_version,
+std::vector<std::string> GetROCDLPaths(std::string gcn_arch_name,
                                        const std::string& rocdl_dir_path) {
   // AMDGPU version-neutral bitcodes.
   static std::vector<std::string>* rocdl_filenames =
@@ -596,7 +596,8 @@ std::vector<std::string> GetROCDLPaths(std::string amdgpu_version,
   }
 
   // Add AMDGPU version-specific bitcodes.
-  std::vector<std::string> tokens = absl::StrSplit(amdgpu_version, ':');
+  std::vector<std::string> tokens = absl::StrSplit(gcn_arch_name, ':');
+  std::string amdgpu_version = gcn_arch_name;
   if (!tokens.empty() && tokens[0].size() >= 3) {
     amdgpu_version = tokens[0].substr(3);
   }
@@ -777,27 +778,30 @@ StatusOr<std::vector<uint8_t>> EmitModuleToHsaco(
 }
 
 // Links ROCm-Device-Libs into the given module if the module needs it.
-Status LinkROCDLIfNecessary(llvm::Module* module, std::string amdgpu_version,
+Status LinkROCDLIfNecessary(llvm::Module* module, std::string gcn_arch_name,
                             const std::string& rocdl_dir_path) {
   if (!CouldNeedDeviceBitcode(*module)) {
     return Status::OK();
   }
 
   return LinkWithBitcodeVector(module,
-                               GetROCDLPaths(amdgpu_version, rocdl_dir_path));
+                               GetROCDLPaths(gcn_arch_name, rocdl_dir_path));
 }
 
 Status AMDGPUTargetModuleLinker(llvm::Module* module, GpuVersion gpu_version,
                                 const HloModuleConfig& hlo_module_config,
                                 const std::string& device_bitcode_dir_path) {
   // Link the input module with ROCDL.
-  auto amdgpu_version = absl::get_if<std::string>(&gpu_version);
-  if (!amdgpu_version) {
-    return xla::InternalError(
-        "Incompatible AMD GCN ISA version was specified.");
+
+  auto compute_capability =
+      absl::get_if<se::RocmComputeCapability>(&gpu_version);
+  if (!compute_capability) {
+    return xla::InternalError("Incompatible compute capability was specified.");
   }
+
+  std::string gcn_arch_name = compute_capability->gcn_arch_name();
   TF_RETURN_IF_ERROR(
-      LinkROCDLIfNecessary(module, *amdgpu_version, device_bitcode_dir_path));
+      LinkROCDLIfNecessary(module, gcn_arch_name, device_bitcode_dir_path));
 
   // For rocm, we always enable flush to zero. (for cuda, this is determined
   // via environemnt variables). This deceision was based on the observation
@@ -868,8 +872,10 @@ std::pair<std::string, std::string> GetFeatureStrFromGCNArchName(
 std::unique_ptr<llvm::TargetMachine> AMDGPUGetTargetMachine(
     llvm::Triple target_triple, GpuVersion gpu_version,
     const HloModuleConfig& hlo_module_config) {
-  auto amdgpu_version = absl::get_if<std::string>(&gpu_version);
-  std::string gcn_arch_name = *amdgpu_version;
+  auto compute_capability =
+      absl::get_if<se::RocmComputeCapability>(&gpu_version);
+
+  std::string gcn_arch_name = compute_capability->gcn_arch_name();
   auto arch = GetFeatureStrFromGCNArchName(gcn_arch_name);
   return GetTargetMachine(std::move(target_triple), arch.first,
                           hlo_module_config, arch.second);
@@ -926,13 +932,16 @@ StatusOr<std::vector<uint8_t>> CompileToHsaco(
         tensorflow::profiler::TraceMeLevel::kInfo);
     XLA_SCOPED_LOGGING_TIMER("Compile module " + module->getName().str());
 
-    auto amdgpu_version = absl::get_if<std::string>(&gpu_version);
-    if (!amdgpu_version) {
+    auto compute_capability = absl::get_if<se::RocmComputeCapability>(&gpu_version);
+    if (!compute_capability) {
       return xla::InternalError(
-          "Incompatible AMD GCN ISA version was specified.");
+          "Incompatible compute capability was specified.");
     }
+
+    std::string gcn_arch_name = compute_capability->gcn_arch_name();
+
     uint64_t hash;
-    if (HsacoCache::Find(str, hash, *amdgpu_version, hsaco)) {
+    if (HsacoCache::Find(str, hash, gcn_arch_name, hsaco)) {
       VLOG(1) << "HSACO cache hit";
       return hsaco;
     }
@@ -961,7 +970,7 @@ StatusOr<std::vector<uint8_t>> CompileToHsaco(
 
     // Lower optimized LLVM module to HSA code object.
     TF_ASSIGN_OR_RETURN(hsaco, EmitModuleToHsaco(module, target_machine.get()));
-    HsacoCache::Add(str, hash, *amdgpu_version, hsaco);
+    HsacoCache::Add(str, hash, gcn_arch_name, hsaco);
   }
   return hsaco;
 }

--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
@@ -55,15 +55,11 @@ StatusOr<std::unique_ptr<Executable>> MlirGpuTestBase::CompileMlirModule(
   se::StreamExecutor* stream_exec = stream->parent();
   GpuDeviceInfo gpu_device_info = GetGpuDeviceInfo(stream_exec);
 
-  std::string amdgpu_arch = stream_exec->GetDeviceDescription()
-                                .rocm_compute_capability()
-                                .gcn_arch_name();
-
   IrEmitterContext ir_emitter_context(
       /*hlo_module=*/nullptr, /*buffer_assignment=*/nullptr,
       backend_->platform()->Name(), gpu_device_info,
       stream_exec->GetDeviceDescription().cuda_compute_capability(),
-      amdgpu_arch,
+      stream_exec->GetDeviceDescription().rocm_compute_capability(),
       /*mlir_context=*/nullptr, llvm_module.get());
 
   HloModuleConfig module_config;

--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
@@ -55,8 +55,9 @@ StatusOr<std::unique_ptr<Executable>> MlirGpuTestBase::CompileMlirModule(
   se::StreamExecutor* stream_exec = stream->parent();
   GpuDeviceInfo gpu_device_info = GetGpuDeviceInfo(stream_exec);
 
-  std::string amdgpu_arch =
-      stream_exec->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+  std::string amdgpu_arch = stream_exec->GetDeviceDescription()
+                                .rocm_compute_capability()
+                                .gcn_arch_name();
 
   IrEmitterContext ir_emitter_context(
       /*hlo_module=*/nullptr, /*buffer_assignment=*/nullptr,

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -37,9 +37,6 @@ namespace xla {
 constexpr int kMinCudaComputeCapabilityMajor = 3;
 constexpr int kMinCudaComputeCapabilityMinor = 5;
 
-// Minimum supported AMDGPU ISA version is 803.
-constexpr int kMinAMDGPUISAVersion = 803;
-
 // The name of the interpreter platform.
 constexpr char kInterpreter[] = "interpreter";
 
@@ -143,16 +140,14 @@ static bool IsDeviceSupported(se::StreamExecutor* executor) {
       return false;
     }
   } else if (executor->platform()->id() == se::rocm::kROCmPlatformId) {
-    int isa_version = 0;
-    if (description.rocm_amdgpu_isa_version(&isa_version)) {
-      if (isa_version < kMinAMDGPUISAVersion) {
-        LOG(INFO) << "StreamExecutor ROCM device ("
-                  << executor->device_ordinal() << ") is of "
-                  << "obsolete AMDGPU ISA version: "
-                  << "gfx" << kMinAMDGPUISAVersion << " required, "
-                  << "device is gfx" << isa_version;
-        return false;
-      }
+    auto rocm_compute_capability = description.rocm_compute_capability();
+    if (!rocm_compute_capability.is_supported_gfx_version()) {
+      LOG(INFO) << "StreamExecutor ROCM device (" << executor->device_ordinal()
+                << ") is of unsupported "
+                << "AMDGPU version : " << rocm_compute_capability.gfx_version()
+                << ". The supported AMDGPU versions are "
+                << rocm_compute_capability.supported_gfx_versions_str() << ".";
+      return false;
     }
   }
   return true;

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1820,7 +1820,8 @@ Status BaseGPUDeviceFactory::GetValidDeviceIds(
             << strings::HumanReadableNumBytes(description->memory_bandwidth())
             << "/s";
 #elif TENSORFLOW_USE_ROCM
-    std::string gcn_arch_name = description->rocm_amdgpu_gcn_arch_name();
+    std::string gcn_arch_name =
+        description->rocm_compute_capability().gcn_arch_name();
     VLOG(1) << "Found device " << i << " with properties: "
             << "\npciBusID: " << description->pci_bus_id()
             << " name: " << description->name()

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -81,10 +81,8 @@ typedef Eigen::GpuDevice GPUDevice;
 bool UseNhwcLayoutForConvOnRocm(se::Stream* stream) {
 #if TENSORFLOW_USE_ROCM
    bool is_enabled = se::gpu::UseNhwcLayoutForRocm();
-   auto arch_name = stream->GetGcnArchName();
-   return (arch_name.find("gfx908") != std::string::npos  ||
-           arch_name.find("gfx90a") != std::string::npos) &&
-           is_enabled; 
+   auto rocm_compute_capability = stream->GetRocmComputeCapability();
+   return (is_enabled && rocm_compute_capability.has_nhwc_layout_support());
 #else
    return false;
 #endif

--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -199,17 +199,15 @@ Status LaunchAutotunedConv(const AutotuneEntry<se::dnn::ConvOp>& autotune_entry,
   }
 }
 
-bool UseNhwcLayoutForConvOnRocm(se::Stream* stream);/* {
-#if TENSORFLOW_USE_ROCM
-   bool is_enabled = se::gpu::UseNhwcLayoutForRocm();
-   auto arch_name = stream->GetGcnArchName();
-   return (arch_name.find("gfx908") != std::string::npos  ||
-           arch_name.find("gfx90a") != std::string::npos) &&
-           is_enabled; 
-#else
-   return false;
-#endif
-}*/
+bool UseNhwcLayoutForConvOnRocm(se::Stream* stream); /* {
+ #if TENSORFLOW_USE_ROCM
+    bool is_enabled = se::gpu::UseNhwcLayoutForRocm();
+    auto rocm_compute_capability = stream->GetRocmComputeCapability();
+    return (is_enabled && rocm_compute_capability.has_nhwc_layout_support());
+ #else
+    return false;
+ #endif
+ }*/
 
 }  // namespace tensorflow
 

--- a/tensorflow/stream_executor/BUILD
+++ b/tensorflow/stream_executor/BUILD
@@ -51,6 +51,7 @@ cc_library(
         "//tensorflow/stream_executor/platform",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:variant",
     ],
 )
 

--- a/tensorflow/stream_executor/device_description.cc
+++ b/tensorflow/stream_executor/device_description.cc
@@ -48,7 +48,6 @@ DeviceDescription::DeviceDescription()
       shared_memory_per_core_(kUninitializedUint64),
       shared_memory_per_block_(kUninitializedUint64),
       clock_rate_ghz_(-1.0),
-      rocm_amdgpu_gcn_arch_name_(kUndefinedString),
       numa_node_(-1),
       core_count_(-1),
       ecc_enabled_(false) {}
@@ -92,7 +91,7 @@ std::unique_ptr<std::map<std::string, std::string>> DeviceDescription::ToMap()
 
   result["CUDA Compute Capability"] = cuda_compute_capability().ToString();
 
-  result["AMDGPU GCN Arch Name"] = rocm_amdgpu_gcn_arch_name_;
+  result["AMDGPU GCN Arch Name"] = rocm_compute_capability().gcn_arch_name();
 
   result["NUMA Node"] = absl::StrCat(numa_node());
   result["Core Count"] = absl::StrCat(core_count());

--- a/tensorflow/stream_executor/device_description.cc
+++ b/tensorflow/stream_executor/device_description.cc
@@ -48,7 +48,6 @@ DeviceDescription::DeviceDescription()
       shared_memory_per_core_(kUninitializedUint64),
       shared_memory_per_block_(kUninitializedUint64),
       clock_rate_ghz_(-1.0),
-      rocm_amdgpu_isa_version_(-1),
       rocm_amdgpu_gcn_arch_name_(kUndefinedString),
       numa_node_(-1),
       core_count_(-1),
@@ -114,15 +113,6 @@ CudaComputeCapability DeviceDescription::cuda_compute_capability() const {
 
 RocmComputeCapability DeviceDescription::rocm_compute_capability() const {
   return rocm_compute_capability_;
-}
-
-bool DeviceDescription::rocm_amdgpu_isa_version(int *version) const {
-  bool status = false;
-  if (rocm_amdgpu_isa_version_ > 0) {
-    *version = rocm_amdgpu_isa_version_;
-    status = true;
-  }
-  return status;
 }
 
 bool ThreadDimOk(const DeviceDescription &device_description,

--- a/tensorflow/stream_executor/device_description.cc
+++ b/tensorflow/stream_executor/device_description.cc
@@ -112,6 +112,10 @@ CudaComputeCapability DeviceDescription::cuda_compute_capability() const {
   return cuda_compute_capability_;
 }
 
+RocmComputeCapability DeviceDescription::rocm_compute_capability() const {
+  return rocm_compute_capability_;
+}
+
 bool DeviceDescription::rocm_amdgpu_isa_version(int *version) const {
   bool status = false;
   if (rocm_amdgpu_isa_version_ > 0) {

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -277,11 +277,6 @@ class DeviceDescription {
   // be "gfx000" (which is an invalid gfx arch).
   RocmComputeCapability rocm_compute_capability() const;
 
-  // Returns the AMDGPU ISA version if we're running on the ROCm platform.
-  // If the information is not available, the version is not modified,
-  // and the return value will be false.
-  bool rocm_amdgpu_isa_version(int *version) const;
-
   // Returns the
   // * AMDGPU GCN Architecture Name if we're running on the ROCm platform.
   // * kUndefinedString otherwise
@@ -352,9 +347,6 @@ class DeviceDescription {
 
   // ROCm gfx arch,  "gfx000" if not available.
   RocmComputeCapability rocm_compute_capability_{"gfx000"};
-
-  // ROCM AMDGPU ISA version, 0 if not available.
-  int rocm_amdgpu_isa_version_;
 
   // ROCm AMDGPU GCN Architecture name, "" if not available.
   std::string rocm_amdgpu_gcn_arch_name_;
@@ -449,10 +441,6 @@ class DeviceDescriptionBuilder {
   void set_rocm_compute_capability(std::string gcn_arch_name) {
     device_description_->rocm_compute_capability_ =
         RocmComputeCapability(gcn_arch_name);
-  }
-
-  void set_rocm_amdgpu_isa_version(int version) {
-    device_description_->rocm_amdgpu_isa_version_ = version;
   }
 
   void set_rocm_amdgpu_gcn_arch_name(const std::string &gcn_arch_name) {

--- a/tensorflow/stream_executor/device_description.h
+++ b/tensorflow/stream_executor/device_description.h
@@ -277,13 +277,6 @@ class DeviceDescription {
   // be "gfx000" (which is an invalid gfx arch).
   RocmComputeCapability rocm_compute_capability() const;
 
-  // Returns the
-  // * AMDGPU GCN Architecture Name if we're running on the ROCm platform.
-  // * kUndefinedString otherwise
-  const std::string rocm_amdgpu_gcn_arch_name() const {
-    return rocm_amdgpu_gcn_arch_name_;
-  }
-
   // Returns the maximum amount of shared memory present on a single core
   // (i.e. Streaming Multiprocessor on NVIDIA GPUs; Compute Unit for OpenCL
   // devices). Note that some devices, such as NVIDIA's have a configurable
@@ -347,9 +340,6 @@ class DeviceDescription {
 
   // ROCm gfx arch,  "gfx000" if not available.
   RocmComputeCapability rocm_compute_capability_{"gfx000"};
-
-  // ROCm AMDGPU GCN Architecture name, "" if not available.
-  std::string rocm_amdgpu_gcn_arch_name_;
 
   int numa_node_;
   int core_count_;
@@ -441,10 +431,6 @@ class DeviceDescriptionBuilder {
   void set_rocm_compute_capability(std::string gcn_arch_name) {
     device_description_->rocm_compute_capability_ =
         RocmComputeCapability(gcn_arch_name);
-  }
-
-  void set_rocm_amdgpu_gcn_arch_name(const std::string &gcn_arch_name) {
-    device_description_->rocm_amdgpu_gcn_arch_name_ = gcn_arch_name;
   }
 
   void set_numa_node(int value) { device_description_->numa_node_ = value; }

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -950,7 +950,6 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
 
   builder.set_device_vendor("Advanced Micro Devices, Inc");
   builder.set_rocm_compute_capability(gcn_arch_name);
-  builder.set_rocm_amdgpu_gcn_arch_name(gcn_arch_name);
 
   builder.set_shared_memory_per_core(
       GpuDriver::GetMaxSharedMemoryPerCore(device).ValueOrDie());

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -950,7 +950,6 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
 
   builder.set_device_vendor("Advanced Micro Devices, Inc");
   builder.set_rocm_compute_capability(gcn_arch_name);
-  builder.set_rocm_amdgpu_isa_version(version);
   builder.set_rocm_amdgpu_gcn_arch_name(gcn_arch_name);
 
   builder.set_shared_memory_per_core(

--- a/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/stream_executor/rocm/rocm_gpu_executor.cc
@@ -949,6 +949,7 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
   builder.set_device_address_bits(64);
 
   builder.set_device_vendor("Advanced Micro Devices, Inc");
+  builder.set_rocm_compute_capability(gcn_arch_name);
   builder.set_rocm_amdgpu_isa_version(version);
   builder.set_rocm_amdgpu_gcn_arch_name(gcn_arch_name);
 

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -2128,8 +2128,8 @@ class Stream {
     return parent()->GetDeviceDescription().cuda_compute_capability();
   }
 
-  std::string GetGcnArchName() const {
-    return parent()->GetDeviceDescription().rocm_amdgpu_gcn_arch_name();
+  RocmComputeCapability GetRocmComputeCapability() const {
+    return parent()->GetDeviceDescription().rocm_compute_capability();
   }
   // Returns the (internal usage) temporary-memory-allocation manager associated
   // with this stream.

--- a/tensorflow/stream_executor/tpu/c_api_decl.h
+++ b/tensorflow/stream_executor/tpu/c_api_decl.h
@@ -150,7 +150,6 @@ typedef struct SE_DeviceDescription {
   int cuda_compute_capability_major;
   int cuda_compute_capability_minor;
 
-  int rocm_amdgpu_isa_version;
   char* rocm_amdgpu_gcn_arch_name;
 
   int numa_node;

--- a/tensorflow/stream_executor/tpu/c_api_decl.h
+++ b/tensorflow/stream_executor/tpu/c_api_decl.h
@@ -150,8 +150,6 @@ typedef struct SE_DeviceDescription {
   int cuda_compute_capability_major;
   int cuda_compute_capability_minor;
 
-  char* rocm_amdgpu_gcn_arch_name;
-
   int numa_node;
   int core_count;
   bool ecc_enabled;


### PR DESCRIPTION
Currently, in the `DeviceDeescription` class,  we store the
* `rocm_amdgpu_isa_version` as an int member
* `rocm_amdgpu_gcn_arch_name` as a string member

The `rocm_amdgpu_isa_version` int member usage, which stores integer suffix in the gfx arch (i.e 900 from "gfx900") is already flawed with the introduction of "gfx90a", and needs to dropped

The `rocm_amdgpu_gcn_arch_name` string usages needs to be updated, to make it similar to what is done on the CUDA side.

This PR
* introduces a class `RocmComputeCapability`, that wraps the `gcn_arch_name` routine and provides helpers functions to do all the `gcn_arch_name` based checks, that are currently dispersed in the TF code.
* adds an instance of the `RocmCompuateCapability` class, `rocm_compute_capability`, as a member of `DeviceDescription`
* removes the `rocm_amdgpu_isa_version` and `rocm_amdgpu_gcn_arch_name` members from the `DeviceDescription` class and replaces their usage with `rocm_compute_capability` instead
* replaces references to `amdgpu_arch` string (in XLA code), with references to `rocm_compute_capability` instead