### PR TITLE
[develop-upstream-QA-rocm53] freeze keras-nightly version for QA-53 branch

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -95,7 +95,7 @@ pip3 install --upgrade gast
 pip3 install --upgrade termcolor
 
 # Keras
-pip3 install keras-nightly --no-deps
+pip3 install keras-nightly==2.10.0.dev2022060207 --no-deps
 pip3 install keras_preprocessing==1.1.0 --no-deps
 pip3 install --upgrade h5py==3.1.0
 

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -24,7 +24,7 @@ gast == 0.4.0
 # Note that here we want the latest version that matches TF major.minor version
 # Note that we must use nightly here as these are used in nightly jobs
 # For release jobs, we will pin these on the release branch
-keras-nightly ~= 2.10.0.dev
+keras-nightly == 2.10.0.dev2022060207
 tb-nightly ~= 2.9.0.a
 tf-estimator-nightly ~= 2.10.0.dev
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -109,7 +109,7 @@ REQUIRED_PACKAGES = [
     standard_or_nightly('tensorflow_estimator >= 2.9.0rc0, < 2.10',
                         'tf-estimator-nightly ~= 2.10.0.dev'),
     standard_or_nightly('keras >= 2.9.0rc0, < 2.10',
-                        'keras-nightly ~= 2.10.0.dev'),
+                        'keras-nightly == 2.10.0.dev2022060207'),
 ]
 REQUIRED_PACKAGES = [ p for p in REQUIRED_PACKAGES if p is not None ]
 


### PR DESCRIPTION
On the 5.3 QA branch a failure was seen when running tf_cnn_brenchmark:

```
Starting TF with rccl FP16 Benchmark with model::resnet50,nGPU::8,Batch-Size::128,NUM-Batches::100,Optimizer:sgd...
Traceback (most recent call last):
  File "/root/benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py", line 29, in <module>
    import benchmark_cnn
  File "/root/benchmarks/scripts/tf_cnn_benchmarks/benchmark_cnn.py", line 51, in <module>
    from models import model_config
  File "/root/benchmarks/scripts/tf_cnn_benchmarks/models/model_config.py", line 35, in <module>
    from models.experimental import deepspeech
  File "/root/benchmarks/scripts/tf_cnn_benchmarks/models/experimental/deepspeech.py", line 126, in <module>
    class DeepSpeech2Model(model_lib.Model):
  File "/root/benchmarks/scripts/tf_cnn_benchmarks/models/experimental/deepspeech.py", line 131, in DeepSpeech2Model
    'lstm': tf.nn.rnn_cell.BasicLSTMCell,
  File "/usr/local/lib/python3.9/dist-packages/tensorflow/python/util/lazy_loader.py", line 58, in __getattr__
    module = self._load()
  File "/usr/local/lib/python3.9/dist-packages/tensorflow/python/util/lazy_loader.py", line 41, in _load
    module = importlib.import_module(self.__name__)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/root/.local/lib/python3.9/site-packages/keras/__init__.py", line 21, in <module>
    from keras import models
  File "/root/.local/lib/python3.9/site-packages/keras/models/__init__.py", line 18, in <module>
    from keras.engine.functional import Functional
  File "/root/.local/lib/python3.9/site-packages/keras/engine/functional.py", line 27, in <module>
    from keras.dtensor import layout_map as layout_map_lib
  File "/root/.local/lib/python3.9/site-packages/keras/dtensor/layout_map.py", line 25, in <module>
    from keras.dtensor import lazy_variable
  File "/root/.local/lib/python3.9/site-packages/keras/dtensor/lazy_variable.py", line 26, in <module>
    from tensorflow.python.trackable import base as trackable
ModuleNotFoundError: No module named 'tensorflow.python.trackable'
```

This was due to this upstream change:
https://github.com/tensorflow/tensorflow/commit/04279434a7f9d9b2dc9792f4d8e246eab29dffec

which keras fixed with:
https://github.com/keras-team/keras/commit/11d062107ee8c4f56600c7493468e204f343abc8

The 53 QA branch is frozen but it still pulls keras-nightly.
This PR will freeze keras-nightly at a point before this change.
