### PR TITLE
Removing the setting of `ROCBLAS_TENSILE_LIBPATH` in `configure.py`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1344,8 +1344,6 @@ def main():
 
   if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('ROCM_PATH')):
     write_action_env_to_bazelrc('ROCM_PATH', environ_cp.get('ROCM_PATH'))
-    write_action_env_to_bazelrc('ROCBLAS_TENSILE_LIBPATH',
-                                environ_cp.get('ROCM_PATH') + '/lib/library')
 
   if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('HIP_PLATFORM')):
     write_action_env_to_bazelrc('HIP_PLATFORM', environ_cp.get('HIP_PLATFORM'))


### PR DESCRIPTION
With ROCm 5.2, TF unit tests started erroring out when loading rocblas because of a change in the location of rocblas tensile libraries

old location : `$ROCM_PATH/lib/library`
new location : `$ROCM_PATH/lib/rocblas/library`

It seems that we no longer need to explicitly set the `ROCBLAS_TENSILE_LIBPATH` env var. When not set, rocblas will look for it in the location determined by where the rocblas library itself was loaded. That should work for all ROCm 5.0, 5.1, 5.2 and beyond.

Therefore this commit removes the setting of `ROCBLAS_TENSILE_LIBPATH` in `configure.py`