### PR TITLE
extend timeout for run_gpu_multi.sh

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -45,7 +45,7 @@ bazel test \
       --test_tag_filters=-no_gpu,-no_rocm \
       --jobs=${N_BUILD_JOBS} \
       --local_test_jobs=${N_TEST_JOBS} \
-      --test_timeout 600,900,2400,7200 \
+      --test_timeout 900,2400,7200,9600 \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \


### PR DESCRIPTION
The random_generator_test_2gpu test takes a while and is often marked flaky.
This PR extends the bazel timeout in order to give it a little more time to complete.