### PR TITLE
Disable a few MLIR/LLVM related tests

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -385,6 +385,7 @@ tf_xla_py_test(
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
         "optonly",
+	"no_rocm",
     ],
     deps = [
         ":xla_test",
@@ -1096,6 +1097,7 @@ tf_xla_py_test(
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
         "optonly",
+	"no_rocm",
     ],
     deps = [
         ":xla_test",
@@ -1273,6 +1275,7 @@ tf_xla_py_test(
     shard_count = 3,
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
+	"no_rocm",
     ],
     deps = [
         ":xla_test",


### PR DESCRIPTION
SWDEV-328651

This commit disables the following tests:

//tensorflow/compiler/tests:spacetobatch_op_test_gpu
//tensorflow/compiler/tests:spacetobatch_op_test_gpu_mlir_bridge_test
//tensorflow/compiler/tests:svd_op_test_gpu
//tensorflow/compiler/tests:svd_op_test_gpu_mlir_bridge_test
//tensorflow/compiler/tests:unstack_test_gpu_mlir_bridge_test 

These recently starting failing on 5.2 on MI200 only. These failures are caused by a LLVM/MLIR bug only exposed in 5.2. That bug was fixed and then included in TF here:
https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/44826dc2ad759ab48ebf78e4da107c3fd1941c9d 

Back-porting the fix to this branch involved too much change. Since this is fixed upstream, I'm disabling these tests in the develop-upstream-QA-rocm52 branch.