### PR TITLE
Dockerfile.rocm - Adding gpu target as a args to override this parame…

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -17,6 +17,19 @@ fi
 
 ROCM_PATH=$ROCM_INSTALL_DIR
 
+while getopts "h:r" opt; do
+  case ${opt} in
+    h)
+        echo "Options:"
+        echo "-r     Use -r to define bazel resource restriction"
+        exit 0
+        ;;
+    r)
+        restriction=true 
+        ;;
+    esac
+done
+
 # Explicitly delete the old whl packages in the /tmp/tensorflow_pkg dir
 # Doing so comes in handy when the TF version number changes, because
 # it will cause the last line in this script (pip3 install ...) to fail.
@@ -29,6 +42,13 @@ TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tf_nightly_rocm*.whl
 
 yes "" | ROCM_PATH=$ROCM_INSTALL_DIR TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
+# Explicitly define resource constraints on bazel to avoid overload on rocm-ci
+if [[ -n $restriction ]]; then
+    bazel build --local_ram_resources=60000 --local_cpu_resources=35 --jobs=70 --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
+    bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC --rocm &&
+    pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl
+    exit 0
+fi
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC --rocm --nightly_flag &&
 pip3 install --upgrade $TF_PKG_LOC/tf_nightly_rocm*.whl

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -7,10 +7,12 @@ ARG ROCM_DEB_REPO=https://repo.radeon.com/rocm/apt/5.1/
 ARG ROCM_BUILD_NAME=ubuntu
 ARG ROCM_BUILD_NUM=main
 ARG ROCM_PATH=/opt/rocm-5.1.0
+ARG GPU_DEVICE_TARGETS="gfx900 gfx906 gfx908 gfx90a gfx1030"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TF_NEED_ROCM 1
 ENV HOME /root/
+ENV HIP_PLATFORM=amd
 RUN apt-get --allow-unauthenticated update && apt install -y wget software-properties-common
 
 # Add rocm repository
@@ -80,7 +82,7 @@ ENV PATH="$ROCM_PATH/bin:${PATH}"
 ENV PATH="$OPENCL_ROOT/bin:${PATH}"
 
 # Add target file to help determine which device(s) to build for
-RUN bash -c 'echo -e "gfx900\ngfx906\ngfx908\ngfx90a\ngfx1030" >> ${ROCM_PATH}/bin/target.lst'
+RUN printf '%s\n' > ${ROCM_PATH}/bin/target.lst ${GPU_DEVICE_TARGETS}
 
 # Need to explicitly create the $ROCM_PATH/.info/version file to workaround what seems to be a bazel bug
 # The env vars being set via --action_env in .bazelrc and .tf_configure.bazelrc files are sometimes
@@ -103,10 +105,12 @@ COPY release/common.sh /install/common.sh
 COPY release/* tensorflow/tools/ci_build/release/
 ARG DEBIAN_FRONTEND=noninteractive
 RUN /install/install_deb_packages.sh
+RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
 
 SHELL ["/bin/bash", "-c"]
 RUN /install/install_bazel.sh
+RUN /install/install_golang.sh
 # Set up the master bazelrc configuration file.
 COPY install/.bazelrc /etc/bazel.bazelrc
 # Configure the build for our ROCm configuration.


### PR DESCRIPTION
…ter on rocm-ci and installing scripts required by QA

build_rocm_python3 - adding a option -r to restrict bazel resource.

Signed-off-by: Brij Lathia <brij.lathia@amd.com>