### PR TITLE
[DO NOT MERGE] Enable convolution_test_cudnn_frontend_disabled test for ROCm.

### DIFF
--- a/tensorflow/compiler/xla/tests/BUILD
+++ b/tensorflow/compiler/xla/tests/BUILD
@@ -1285,7 +1285,6 @@ xla_test(
     backends = ["gpu"],
     shard_count = 50,
     tags = [
-        "no_rocm",
         "nozapfhahn",
         "optonly",
     ],


### PR DESCRIPTION
This test was most likely added for TFRT BEF reasons.

It was initially specified with a no_rocm tag but after discovering that it actually works on ROCm, the no_rocm tag was removed in this PR.

/cc @deven-amd 