### PR TITLE
Disable //tensorflow/python/kernel_tests/distributions:beta_test sinc…

### DIFF
--- a/tensorflow/python/kernel_tests/distributions/BUILD
+++ b/tensorflow/python/kernel_tests/distributions/BUILD
@@ -61,6 +61,7 @@ cuda_py_test(
     size = "small",
     srcs = ["beta_test.py"],
     tags = [
+        "no_oss",
         "nomac",  # b/191763315
         "notsan",  # b/173653918
     ],


### PR DESCRIPTION
…e tf.distributions is deprecated.

/cc @deven-amd @jayfurmanek 