### PR TITLE
Removing the `no_rocm` tag from `//tensorflow/compiler/jit:xla_activity_listener_test` in the CPU testuite

### DIFF
--- a/tensorflow/compiler/jit/BUILD
+++ b/tensorflow/compiler/jit/BUILD
@@ -1166,7 +1166,6 @@ tf_cc_test(
 tf_cc_test(
     name = "xla_activity_listener_test",
     srcs = ["xla_activity_listener_test.cc"],
-    tags = ["no_rocm"],
     deps = [
         ":flags",
         ":xla_activity_listener",


### PR DESCRIPTION

This reverts commit 5e755cd64aab25ef0c9c13531f427017db7203dd.

See above commit for more details