### PR TITLE
Enable kernel launch test for ROCm.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -777,9 +777,7 @@ filegroup(
 tf_cc_test(
     name = "kernel_launch_test",
     srcs = ["kernel_launch_test.cc"],
-    tags = tf_cuda_tests_tags() + [
-        "no_rocm",
-    ],
+    tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
         "//tensorflow/compiler/xla/tests:hlo_test_base",


### PR DESCRIPTION
This works on ROCm.

Also, this test enablement is needed for BEF thunk and BEF executable.
