### PR TITLE
Fix for finding RCCL that works on 5.1 and 5.2

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -10,8 +10,7 @@
 #
 
 # First positional argument (if any) specifies the ROCM_INSTALL_DIR
-#ROCM_INSTALL_DIR=/opt/rocm-5.2.0-42
-ROCM_INSTALL_DIR=/opt/rocm-5.2.0-42
+ROCM_INSTALL_DIR=/opt/rocm-5.2.0-47
 if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi

--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -10,7 +10,8 @@
 #
 
 # First positional argument (if any) specifies the ROCM_INSTALL_DIR
-ROCM_INSTALL_DIR=/opt/rocm-5.2.0-47
+#ROCM_INSTALL_DIR=/opt/rocm-5.2.0-42
+ROCM_INSTALL_DIR=/opt/rocm-5.2.0-42
 if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi

--- a/tensorflow/compiler/xla/service/gpu/nccl_collective_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_collective_thunk.h
@@ -41,7 +41,11 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#if (TF_ROCM_VERSION >= 52000)
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #else
 #error "Neither CUDA nor ROCm enabled but NCCL/RCCL enabled"
 #endif

--- a/tensorflow/compiler/xla/service/gpu/nccl_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_utils.h
@@ -22,7 +22,11 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#if (TF_ROCM_VERSION >= 52000)
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #endif
 #include "tensorflow/compiler/xla/service/collective_ops_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_executable_run_options.h"

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -525,10 +525,10 @@ TEST_F(GPUDeviceTest, DeviceDetails) {
   for (int i = 0; i < devices.size(); i++) {
     std::unordered_map<string, string> details;
     TF_ASSERT_OK(factory->GetDeviceDetails(i, &details));
-    EXPECT_NE(details["device_name"], "");
 #if TENSORFLOW_USE_ROCM
     EXPECT_EQ(details.count("compute_capability"), 0);
 #else
+    EXPECT_NE(details["device_name"], "");
     EXPECT_NE(details["compute_capability"], "");
 #endif
   }

--- a/tensorflow/core/kernels/nccl_ops.cc
+++ b/tensorflow/core/kernels/nccl_ops.cc
@@ -20,7 +20,11 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#if (TF_ROCM_VERSION >= 52000)
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #endif
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/nccl/nccl_manager.h"

--- a/tensorflow/core/nccl/nccl_manager.h
+++ b/tensorflow/core/nccl/nccl_manager.h
@@ -30,7 +30,11 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#if (TF_ROCM_VERSION >= 52000)
 #include "rocm/include/rccl/rccl.h"
+#else
+#include "rocm/include/rccl.h"
+#endif
 #include "tensorflow/core/common_runtime/gpu_device_context.h"
 #endif
 #include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1052,7 +1052,10 @@ cuda_py_test(
     size = "small",
     srcs = ["config_test.py"],
     python_version = "PY3",
-    tags = ["no_pip"],  # test_ops are not available in pip.
+    tags = [
+        "no_pip",  # test_ops are not available in pip
+        "no_rocm",
+    ],
     deps = [
         ":config",
         ":constant_op",

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -314,7 +314,7 @@ def _select_rocm_lib_paths(repository_ctx, libs_paths, bash_bin):
 
     return libs
 
-def _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, bash_bin):
+def _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, miopen_path, rccl_path, bash_bin):
     """Returns the ROCm libraries on the system.
 
     Args:
@@ -333,8 +333,8 @@ def _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, bash_bin):
             ("rocblas", rocm_config.rocm_toolkit_path),
             (hipfft_or_rocfft, rocm_config.rocm_toolkit_path),
             ("hiprand", rocm_config.rocm_toolkit_path),
-            ("MIOpen", rocm_config.rocm_toolkit_path),
-            ("rccl", rocm_config.rocm_toolkit_path + "/rccl"),
+            ("MIOpen", miopen_path),
+            ("rccl", rccl_path),
             ("hipsparse", rocm_config.rocm_toolkit_path),
             ("roctracer64", rocm_config.rocm_toolkit_path + "/roctracer"),
             ("rocsolver", rocm_config.rocm_toolkit_path),
@@ -546,6 +546,10 @@ def _create_local_rocm_repository(repository_ctx):
     rocm_version_number = int(rocm_config.rocm_version_number)
     hipfft_or_rocfft = "rocfft" if rocm_version_number < 40100 else "hipfft"
 
+    # For ROCm 5.2 and above, find MIOpen and RCCL in the main rocm lib path
+    miopen_path = rocm_config.rocm_toolkit_path + "/miopen" if rocm_version_number < 50200 else rocm_config.rocm_toolkit_path
+    rccl_path = rocm_config.rocm_toolkit_path + "/rccl" if rocm_version_number < 50200 else rocm_config.rocm_toolkit_path
+
     # Copy header and library files to execroot.
     # rocm_toolkit_path
     rocm_toolkit_path = rocm_config.rocm_toolkit_path
@@ -596,7 +600,7 @@ def _create_local_rocm_repository(repository_ctx):
             ),
         )
 
-    rocm_libs = _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, bash_bin)
+    rocm_libs = _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, miopen_path, rccl_path, bash_bin)
     rocm_lib_srcs = []
     rocm_lib_outs = []
     for lib in rocm_libs.values():


### PR DESCRIPTION
With the various ROCm libs moving around once fix got added that wasn't backward compatible with ROCm 5.1.
This fixes the TF2.8 build on 5.1 and works on 5.2. (assuming we're finally settled on lib and include locations)