### PR TITLE
Updating `parameter_server_strategy_v2_test` to have TF_NUM_INTEROP_T…

### DIFF
--- a/tensorflow/python/distribute/parameter_server_strategy_v2_test.py
+++ b/tensorflow/python/distribute/parameter_server_strategy_v2_test.py
@@ -24,6 +24,8 @@ import copy
 import functools
 import os
 
+os.environ["TF_NUM_INTEROP_THREADS"]="16"
+
 from absl.testing import parameterized
 import numpy as np
 


### PR DESCRIPTION
…HREADS=16

For reasons that I have not yet figured out, most of the subtests within the `//tensorflow/python/distribute:parameter_server_strategy_v2_test` test create their own tf_Compute threadpool (as opposed to creating one tf_Compute threadpool for the entire test). The number of threads in this threadpool, by default, matches the number of CPU cores on the node on which the test is being run.

The tf_Compute threadpools created by the subtests do not get released until the end of the entire test is (i.e. until all the subtests are completed). For nodes with a lot of CPU cores (some of our test nodes have 256 cores!), this can result in the creation of tens of thousands of threads (30k+ when the test failed for me on a 256 core node), eventually leading to the pthread_create call failure (return value 11, out of resource error)

```
...
2021-11-10 00:18:24.836496: F tensorflow/core/platform/default/env.cc:73] Check failed: ret == 0 (11 vs. 0)Thread tf_Compute creation via pthread_create() failed.
Fatal Python error: Aborted

Thread 0x00007ff98b291740 (most recent call first):
  File "/root/.cache/ba2021-11-10 00:18:24.836561: F tensorflow/core/platform/default/env.cc:73] Check failed: ret == 0 (11 vs. 0)Thread tf_Compute creation via pthread_create() failed.
zel/_bazel_root/efb*** Received signal 6 ***
8*** BEGIN MANGLED STACK TRACE ***
8f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/parameter_server_strategy_v2_test.runfiles/org_tensorflow/tensorflow/python/eager/context.py", line 580 in ensure_initialized
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/parameter_server_strategy_v2_test.runfiles/org_tensorflow/tensorflow/python/eager/context.py", line 1473 in list_logical_devices
  File "/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/parameter_server_strate/root/.cache/bazel/_bazel_root/efb88f6336d9c4a18216fb94287b8d97/execroot/org_tensorflow/bazel-out/k8-opt/bin/tensorflow/python/distribute/parameter_ser
...
...
```

We can control the number of threads created in the tf_Compute threadpool via the TF_NUM_INTEROP_THREADS env var, and this commit uses to that env var to limit the threadpool size to 16 for this test.

The threadpool in question is created here - tensorflow/core/common_runtime/process_util.cc:NewThreadPoolFromSessionOptions

related JIRA ticket - https://ontrack-internal.amd.com/browse/SWDEV-298609