### PR TITLE
[XLA:Python] Unbreak OSS JAX build on Mac.

### DIFF
--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -566,6 +566,7 @@ cc_library(
         "//tensorflow/core/profiler/lib:profiler_session",
         "//tensorflow/core/profiler/rpc:profiler_server_impl",
         "//tensorflow/core/profiler/rpc/client:capture_profile",
+        "//tensorflow/core/profiler/rpc/client:profiler_client",
         "//tensorflow/python/profiler/internal:traceme_wrapper",
         "@pybind11",
     ],


### PR DESCRIPTION
Removing this dependency causes a link failure on Mac OS.

PiperOrigin-RevId: 446459597