### PR TITLE
mark nightly whls as nightly

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -634,9 +634,12 @@ if [[ "$IS_NIGHTLY" == 1 ]]; then
   # If 'nightly' is not specified in the project name already, then add.
   if ! [[ $PROJECT_NAME == *"nightly"* ]]; then
     echo "WARNING: IS_NIGHTLY=${IS_NIGHTLY} but requested project name \
-    (PROJECT_NAME=${PROJECT_NAME}) does not include 'nightly' string. \
-    Renaming it to 'tf_nightly'."
+    (PROJECT_NAME=${PROJECT_NAME}) does not include 'nightly' string."
     PROJECT_NAME="tf_nightly"
+    if [[ ${CONTAINER_TYPE} == "rocm" ]]; then
+      PROJECT_NAME="${PROJECT_NAME}_rocm"
+    fi
+    echo "Renaming it to '${PROJECT_NAME}'."
   fi
   NIGHTLY_FLAG="--nightly_flag"
 fi

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py37_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py37_pip.sh
@@ -60,7 +60,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --keep_going "
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} -//tensorflow/lite/... "
 export TF_PIP_TESTS="test_pip_virtualenv_non_clean test_pip_virtualenv_clean"
-export IS_NIGHTLY=0 # Not nightly; uncomment if building from tf repo.
+export IS_NIGHTLY="${IS_NIGHTLY}:=0"
 export TF_PROJECT_NAME="tensorflow_rocm"  # single pip package!
 export TF_PIP_TEST_ROOT="pip_test"
 

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py38_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py38_pip.sh
@@ -60,7 +60,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --keep_going "
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} -//tensorflow/lite/... "
 export TF_PIP_TESTS="test_pip_virtualenv_non_clean test_pip_virtualenv_clean"
-export IS_NIGHTLY=0 # Not nightly; uncomment if building from tf repo.
+export IS_NIGHTLY="${IS_NIGHTLY}:=0"
 export TF_PROJECT_NAME="tensorflow_rocm"  # single pip package!
 export TF_PIP_TEST_ROOT="pip_test"
 

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py39_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py39_pip.sh
@@ -60,7 +60,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --keep_going "
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} -//tensorflow/lite/... "
 export TF_PIP_TESTS="test_pip_virtualenv_non_clean test_pip_virtualenv_clean"
-export IS_NIGHTLY=0 # Not nightly; uncomment if building from tf repo.
+export IS_NIGHTLY="${IS_NIGHTLY}:=0"
 export TF_PROJECT_NAME="tensorflow_rocm"  # single pip package!
 export TF_PIP_TEST_ROOT="pip_test"
 


### PR DESCRIPTION
The IS_NIGHTLY env variable determines if a build is a nightly build or not. Nightly builds also take in nightly builds from dependencies like tensorboard and tensorflow-estimator. Mis-matches will cause test fails, so it's imperative that we set this properly for nightly builds.

We currently have IS_NIGHTLY hard-coded to 0. Change this to only set to 0 when IS_NIGHTLY is not currently set so it can be set in the environment or docker container.

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1073