### PR TITLE
Updating `rocm_configure.bzl` to account for ROCm 5.2 related header file changes (rccl)

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/nccl_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_utils.h
@@ -27,7 +27,12 @@ limitations under the License.
 
 // Common place for all collective thunks to include nccl/rccl headers.
 #if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#if TF_ROCM_VERSION >= 50200
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #else
 #include "third_party/nccl/nccl.h"
 #endif

--- a/tensorflow/core/kernels/nccl_ops.cc
+++ b/tensorflow/core/kernels/nccl_ops.cc
@@ -20,7 +20,12 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#if TF_ROCM_VERSION >= 50200
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #endif
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/nccl/nccl_manager.h"

--- a/tensorflow/core/nccl/nccl_manager.h
+++ b/tensorflow/core/nccl/nccl_manager.h
@@ -30,7 +30,12 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#if TF_ROCM_VERSION >= 50200
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #include "tensorflow/core/common_runtime/gpu_device_context.h"
 #endif
 #include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -575,12 +575,6 @@ def _create_local_rocm_repository(repository_ctx):
             name = "miopen-include",
             src_dir = rocm_toolkit_path + "/miopen/include",
             out_dir = "rocm/include/miopen",
-        ),
-        make_copy_dir_rule(
-            repository_ctx,
-            name = "rccl-include",
-            src_dir = rocm_toolkit_path + "/rccl/include",
-            out_dir = "rocm/include/rccl",
         )
     ]
 
@@ -672,7 +666,6 @@ def _create_local_rocm_repository(repository_ctx):
         "%{copy_rules}": "\n".join(copy_rules),
         "%{rocm_headers}": ('":rocm-include",\n' +
                             '":miopen-include",\n' +
-                            '":rccl-include",\n' +
                             hiprand_include +
                             rocrand_include),
     }


### PR DESCRIPTION
This PR is really a continuation for PRs #1603, #1605, #1607, #1612, #1614, #1617, #1620 and #1628 (in the ROCm TF fork)

------------------------------

ROCM 5.2 mainline build 9933 introduces changes to the location of the rccl header/libary files, which lead to the following TF build failure.

This commit updates the `rocm_configure.bzl` file to fix that build failure.

```
ERROR: Traceback (most recent call last):
	File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/external/local_config_rocm/rocm/BUILD", line 1730, column 8, in <toplevel>
		genrule(
Error in genrule: generated file 'rocm/include/rccl/rccl.h' in rule 'rccl-include' conflicts with existing generated file from rule 'rocm-include', defined at /root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/external/local_config_rocm/rocm/BUILD:185:8
INFO: Repository rules_proto instantiated at:
  /root/tensorflow/WORKSPACE:23:14: in <toplevel>
  /root/tensorflow/tensorflow/workspace0.bzl:116:17: in workspace
Repository rule http_archive defined at:
  /root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/external/bazel_tools/tools/build_defs/repo/http.bzl:364:31: in <toplevel>
ERROR: /root/tensorflow/tensorflow/stream_executor/rocm/BUILD:426:11: errors encountered resolving select() keys for //tensorflow/stream_executor/rocm:all_runtime
ERROR: Analysis of target '//tensorflow/stream_executor/rocm:all_runtime' failed; build aborted:
```