### PR TITLE
freeze tensorflow-estimator version for QA-53 branch

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -100,7 +100,7 @@ pip3 install keras_preprocessing==1.1.0 --no-deps
 pip3 install --upgrade h5py==3.1.0
 
 # Estimator
-pip3 install tf-estimator-nightly --no-deps
+pip3 install tf-estimator-nightly==2.10.0.dev2022060108 --no-deps
 
 # Tensorboard
 pip3 install tb-nightly --no-deps

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -26,7 +26,7 @@ gast == 0.4.0
 # For release jobs, we will pin these on the release branch
 keras-nightly == 2.10.0.dev2022060207
 tb-nightly ~= 2.9.0.a
-tf-estimator-nightly ~= 2.10.0.dev
+tf-estimator-nightly == 2.10.0.dev2022060108
 
 # Test dependencies
 grpcio ~= 1.43.0  # NOTE: Earliest version for Python 3.10

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -107,7 +107,7 @@ REQUIRED_PACKAGES = [
     # These are all updated during the TF release process.
     standard_or_nightly('tensorboard >= 2.8, < 2.9', 'tb-nightly ~= 2.9.0.a'),
     standard_or_nightly('tensorflow_estimator >= 2.9.0rc0, < 2.10',
-                        'tf-estimator-nightly ~= 2.10.0.dev'),
+                        'tf-estimator-nightly == 2.10.0.dev2022060108'),
     standard_or_nightly('keras >= 2.9.0rc0, < 2.10',
                         'keras-nightly == 2.10.0.dev2022060207'),
 ]


### PR DESCRIPTION
On the 5.3 QA branch a failure was seen when running MLPerf Resnet50 model:
```
Traceback (most recent call last):
  File "/root/MLPerf-mGPU/Resnet50_TF2.3/resnet_ctl_imagenet_main.py", line 29, in <module>
    from tf2_common.utils.flags import core as flags_core
  File "/root/MLPerf-mGPU/Resnet50_TF2.3/tf2_common/utils/flags/core.py", line 31, in <module>
    from tf2_common.utils.flags import _base
  File "/root/MLPerf-mGPU/Resnet50_TF2.3/tf2_common/utils/flags/_base.py", line 26, in <module>
    from tf2_common.utils.logs import hooks_helper
  File "/root/MLPerf-mGPU/Resnet50_TF2.3/tf2_common/utils/logs/hooks_helper.py", line 30, in <module>
    from tf2_common.utils.logs import hooks
  File "/root/MLPerf-mGPU/Resnet50_TF2.3/tf2_common/utils/logs/hooks.py", line 29, in <module>
    class ExamplesPerSecondHook(tf.estimator.SessionRunHook):
  File "/usr/local/lib/python3.9/dist-packages/tensorflow/python/util/lazy_loader.py", line 58, in __getattr__
    module = self._load()
  File "/usr/local/lib/python3.9/dist-packages/tensorflow/python/util/lazy_loader.py", line 41, in _load
    module = importlib.import_module(self.__name__)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/usr/local/lib/python3.9/dist-packages/tensorflow_estimator/__init__.py", line 8, in <module>
    from tensorflow_estimator._api.v1 import estimator
  File "/usr/local/lib/python3.9/dist-packages/tensorflow_estimator/_api/v1/estimator/__init__.py", line 8, in <module>
    from tensorflow_estimator._api.v1.estimator import experimental
  File "/usr/local/lib/python3.9/dist-packages/tensorflow_estimator/_api/v1/estimator/experimental/__init__.py", line 8, in <module>
    from tensorflow_estimator.python.estimator.canned.dnn import dnn_logit_fn_builder
  File "/usr/local/lib/python3.9/dist-packages/tensorflow_estimator/python/estimator/canned/dnn.py", line 27, in <module>
    from tensorflow_estimator.python.estimator import estimator
  File "/usr/local/lib/python3.9/dist-packages/tensorflow_estimator/python/estimator/estimator.py", line 31, in <module>
    from tensorflow.python.checkpoint import checkpoint as trackable_util
ModuleNotFoundError: No module named 'tensorflow.python.checkpoint
```

This was due to this upstream change:
https://github.com/tensorflow/tensorflow/commit/04279434a7f9d9b2dc9792f4d8e246eab29dffec

which tensorflow-estimator fixed with:
https://github.com/tensorflow/estimator/commit/1e09a38a265e6cdd0377ecc9dbd33a6633a95cdf

The 53 QA branch is frozen but it still pulls tf-estimator-nightly.
This PR will freeze tf-estimator-nightly at a point before this change.
