### PR TITLE
[r2.4-rocm-enhanced] Changes to track call-context information (forward pass / backprop pa…

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/batch_matmul_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/batch_matmul_op.cc
@@ -27,17 +27,22 @@ class BatchMatMulOp : public XlaOpKernel {
   explicit BatchMatMulOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("adj_x", &adj_x_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("adj_y", &adj_y_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("grad_x", &grad_x_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("grad_y", &grad_y_));
   }
 
   void Compile(XlaOpKernelContext* ctx) override {
     auto result = xla::BatchDot(MaybeConjugate(ctx->Input(0), adj_x_), adj_x_,
-                                MaybeConjugate(ctx->Input(1), adj_y_), adj_y_);
+                                MaybeConjugate(ctx->Input(1), adj_y_), adj_y_,
+				xla::PrecisionConfig::DEFAULT, grad_x_, grad_y_);
     ctx->SetOutput(0, result);
   }
 
  private:
   bool adj_x_;
   bool adj_y_;
+  bool grad_x_;
+  bool grad_y_;
 };
 
 REGISTER_XLA_OP(Name("BatchMatMul"), BatchMatMulOp);

--- a/tensorflow/compiler/tf2xla/kernels/matmul_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/matmul_op.cc
@@ -34,6 +34,8 @@ class MatMulOp : public XlaOpKernel {
       : XlaOpKernel(ctx), is_sparse_(is_sparse) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_a", &transpose_a_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_b", &transpose_b_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("grad_a", &grad_a_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("grad_b", &grad_b_));
     if (is_sparse) {
       OP_REQUIRES_OK(ctx, ctx->GetAttr("Ta", &a_type_));
       OP_REQUIRES_OK(ctx, ctx->GetAttr("Tb", &b_type_));
@@ -82,13 +84,16 @@ class MatMulOp : public XlaOpKernel {
         b = xla::ConvertElementType(b, xla::F32);
       }
     }
-    ctx->SetOutput(0, xla::BatchDot(a, transpose_a_, b, transpose_b_));
+    ctx->SetOutput(0, xla::BatchDot(a, transpose_a_, b, transpose_b_,
+			    xla::PrecisionConfig::DEFAULT, grad_a_, grad_b_));
   }
 
  private:
   bool is_sparse_;
   bool transpose_a_;
   bool transpose_b_;
+  bool grad_a_;
+  bool grad_b_;
   DataType a_type_;
   DataType b_type_;
 };

--- a/tensorflow/compiler/xla/client/lib/matrix.cc
+++ b/tensorflow/compiler/xla/client/lib/matrix.cc
@@ -352,24 +352,27 @@ void DeleteDimsFromContainer(absl::Span<const int64> to_delete, Shape* shape,
 xla::XlaOp Einsum(xla::XlaOp x, absl::Span<const int64> x_config, xla::XlaOp y,
                   absl::Span<const int64> y_config,
                   absl::Span<const int64> output_config,
-                  xla::PrecisionConfig::Precision precision) {
+                  xla::PrecisionConfig::Precision precision,
+		  bool grad_x, bool grad_y) {
   XlaBuilder* builder = x.builder();
   return builder->ReportErrorOrReturn([&]() -> StatusOr<XlaOp> {
     auto x_diagonal_labels = EinsumDiagonalLabels(x_config);
     if (x_diagonal_labels) {
       return Einsum(EinsumDiagonal(x, x_config), x_diagonal_labels->at(0), y,
-                    y_config, output_config, precision);
+                    y_config, output_config, precision,
+		    grad_x, grad_y);
     }
     auto y_diagonal_labels = EinsumDiagonalLabels(y_config);
     if (y_diagonal_labels) {
       return Einsum(x, x_config, EinsumDiagonal(y, y_config),
-                    y_diagonal_labels->at(0), output_config, precision);
+                    y_diagonal_labels->at(0), output_config, precision,
+		    grad_x, grad_y);
     }
     auto output_diagonal_labels = EinsumDiagonalLabels(output_config);
     if (output_diagonal_labels) {
       return EinsumInverseDiagonal(
           Einsum(x, x_config, y, y_config, output_diagonal_labels->at(0),
-                 precision),
+                 precision, grad_x, grad_y),
           output_config);
     }
 
@@ -512,6 +515,10 @@ xla::XlaOp Einsum(xla::XlaOp x, absl::Span<const int64> x_config, xla::XlaOp y,
     precision_proto.add_operand_precision(precision);
     precision_proto.add_operand_precision(precision);
     auto dot = DotGeneral(x, y, dnums, &precision_proto);
+    builder->SetInstructionFrontendAttribute(dot, "grad_x",
+                                             (grad_x ? "true" : "false"));
+    builder->SetInstructionFrontendAttribute(dot, "grad_y",
+                                             (grad_y ? "true" : "false"));
     dot = Transpose(dot, transpose_dims);
     if (transpose_rank == output_rank) {
       return dot;
@@ -536,12 +543,14 @@ xla::XlaOp Einsum(xla::XlaOp x, absl::Span<const int64> x_config, xla::XlaOp y,
   });
 }
 
-XlaOp BatchDot(XlaOp x, XlaOp y, PrecisionConfig::Precision precision) {
-  return BatchDot(x, false, y, false, precision);
+XlaOp BatchDot(XlaOp x, XlaOp y, PrecisionConfig::Precision precision,
+               bool grad_x, bool grad_y) {
+  return BatchDot(x, false, y, false, precision, grad_x, grad_y);
 }
 
 XlaOp BatchDot(XlaOp x, bool transpose_x, XlaOp y, bool transpose_y,
-               PrecisionConfig::Precision precision) {
+               PrecisionConfig::Precision precision,
+	       bool grad_x, bool grad_y) {
   XlaBuilder* builder = x.builder();
   return builder->ReportErrorOrReturn([&]() -> StatusOr<XlaOp> {
     std::string string("...mk,...kn->...mn");
@@ -551,7 +560,7 @@ XlaOp BatchDot(XlaOp x, bool transpose_x, XlaOp y, bool transpose_y,
     if (transpose_y) {
       std::swap(string[6 + 3], string[6 + 4]);
     }
-    return Einsum(x, y, string, precision);
+    return Einsum(x, y, string, precision, grad_x, grad_y);
   });
 }
 
@@ -671,12 +680,12 @@ std::string NormalizeEinsumString(absl::string_view einsum_config) {
 }
 
 XlaOp Einsum(XlaOp x, XlaOp y, absl::string_view einsum_config,
-             PrecisionConfig::Precision precision) {
+             PrecisionConfig::Precision precision, bool grad_x,  bool grad_y) {
   XlaBuilder* builder = x.builder();
   return builder->ReportErrorOrReturn([&]() -> StatusOr<XlaOp> {
     auto new_config = NormalizeEinsumString(einsum_config);
     if (!new_config.empty()) {
-      return Einsum(x, y, new_config, precision);
+      return Einsum(x, y, new_config, precision, grad_x, grad_y);
     }
     TF_ASSIGN_OR_RETURN(Shape x_shape, builder->GetShape(x));
     TF_ASSIGN_OR_RETURN(Shape y_shape, builder->GetShape(y));
@@ -684,14 +693,14 @@ XlaOp Einsum(XlaOp x, XlaOp y, absl::string_view einsum_config,
         auto einsum_config_numeric,
         ParseEinsumString(einsum_config, x_shape.rank(), y_shape.rank()));
     return Einsum(x, einsum_config_numeric[0], y, einsum_config_numeric[1],
-                  einsum_config_numeric[2], precision);
+                  einsum_config_numeric[2], precision, grad_x, grad_y);
   });
 }
 
 XlaOp Einsum(XlaOp x, absl::string_view einsum_config,
-             PrecisionConfig::Precision precision) {
+             PrecisionConfig::Precision precision, bool grad_x,  bool grad_y) {
   return Einsum(ScalarLike(x, 1), x, absl::StrCat(",", einsum_config),
-                precision);
+                precision, grad_x, grad_y);
 }
 
 XlaOp TransposeInMinorDims(XlaOp x) {

--- a/tensorflow/compiler/xla/client/lib/matrix.h
+++ b/tensorflow/compiler/xla/client/lib/matrix.h
@@ -82,10 +82,12 @@ XlaOp LowerTriangle(XlaOp x);
 //     output[..., :, :] = matrix(x[..., :, :]) * matrix(y[..., :, :])
 xla::XlaOp BatchDot(
     xla::XlaOp x, xla::XlaOp y,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT);
+    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
+    bool grad_x = false, bool grad_y = false);
 xla::XlaOp BatchDot(
     xla::XlaOp x, bool transpose_x, xla::XlaOp y, bool transpose_y,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT);
+    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
+    bool grad_x = false, bool grad_y = false);
 
 // Parse an einsum string into dimension numbers:
 //   "ab,cb->ac"
@@ -115,10 +117,12 @@ std::string NormalizeEinsumString(absl::string_view einsum_config);
 // Supports two operand einsum notation like "ab,cb->ac".
 xla::XlaOp Einsum(
     xla::XlaOp x, xla::XlaOp y, absl::string_view einsum_config,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT);
+    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
+    bool grad_x = false, bool grad_y = false);
 xla::XlaOp Einsum(
     xla::XlaOp x, absl::string_view einsum_config,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT);
+    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
+    bool grad_x = false, bool grad_y = false);
 
 
 // Same as above but supporting numeric labels on dimensions. So "ab,cb->ac"
@@ -129,7 +133,8 @@ xla::XlaOp Einsum(
 xla::XlaOp Einsum(
     xla::XlaOp x, absl::Span<const int64> x_config, xla::XlaOp y,
     absl::Span<const int64> y_config, absl::Span<const int64> output_config,
-    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT);
+    xla::PrecisionConfig::Precision precision = xla::PrecisionConfig::DEFAULT,
+    bool grad_x = false, bool grad_y = false);
 
 // Transposes a stack of matrices `x` by swapping the last two dimensions.
 xla::XlaOp TransposeInMinorDims(xla::XlaOp x);

--- a/tensorflow/compiler/xla/service/gpu/backend_configs.proto
+++ b/tensorflow/compiler/xla/service/gpu/backend_configs.proto
@@ -40,6 +40,8 @@ message CudnnConvBackendConfig {
   // The scaling factor multiplied with the side input. If no side input buffer
   // is provided, this field must be 0.
   double side_input_scale = 5;
+
+  string call_context = 7;
 }
 
 // Backend config for the GEMM operation running through cuBLAS.
@@ -59,4 +61,7 @@ message GemmBackendConfig {
   xla.DotDimensionNumbers dot_dimension_numbers = 7;
 
   int64 batch_size = 8;
+
+  bool grad_x = 12;
+  bool grad_y = 13;
 }

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -67,6 +67,11 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       *gemm_config.mutable_dot_dimension_numbers() =
           instr->dot_dimension_numbers();
       gemm_config.set_batch_size(batch_size);
+
+      auto attributes = instr->frontend_attributes().map();
+      gemm_config.set_grad_x(attributes["grad_x"] == "true");
+      gemm_config.set_grad_y(attributes["grad_y"] == "true");
+
       TF_RETURN_IF_ERROR(gemm_call->set_backend_config(gemm_config));
       TF_RETURN_IF_ERROR(
           ReplaceWithNewInstruction(instr, std::move(gemm_call)));

--- a/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
@@ -128,16 +128,18 @@ static bool DoGemmWithAlgorithm(
     // Autotuning is disabled for batch_size != 1.
     CHECK_EQ(1, batch_size);
     return stream
-        ->ThenBlasGemmWithAlgorithm(
+        ->ThenBlasGemm(
+            se::blas::GemmCallContext<Element> {
             lhs_transpose, rhs_transpose, output_matrix.num_rows,
             output_matrix.num_cols,
             /*size of reduce dim=*/k,
-            /*alpha=*/static_cast<Element>(alpha), lhs_data,
-            /*leading dim of LHS=*/lhs_matrix.num_rows, rhs_data,
-            /*leading dim of RHS=*/rhs_matrix.num_rows,
-            /*beta=*/static_cast<Element>(beta), &output_data,
-            /*leading dim of output=*/output_matrix.num_rows, computation_type,
-            *algorithm, output_profile_result)
+            /*alpha=*/alpha,
+            /*beta=*/beta,
+            &lhs_data, /*leading dim of LHS=*/lhs_matrix.num_rows,
+            &rhs_data, /*leading dim of RHS=*/rhs_matrix.num_rows,
+            &output_data, /*leading dim of output=*/output_matrix.num_rows, 
+            se::blas::CallContext::kNone,  -1, -1, -1, 1, computation_type, 
+            output_profile_result, *algorithm})
         .ok();
   }
 
@@ -146,25 +148,32 @@ static bool DoGemmWithAlgorithm(
     int64 rhs_stride = rhs_matrix.num_rows * rhs_matrix.num_cols;
     int64 output_stride = output_matrix.num_rows * output_matrix.num_cols;
     return stream
-        ->ThenBlasGemmStridedBatched(
+        ->ThenBlasGemm(
+            se::blas::GemmCallContext<Element> {
             lhs_transpose, rhs_transpose, output_matrix.num_rows,
-            output_matrix.num_cols, /*size of reduce dim=*/k,
-            /*alpha=*/alpha, lhs_data,
-            /*leading dim of LHS=*/lhs_matrix.num_rows, lhs_stride, rhs_data,
-            /*leading dim of RHS=*/rhs_matrix.num_rows, rhs_stride,
-            /*beta=*/beta, &output_data,
-            /*leading dim of output=*/output_matrix.num_rows, output_stride,
-            batch_size)
+            output_matrix.num_cols,
+            /*size of reduce dim=*/k,
+            /*alpha=*/alpha,
+            /*beta=*/beta,
+            &lhs_data, /*leading dim of LHS=*/lhs_matrix.num_rows,
+            &rhs_data, /*leading dim of RHS=*/rhs_matrix.num_rows,
+            &output_data, /*leading dim of output=*/output_matrix.num_rows,
+            se::blas::CallContext::kNone, lhs_stride, rhs_stride, output_stride,
+            batch_size, computation_type})
         .ok();
   }
 
   return stream
       ->ThenBlasGemm(
+          se::blas::GemmCallContext<Element> {
           lhs_transpose, rhs_transpose, output_matrix.num_rows,
-          output_matrix.num_cols, /*size of reduce dim=*/k, /*alpha=*/alpha,
-          lhs_data, /*leading dim of LHS=*/lhs_matrix.num_rows, rhs_data,
-          /*leading dim of RHS=*/rhs_matrix.num_rows, /*beta=*/beta,
-          &output_data, /*leading dim of output=*/output_matrix.num_rows)
+          output_matrix.num_cols, 
+          /*size of reduce dim=*/k, 
+          /*alpha=*/alpha,
+          /*beta=*/beta,
+          &lhs_data, /*leading dim of LHS=*/lhs_matrix.num_rows, 
+          &rhs_data, /*leading dim of RHS=*/rhs_matrix.num_rows,
+          &output_data, /*leading dim of output=*/output_matrix.num_rows})
       .ok();
 }
 
@@ -192,6 +201,13 @@ Status RunGemm(const GpuGemmConfig &gemm_config,
   int64 col_dim = dim_nums.lhs_batch_dimensions_size() + 1;
 
   int64 batch_size = backend_config.batch_size();
+  se::blas::CallContext call_context = se::blas::CallContext::kNone;
+  if (backend_config.grad_x()) {
+    call_context = se::blas::CallContext::kBackpropInput1;
+  }
+  if (backend_config.grad_y()) {
+    call_context = se::blas::CallContext::kBackpropInput2;
+  }
 
   // Check that the batch dims don't cover the last two dims.
   for (int64 batch_dim : dim_nums.lhs_batch_dimensions()) {

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -125,7 +125,8 @@ StatusOr<std::vector<se::dnn::ProfileResult>> GetMIOpenAlgorithms(
     const HloCustomCallInstruction* instr,
     absl::Span<se::DeviceMemoryBase> operand_buffers,
     se::DeviceMemoryBase result_buffer, se::StreamExecutor* stream_exec,
-    ScratchAllocator* scratch_allocator, se::Stream* stream) {
+    ScratchAllocator* scratch_allocator, 
+    se::dnn::CallContext call_context, se::Stream* stream) {
   std::vector<se::dnn::ProfileResult> algorithms;
 
   TF_ASSIGN_OR_RETURN(GpuConvConfig config, GetGpuConvConfig(instr));
@@ -143,7 +144,7 @@ StatusOr<std::vector<se::dnn::ProfileResult>> GetMIOpenAlgorithms(
       kind, dtype, stream, params.config.input_descriptor, params.input_buf,
       params.config.filter_descriptor, params.filter_buf,
       params.config.output_descriptor, params.output_buf,
-      params.config.conv_desc, scratch_allocator, &algorithms);
+      params.config.conv_desc, scratch_allocator, call_context, &algorithms);
   DCHECK(succ);
 
   return algorithms;
@@ -687,10 +688,15 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
 
   ScratchAllocator scratch_allocator(device_ordinal, allocator);
 
+  TF_ASSIGN_OR_RETURN(auto backend_config,
+                      instr->backend_config<CudnnConvBackendConfig>());
+  se::dnn::CallContext call_context =
+      GetCallContext(backend_config.call_context());
+
   TF_ASSIGN_OR_RETURN(
       std::vector<se::dnn::ProfileResult> algorithms,
       GetMIOpenAlgorithms(instr, absl::MakeSpan(operand_buffers), result_buffer,
-                          stream_exec_, &scratch_allocator, stream));
+                          stream_exec_, &scratch_allocator, call_context, stream));
 
   std::vector<AutotuneResult> profile_results;
 

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_rewriter.cc
@@ -680,8 +680,13 @@ StatusOr<bool> RunOnInstruction(HloInstruction* conv) {
     return false;
   }
 
-  TF_RETURN_IF_ERROR(
-      custom_call->set_backend_config(GetDefaultBackendConfig()));
+  //TF_RETURN_IF_ERROR(
+  //    custom_call->set_backend_config(GetDefaultBackendConfig()));
+  auto backend_config = GetDefaultBackendConfig();
+  auto attributes = conv->frontend_attributes().map();
+  backend_config.set_call_context(attributes["call_context"]);
+
+  TF_RETURN_IF_ERROR(custom_call->set_backend_config(backend_config));
 
   VLOG(1) << "Replacing convolution " << conv->ToString() << " with "
           << custom_call->ToString();

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
@@ -254,6 +254,16 @@ Status RunGpuConvImpl(const GpuConvParams& params,
 
 }  // anonymous namespace
 
+se::dnn::CallContext GetCallContext(const absl::string_view call_context) {
+  if (call_context == "kForward")
+    return se::dnn::CallContext::kForward;
+  else if (call_context == "kBackpropData")
+    return se::dnn::CallContext::kBackpropData;
+  else if (call_context == "kBackpropFilter")
+    return se::dnn::CallContext::kBackpropFilter;
+  return se::dnn::CallContext::kNone;
+}
+
 StatusOr<GpuConvConfig> GetGpuConvConfig(
     const HloCustomCallInstruction* cudnn_call) {
   GpuConvConfig config;
@@ -272,6 +282,7 @@ StatusOr<GpuConvConfig> GetGpuConvConfig(
       se::dnn::AlgorithmDesc(backend_config.algorithm(),
                              backend_config.tensor_ops_enabled()),
       cudnn_call->shape().tuple_shapes(1).dimensions(0));
+  config.call_context = GetCallContext(backend_config.call_context());
   config.conv_result_scale = backend_config.conv_result_scale();
 
   Shape operand0_shape = cudnn_call->operand(0)->shape();

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
@@ -61,6 +61,8 @@ struct GpuConvConfig {
     double side_input_scale;
   };
 
+  se::dnn::CallContext call_context;
+
   PrimitiveType input_type;
   PrimitiveType output_type;
   CudnnConvKind kind;
@@ -94,6 +96,8 @@ struct GpuConvParams {
 };
 
 // This file contains low-level routines for running cudnn convolutions.
+
+se::dnn::CallContext GetCallContext(const absl::string_view call_context);
 
 // Calls into cudnn to run the specified convolution.
 //

--- a/tensorflow/core/kernels/batch_gemm_op.cc
+++ b/tensorflow/core/kernels/batch_gemm_op.cc
@@ -23,6 +23,8 @@ class BatchGemmOp : public OpKernel {
   explicit BatchGemmOp(OpKernelConstruction* context) : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("adj_x", &transpose_a_));
     OP_REQUIRES_OK(context, context->GetAttr("adj_y", &transpose_b_));
+    OP_REQUIRES_OK(context, context->GetAttr("grad_x", &grad_a_));
+    OP_REQUIRES_OK(context, context->GetAttr("grad_y", &grad_b_));
     OP_REQUIRES_OK(context, context->GetAttr("alpha", &alpha_));
     OP_REQUIRES_OK(context, context->GetAttr("beta", &beta_));
   }
@@ -87,10 +89,17 @@ class BatchGemmOp : public OpKernel {
       return;
     }
 
+    se::blas::CallContext call_context = se::blas::CallContext::kForward;
+    if(grad_a_)
+      call_context = se::blas::CallContext::kBackpropInput2;
+    else if(grad_b_)
+      call_context = se::blas::CallContext::kBackpropInput1;
+
+
     LaunchBatchMatMul<Device, Scalar>::Launch(
         ctx, in0_reshaped, in1_reshaped,
         /*adj_x=*/false, /*adj_y=*/false, transpose_a_, transpose_b_, bcast,
-        /*use_autotune*/ false, &out_reshaped, alpha_, beta_);
+        /*use_autotune*/ false, &out_reshaped, call_context, alpha_, beta_);
   }
 
  private:
@@ -108,6 +117,7 @@ class BatchGemmOp : public OpKernel {
 
   bool transpose_a_;
   bool transpose_b_;
+  bool grad_a_, grad_b_;
   float alpha_;
   float beta_;
 };

--- a/tensorflow/core/kernels/eigen_cuboid_convolution.h
+++ b/tensorflow/core/kernels/eigen_cuboid_convolution.h
@@ -29,6 +29,10 @@ namespace Eigen {
 
 namespace internal {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
+
 // WARNING: Most of the code here implicitly assumes that the matrix is in
 // ColMajor layout. This is guaranteed by the tensor contraction (see
 // TensorContraction.h).
@@ -1990,5 +1994,7 @@ CuboidConvolution(const Input& input, const Kernel& kernel,
 }
 
 }  // end namespace Eigen
+
+#pragma GCC diagnostic pop
 
 #endif  // TENSORFLOW_CORE_KERNELS_EIGEN_CUBOID_CONVOLUTION_H_

--- a/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
@@ -23,6 +23,9 @@ namespace Eigen {
 
 namespace internal {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
 // WARNING: Most of the code here implicitly assumes that the matrix is in
 // ColMajor layout. This is guaranteed by the tensor contraction (see
 // TensorContraction.h).
@@ -1769,5 +1772,7 @@ EIGEN_DEVICE_FUNC
 }
 
 }  // end namespace Eigen
+
+#pragma GCC diagnostic pop
 
 #endif  // TENSORFLOW_CORE_KERNELS_EIGEN_SPATIAL_CONVOLUTIONS_INL_H_

--- a/tensorflow/core/kernels/eigen_spatial_convolutions.h
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions.h
@@ -28,6 +28,9 @@ limitations under the License.
 namespace Eigen {
 namespace internal {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
 // After we vectorized all loads from the underlying tensor using Packet ops, we
 // have to finalize coefficients that do not fit into a packet.
 template <typename Scalar, typename DataMapper, int packet_size,
@@ -439,6 +442,7 @@ struct gemm_pack_colmajor_block<
     }
   }
 };
+#pragma GCC diagnostic pop
 }  // namespace internal
 }  // namespace Eigen
 #endif  // defined(TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL)

--- a/tensorflow/core/kernels/eigen_volume_patch.h
+++ b/tensorflow/core/kernels/eigen_volume_patch.h
@@ -20,6 +20,9 @@ limitations under the License.
 
 namespace Eigen {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+
 // Changes the interpretation of padding in TensorVolumePatchOp to be compatible
 // with the rest of TensorFlow (odd padding is split so that more padding is put
 // on the right end of the tensor).
@@ -651,6 +654,7 @@ OVERRIDE_EVALUATOR(Eigen::ThreadPoolDevice);
 OVERRIDE_EVALUATOR(Eigen::DefaultDevice);
 
 #undef OVERRIDE_EVALUATOR
+#pragma GCC diagnostic pop
 
 };  // namespace Eigen
 

--- a/tensorflow/core/kernels/linalg/einsum_op_impl.h
+++ b/tensorflow/core/kernels/linalg/einsum_op_impl.h
@@ -583,7 +583,7 @@ struct EinsumHelper {
         ReshapeToRank3(*output, bcast.output_batch_size(), &output_reshaped));
     LaunchBatchMatMul<Device, T>::Launch(ctx, lhs, rhs, /*adj_x=*/false,
                                          /*adj_y=*/false, trans_x, trans_y,
-                                         bcast, &output_reshaped);
+                                         bcast, &output_reshaped, se::blas::CallContext::kNone);
     return Status::OK();
   }
 };

--- a/tensorflow/core/kernels/linalg/einsum_op_impl.h
+++ b/tensorflow/core/kernels/linalg/einsum_op_impl.h
@@ -583,7 +583,7 @@ struct EinsumHelper {
         ReshapeToRank3(*output, bcast.output_batch_size(), &output_reshaped));
     LaunchBatchMatMul<Device, T>::Launch(ctx, lhs, rhs, /*adj_x=*/false,
                                          /*adj_y=*/false, trans_x, trans_y,
-                                         bcast, &output_reshaped, se::blas::CallContext::kNone);
+                                         bcast, &output_reshaped, static_cast<int>(se::blas::CallContext::kNone));
     return Status::OK();
   }
 };

--- a/tensorflow/core/kernels/linalg/einsum_op_impl.h
+++ b/tensorflow/core/kernels/linalg/einsum_op_impl.h
@@ -581,9 +581,15 @@ struct EinsumHelper {
     Tensor output_reshaped;
     TF_RETURN_IF_ERROR(
         ReshapeToRank3(*output, bcast.output_batch_size(), &output_reshaped));
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
     LaunchBatchMatMul<Device, T>::Launch(ctx, lhs, rhs, /*adj_x=*/false,
                                          /*adj_y=*/false, trans_x, trans_y,
                                          bcast, &output_reshaped, static_cast<int>(se::blas::CallContext::kNone));
+#else
+    LaunchBatchMatMul<Device, T>::Launch(ctx, lhs, rhs, /*adj_x=*/false,
+                                         /*adj_y=*/false, trans_x, trans_y,
+                                         bcast, &output_reshaped, 0);
+#endif
     return Status::OK();
   }
 };

--- a/tensorflow/core/kernels/matmul_op.cc
+++ b/tensorflow/core/kernels/matmul_op.cc
@@ -119,7 +119,8 @@ struct LaunchMatMulBase {
   static void launch(
       OpKernelContext* ctx, const Tensor& a, const Tensor& b,
       const Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1>& dim_pair,
-      std::vector<AlgorithmType>* algorithms, bool use_autotune, Tensor* out) {
+      std::vector<AlgorithmType>* algorithms, bool use_autotune,
+      bool grad_a, bool grad_b, Tensor* out) {
     // An explicit vector-matrix multiply is much better optimized than an
     // implicit one and this is a bottleneck during non-batched inference.
     bool was_vector = ExplicitVectorMatrixOptimization<T>(a, b, dim_pair, out);
@@ -242,7 +243,8 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
   static void launch(
       OpKernelContext* ctx, const Tensor& a, const Tensor& b,
       const Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1>& dim_pair,
-      std::vector<int64>* algorithms, bool use_autotune, Tensor* out) {
+      std::vector<int64>* algorithms, bool use_autotune,
+      bool grad_a, bool grad_b, Tensor* out) {
     using se::blas::AlgorithmConfig;
     using se::blas::ComputationType;
     using se::blas::kDefaultAlgorithm;
@@ -269,8 +271,6 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
                                 b.template flat<T>().size());
     auto c_ptr = AsDeviceMemory(out->template flat<T>().data(),
                                 out->template flat<T>().size());
-    auto alpha = static_cast<T>(1.0);
-    auto beta = static_cast<T>(0.0);
 
     int device_id = stream->parent()->device_ordinal();
     DataType dtype = a.dtype();
@@ -282,6 +282,18 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
     ComputationType computation_type;
     bool compute_type_supported =
         GetCublasAutotuneComputationType(dtype, &computation_type);
+    typedef typename std::conditional<std::is_same<T, Eigen::half>::value, float, T>::type AlphaT;
+    se::blas::GemmCallContext<T> arg{blas_transpose_b, blas_transpose_a,
+        n, m, k, 1.0, 0.0, &b_ptr,
+        transpose_b ? k : n, &a_ptr, transpose_a ? m : k,
+        &c_ptr, n};
+
+    // reversed because we swap inputs
+    if(grad_a)
+      arg.context = se::blas::CallContext::kBackpropInput2;
+    else if(grad_b)
+      arg.context = se::blas::CallContext::kBackpropInput1;
+
     if (use_autotune && compute_type_supported && !algorithms->empty()) {
       ProfileResult best_result;
       // TODO(yangzihao): Unify this code with conv autotuning.
@@ -294,14 +306,10 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
           // where A, B and C are assumed to be in column major.
           // We want the output to be in row-major, so we can compute
           // C' = B' x A' (' stands for transpose)
-          bool cublas_launch_status =
-              stream
-                  ->ThenBlasGemmWithAlgorithm(
-                      blas_transpose_b, blas_transpose_a, n, m, k, alpha, b_ptr,
-                      transpose_b ? k : n, a_ptr, transpose_a ? m : k, beta,
-                      &c_ptr, n, computation_type, profile_algorithm,
-                      &profile_result)
-                  .ok();
+          arg.type = computation_type;
+          arg.algorithm = profile_algorithm;
+          arg.output_profile_result = &profile_result;
+          bool cublas_launch_status = stream->ThenBlasGemm(arg).ok();	  
           if (cublas_launch_status) {
             if (profile_result.is_valid()) {
               if (profile_result.elapsed_time_in_ms() <
@@ -312,13 +320,10 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
           }
         }
         // Try BlasGemmWithProfiling
-        bool cublas_launch_status =
-            stream
-                ->ThenBlasGemmWithProfiling(
-                    blas_transpose_b, blas_transpose_a, n, m, k, 1.0, b_ptr,
-                    transpose_b ? k : n, a_ptr, transpose_a ? m : k, 0.0,
-                    &c_ptr, n, &profile_result)
-                .ok();
+        arg.type = se::blas::ComputationType::kUndefined;
+        arg.algorithm = se::blas::kDefaultGemmAlgo;
+        arg.output_profile_result = &profile_result;
+        bool cublas_launch_status = stream->ThenBlasGemm(arg).ok();
         if (cublas_launch_status) {
           if (profile_result.is_valid()) {
             if (profile_result.elapsed_time_in_ms() <
@@ -353,14 +358,10 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
       if (algorithm_config.algorithm() != kNoAlgorithm &&
           algorithm_config.algorithm() != kDefaultBlasGemm &&
           algorithm_config.algorithm() != kDefaultBlasGemv) {
-        bool cublas_launch_status =
-            stream
-                ->ThenBlasGemmWithAlgorithm(
-                    blas_transpose_b, blas_transpose_a, n, m, k, alpha, b_ptr,
-                    transpose_b ? k : n, a_ptr, transpose_a ? m : k, beta,
-                    &c_ptr, n, computation_type, algorithm_config.algorithm(),
-                    nullptr)
-                .ok();
+        arg.type = computation_type;
+        arg.algorithm = algorithm_config.algorithm();
+        arg.output_profile_result = nullptr;
+        bool cublas_launch_status = stream->ThenBlasGemm(arg).ok();
         if (!cublas_launch_status) {
           ctx->SetStatus(errors::Internal(
               "Blas GEMM with algorithm launch failed : a.shape=(",
@@ -395,12 +396,10 @@ struct LaunchMatMul<GPUDevice, T, true /* USE_CUBLAS */> {
                                    a_ptr, b_ptr, &c_ptr, nullptr);
       } else {
         // Use C' = B' x A' (' stands for transpose)
-        bool blas_launch_status =
-            stream
-                ->ThenBlasGemm(blas_transpose_b, blas_transpose_a, n, m, k,
-                               1.0f, b_ptr, transpose_b ? k : n, a_ptr,
-                               transpose_a ? m : k, 0.0f, &c_ptr, n)
-                .ok();
+        arg.type = se::blas::ComputationType::kUndefined;
+        arg.algorithm = se::blas::kDefaultGemmAlgo;
+        arg.output_profile_result = nullptr;
+        bool blas_launch_status = stream->ThenBlasGemm(arg).ok();
         if (!blas_launch_status) {
           ctx->SetStatus(errors::Internal(
               "Blas GEMM launch failed : a.shape=(", a.dim_size(0), ", ",
@@ -431,6 +430,8 @@ class MatMulOp : public OpKernel {
       : OpKernel(ctx), algorithms_set_already_(false) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_a", &transpose_a_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_b", &transpose_b_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("grad_a", &grad_a_));
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("grad_b", &grad_b_));
 
     LaunchMatMul<Device, T, USE_CUBLAS>::GetBlasGemmAlgorithm(
         ctx, &algorithms_, &algorithms_set_already_);
@@ -499,12 +500,14 @@ class MatMulOp : public OpKernel {
 
       LaunchMatMul<Device, float, USE_CUBLAS>::launch(
           ctx, a_float, b_float, dim_pair, &algorithms_, use_autotune_,
+          grad_a_, grad_b_,
           &out_float);
       FloatToBFloat16(out_float.flat<float>().data(),
                       out->flat<bfloat16>().data(), out->NumElements());
     } else {
       LaunchMatMul<Device, T, USE_CUBLAS>::launch(
-          ctx, a, b, dim_pair, &algorithms_, use_autotune_, out);
+          ctx, a, b, dim_pair, &algorithms_, use_autotune_,
+          grad_a_, grad_b_, out);
     }
   }
 
@@ -514,6 +517,7 @@ class MatMulOp : public OpKernel {
   bool use_autotune_;
   bool transpose_a_;
   bool transpose_b_;
+  bool grad_a_, grad_b_;
 };
 
 namespace functor {

--- a/tensorflow/core/kernels/rnn/blas_gemm.cc
+++ b/tensorflow/core/kernels/rnn/blas_gemm.cc
@@ -40,7 +40,7 @@ void TensorCuBlasGemm<T>::operator()(OpKernelContext* ctx, bool transa,
                                      bool transb, uint64 m, uint64 n, uint64 k,
                                      float alpha, const T* a, int lda,
                                      const T* b, int ldb, float beta, T* c,
-                                     int ldc, se::blas::CallContext call_context) {
+                                     int ldc, int call_context) {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                  se::blas::Transpose::kTranspose};
@@ -53,7 +53,7 @@ void TensorCuBlasGemm<T>::operator()(OpKernelContext* ctx, bool transa,
       ctx->op_device_context()
           ->stream()
           ->ThenBlasGemm(se::blas::GemmCallContext<T>{trans[transa], trans[transb], m, n, k,
-                         alpha, beta, &a_ptr, lda, &b_ptr, ldb, &c_ptr, ldc, call_context})
+                         alpha, beta, &a_ptr, lda, &b_ptr, ldb, &c_ptr, ldc, static_cast<se::blas::CallContext>(call_context)})
           .ok();
   OP_REQUIRES(ctx, blas_launch_status, errors::Aborted("CuBlasGemm failed!"));
 #else

--- a/tensorflow/core/kernels/rnn/blas_gemm.cc
+++ b/tensorflow/core/kernels/rnn/blas_gemm.cc
@@ -40,7 +40,7 @@ void TensorCuBlasGemm<T>::operator()(OpKernelContext* ctx, bool transa,
                                      bool transb, uint64 m, uint64 n, uint64 k,
                                      float alpha, const T* a, int lda,
                                      const T* b, int ldb, float beta, T* c,
-                                     int ldc) {
+                                     int ldc, se::blas::CallContext call_context) {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                  se::blas::Transpose::kTranspose};
@@ -52,8 +52,8 @@ void TensorCuBlasGemm<T>::operator()(OpKernelContext* ctx, bool transa,
   bool blas_launch_status =
       ctx->op_device_context()
           ->stream()
-          ->ThenBlasGemm(trans[transa], trans[transb], m, n, k, alpha, a_ptr,
-                         lda, b_ptr, ldb, beta, &c_ptr, ldc)
+          ->ThenBlasGemm(se::blas::GemmCallContext<T>{trans[transa], trans[transb], m, n, k,
+                         alpha, beta, &a_ptr, lda, &b_ptr, ldb, &c_ptr, ldc, call_context})
           .ok();
   OP_REQUIRES(ctx, blas_launch_status, errors::Aborted("CuBlasGemm failed!"));
 #else

--- a/tensorflow/core/kernels/rnn/blas_gemm.h
+++ b/tensorflow/core/kernels/rnn/blas_gemm.h
@@ -25,6 +25,10 @@ limitations under the License.
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #endif
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/platform/stream_executor.h"
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 namespace tensorflow {
 class OpKernelContext;
 namespace functor {
@@ -33,7 +37,8 @@ template <typename T>
 struct TensorCuBlasGemm {
   void operator()(OpKernelContext* ctx, bool transa, bool transb, uint64 m,
                   uint64 n, uint64 k, float alpha, const T* a, int lda,
-                  const T* b, int ldb, float beta, T* c, int ldc);
+                  const T* b, int ldb, float beta, T* c, int ldc,
+		  se::blas::CallContext);
 };
 
 template <typename T>
@@ -56,14 +61,15 @@ struct TensorBlasGemm<Device, T, true /* USE_CUBLAS */> {
                       typename TTypes<T>::ConstMatrix a,
                       typename TTypes<T>::ConstMatrix b,
                       typename gemm_compute_type<T>::type beta,
-                      typename TTypes<T>::Matrix c) {
+                      typename TTypes<T>::Matrix c,
+                      se::blas::CallContext cc) {
     int64 m = c.dimensions()[0];
     int64 n = c.dimensions()[1];
     int64 k = transa ? a.dimensions()[0] : a.dimensions()[1];
 
     TensorCuBlasGemm<T>()(ctx, transb, transa, n, m, k, alpha, b.data(),
                           transb ? k : n, a.data(), transa ? m : k, beta,
-                          c.data(), n);
+                          c.data(), n, cc);
   }
 };
 
@@ -74,7 +80,8 @@ struct TensorBlasGemm<Device, T, false /* USE_CUBLAS */> {
                       typename TTypes<T>::ConstMatrix a,
                       typename TTypes<T>::ConstMatrix b,
                       typename gemm_compute_type<T>::type beta,
-                      typename TTypes<T>::Matrix c) {
+                      typename TTypes<T>::Matrix c,
+                      se::blas::CallContext cc) {
     Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1> contract_pairs;
     contract_pairs[0] =
         Eigen::IndexPair<Eigen::DenseIndex>(transa == false, transb == true);

--- a/tensorflow/core/kernels/rnn/blas_gemm.h
+++ b/tensorflow/core/kernels/rnn/blas_gemm.h
@@ -38,7 +38,7 @@ struct TensorCuBlasGemm {
   void operator()(OpKernelContext* ctx, bool transa, bool transb, uint64 m,
                   uint64 n, uint64 k, float alpha, const T* a, int lda,
                   const T* b, int ldb, float beta, T* c, int ldc,
-		  se::blas::CallContext);
+		  int cc);
 };
 
 template <typename T>
@@ -62,7 +62,7 @@ struct TensorBlasGemm<Device, T, true /* USE_CUBLAS */> {
                       typename TTypes<T>::ConstMatrix b,
                       typename gemm_compute_type<T>::type beta,
                       typename TTypes<T>::Matrix c,
-                      se::blas::CallContext cc) {
+                      int cc) {
     int64 m = c.dimensions()[0];
     int64 n = c.dimensions()[1];
     int64 k = transa ? a.dimensions()[0] : a.dimensions()[1];
@@ -81,7 +81,7 @@ struct TensorBlasGemm<Device, T, false /* USE_CUBLAS */> {
                       typename TTypes<T>::ConstMatrix b,
                       typename gemm_compute_type<T>::type beta,
                       typename TTypes<T>::Matrix c,
-                      se::blas::CallContext cc) {
+                      int cc) {
     Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1> contract_pairs;
     contract_pairs[0] =
         Eigen::IndexPair<Eigen::DenseIndex>(transa == false, transb == true);

--- a/tensorflow/core/kernels/rnn/gru_ops.h
+++ b/tensorflow/core/kernels/rnn/gru_ops.h
@@ -90,7 +90,7 @@ struct GRUBlockCellFprop : public GRUCell {
     TensorBlasGemm<Device, T, USE_CUBLAS>::compute(
         ctx, d, false, false, typename gemm_compute_type<T>::type(1.f),
         const_x_h_prev, w_ru, typename gemm_compute_type<T>::type(0.f),
-        r_u_bar);
+        r_u_bar, se::blas::CallContext::kNone);
 
     // Creating a bias matrix for adding by broadcasting 'b_ru'
     Eigen::array<Eigen::DenseIndex, 2> broadcast_shape({batch_size_, 1});
@@ -110,7 +110,8 @@ struct GRUBlockCellFprop : public GRUCell {
                                                     x_h_prevr.dimensions());
     TensorBlasGemm<Device, T, USE_CUBLAS>::compute(
         ctx, d, false, false, typename gemm_compute_type<T>::type(1.f),
-        const_x_h_prevr, w_c, typename gemm_compute_type<T>::type(0.f), c);
+        const_x_h_prevr, w_c, typename gemm_compute_type<T>::type(0.f), c,
+        se::blas::CallContext::kNone);
 
     Eigen::array<Eigen::DenseIndex, 2> b_c_shape({1, b_c.dimensions()[0]});
     c.device(d) += (b_c.reshape(b_c_shape).broadcast(broadcast_shape));
@@ -154,7 +155,7 @@ struct GRUBlockCellBprop : public GRUCell {
     TensorBlasGemm<Device, T, USE_CUBLAS>::compute(
         ctx, d, false, true, typename gemm_compute_type<T>::type(1.f),
         const_d_c_bar, w_c, typename gemm_compute_type<T>::type(0.f),
-        d_x_comp2_and_h_prevr);
+        d_x_comp2_and_h_prevr, se::blas::CallContext::kBackpropInput1);
 
     d_hr.device(d) = d_x_comp2_and_h_prevr.slice(h_offsets(), h_extends());
     d_r_bar.device(d) = (d_hr * h_prev * r) * (r.constant(T(1)) - r);
@@ -170,7 +171,7 @@ struct GRUBlockCellBprop : public GRUCell {
     TensorBlasGemm<Device, T, USE_CUBLAS>::compute(
         ctx, d, false, true, typename gemm_compute_type<T>::type(1.f),
         const_d_r_bar_u_bar, w_ru, typename gemm_compute_type<T>::type(0.f),
-        d_x_comp1_and_h_prev_comp1);
+        d_x_comp1_and_h_prev_comp1, se::blas::CallContext::kBackpropInput1);
 
     // d_x = d_x_comp1 + d_x_comp2
     d_x.device(d) = (d_x_comp1_and_h_prev_comp1 + d_x_comp2_and_h_prevr)

--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -62,7 +62,8 @@ void LSTMBlockCellFpropWithEigen(
   typename TTypes<T>::ConstMatrix const_xh(xh.data(), xh.dimensions());
   TensorBlasGemm<CPUDevice, T, false /* USE_CUBLAS */>::compute(
       ctx, d, false, false, typename gemm_compute_type<T>::type(1.f), const_xh,
-      w, typename gemm_compute_type<T>::type(0.f), gates);
+      w, typename gemm_compute_type<T>::type(0.f), gates,
+      se::blas::CallContext::kForward);
   Eigen::array<Eigen::DenseIndex, 2> b_shape({1, b.dimensions()[0]});
   Eigen::array<Eigen::DenseIndex, 2> broadcast_shape({cell.batch_size(), 1});
   gates.device(d) += b.reshape(b_shape).broadcast(broadcast_shape);

--- a/tensorflow/core/kernels/rnn/lstm_ops.h
+++ b/tensorflow/core/kernels/rnn/lstm_ops.h
@@ -276,7 +276,8 @@ struct BlockLSTMBprop : public LSTMBlockCell {
     typename TTypes<T>::ConstMatrix const_dgates(dgates.data(),
                                                  dgates.dimensions());
     TensorBlasGemm<Device, T, USE_CUBLAS>::compute(
-        ctx, d, false, true, 1.f, const_dgates, w, 0.f, xh_grad);
+        ctx, d, false, true, 1.f, const_dgates, w, 0.f, xh_grad,
+        se::blas::CallContext::kBackpropInput1);
 
     // xh.
     xh.slice(xh_x_offsets(), xh_x_extents()).device(d) = x;
@@ -289,7 +290,8 @@ struct BlockLSTMBprop : public LSTMBlockCell {
 
     // w_grad.
     TensorBlasGemm<Device, T, USE_CUBLAS>::compute(
-        ctx, d, true, false, 1.f, const_xh, const_dgates, 1.f, w_grad);
+        ctx, d, true, false, 1.f, const_xh, const_dgates, 1.f, w_grad,
+        se::blas::CallContext::kBackpropInput2);
 
     // b_grad.
     b_grad.device(d) += dgates.sum(Eigen::array<int, 1>({0}));

--- a/tensorflow/core/kernels/rnn/lstm_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops_gpu.cu.cc
@@ -255,7 +255,7 @@ void LSTMBlockCellFpropWithCUDA(
   typename TTypes<T>::ConstMatrix const_xh(xh.data(), xh.dimensions());
   TensorBlasGemm<GPUDevice, T, true /* USE_CUBLAS */>::compute(
       ctx, d, false, false, typename gemm_compute_type<T>::type(1.f), const_xh,
-      w, typename gemm_compute_type<T>::type(0.f), gates);
+      w, typename gemm_compute_type<T>::type(0.f), gates, se::blas::CallContext::kNone);
 
   // Add bias, apply non-linearities and gating.
   //

--- a/tensorflow/core/kernels/rnn/lstm_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops_gpu.cu.cc
@@ -255,7 +255,7 @@ void LSTMBlockCellFpropWithCUDA(
   typename TTypes<T>::ConstMatrix const_xh(xh.data(), xh.dimensions());
   TensorBlasGemm<GPUDevice, T, true /* USE_CUBLAS */>::compute(
       ctx, d, false, false, typename gemm_compute_type<T>::type(1.f), const_xh,
-      w, typename gemm_compute_type<T>::type(0.f), gates, se::blas::CallContext::kNone);
+      w, typename gemm_compute_type<T>::type(0.f), gates, static_cast<int>(se::blas::CallContext::kNone));
 
   // Add bias, apply non-linearities and gating.
   //

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -124,6 +124,8 @@ REGISTER_OP("BatchMatMul")
         "complex128}")
     .Attr("adj_x: bool = false")
     .Attr("adj_y: bool = false")
+    .Attr("grad_x: bool = false")
+    .Attr("grad_y: bool = false")
     .SetShapeFn(shape_inference::BatchMatMulShape);
 
 REGISTER_OP("BatchMatMulV2")
@@ -135,6 +137,8 @@ REGISTER_OP("BatchMatMulV2")
         "complex128}")
     .Attr("adj_x: bool = false")
     .Attr("adj_y: bool = false")
+    .Attr("grad_x: bool = false")
+    .Attr("grad_y: bool = false")
     .SetShapeFn(shape_inference::BatchMatMulV2Shape);
 
 // Note: Reusing the BatchMatMulV2Shape inference function
@@ -148,6 +152,8 @@ REGISTER_OP("BatchGemm")
     .Attr("adj_y: bool = false")
     .Attr("alpha: float = 1.0")
     .Attr("beta: float = 0.0")
+    .Attr("grad_x: bool = false")
+    .Attr("grad_y: bool = false")
     .SetShapeFn(shape_inference::BatchMatMulV2Shape);
 
 #ifdef INTEL_MKL
@@ -1057,6 +1063,8 @@ REGISTER_OP("MatMul")
     .Attr(
         "T: {bfloat16, half, float, double, int32, int64, complex64, "
         "complex128}")
+    .Attr("grad_a: bool = false")
+    .Attr("grad_b: bool = false")
     .SetShapeFn(shape_inference::MatMulShape);
 
 #ifdef INTEL_MKL

--- a/tensorflow/core/ops/ops.pbtxt
+++ b/tensorflow/core/ops/ops.pbtxt
@@ -3764,6 +3764,20 @@ op {
       b: false
     }
   }
+  attr {
+    name: "grad_x"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
+  attr {
+    name: "grad_y"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
 }
 op {
   name: "BatchMatMulV2"
@@ -3805,6 +3819,20 @@ op {
   }
   attr {
     name: "adj_y"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
+  attr {
+    name: "grad_x"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
+  attr {
+    name: "grad_y"
     type: "bool"
     default_value {
       b: false
@@ -23194,6 +23222,20 @@ op {
         type: DT_COMPLEX64
         type: DT_COMPLEX128
       }
+    }
+  }
+  attr {
+    name: "grad_a"
+    type: "bool"
+    default_value {
+      b: false
+    }
+  }
+  attr {
+    name: "grad_b"
+    type: "bool"
+    default_value {
+      b: false
     }
   }
 }

--- a/tensorflow/python/debug/cli/analyzer_cli_test.py
+++ b/tensorflow/python/debug/cli/analyzer_cli_test.py
@@ -927,6 +927,8 @@ class AnalyzerCLISimpleMulAddTest(test_util.TensorFlowTestCase):
 
     test_attr_key_val_pairs = [("transpose_a", "b: false"),
                                ("transpose_b", "b: false"),
+                               ('grad_a', 'b: false'),
+                               ('grad_b', 'b: false'),
                                ("T", "type: DT_DOUBLE")]
     if test_util.IsMklEnabled():
       test_attr_key_val_pairs.append(("_kernel", 's: "MklNameChangeOp"'))

--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -679,7 +679,8 @@ class AutoMixedPrecisionTest(test.TestCase, parameterized.TestCase):
       self._assert_output_f16(mode, node_map, 'Relu' + suffix)
       self._assert_output_f16(mode, node_map, 'MaxPool' + suffix)
     self._assert_output_f16(mode, node_map, 'concat')
-    self.assertAllClose(output_val_ref, output_val, atol=1e-3, rtol=1e-3)
+    tol=1e-2 if test.is_built_with_rocm else 1e-3
+      self.assertAllClose(output_val_ref, output_val, atol=tol, rtol=tol)
 
   @parameterized.parameters(['cuda', 'mkl'])
   @test_util.run_deprecated_v1

--- a/tensorflow/python/grappler/auto_mixed_precision_test.py
+++ b/tensorflow/python/grappler/auto_mixed_precision_test.py
@@ -678,8 +678,8 @@ class AutoMixedPrecisionTest(test.TestCase, parameterized.TestCase):
       self._assert_output_f16(mode, node_map, 'Conv2D' + suffix)
       self._assert_output_f16(mode, node_map, 'Relu' + suffix)
       self._assert_output_f16(mode, node_map, 'MaxPool' + suffix)
-    self._assert_output_f16(mode, node_map, 'concat')
-    tol=1e-2 if test.is_built_with_rocm else 1e-3
+      self._assert_output_f16(mode, node_map, 'concat')
+      tol=1e-2 if test.is_built_with_rocm else 1e-3
       self.assertAllClose(output_val_ref, output_val, atol=tol, rtol=tol)
 
   @parameterized.parameters(['cuda', 'mkl'])

--- a/tensorflow/python/ops/linalg/linear_operator.py
+++ b/tensorflow/python/ops/linalg/linear_operator.py
@@ -1217,6 +1217,8 @@ def _matmul(  # pylint:disable=missing-docstring
     adjoint_b=False,
     a_is_sparse=False,
     b_is_sparse=False,
+    grad_a=False,
+    grad_b=False,
     name=None):
   if transpose_a or transpose_b:
     raise ValueError("Transposing not supported at this time.")

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -1646,13 +1646,13 @@ def _MatMulGradAgainstFirstOnly(op, grad):
   t_b = op.get_attr("transpose_b")
   b = math_ops.conj(op.inputs[1])
   if not t_a and not t_b:
-    grad_a = gen_math_ops.mat_mul(grad, b, transpose_b=True)
+    grad_a = gen_math_ops.mat_mul(grad, b, transpose_b=True, grad_a=True)
   elif not t_a and t_b:
-    grad_a = gen_math_ops.mat_mul(grad, b)
+    grad_a = gen_math_ops.mat_mul(grad, b, grad_a=True)
   elif t_a and not t_b:
-    grad_a = gen_math_ops.mat_mul(b, grad, transpose_b=True)
+    grad_a = gen_math_ops.mat_mul(b, grad, transpose_b=True, grad_a=True)
   elif t_a and t_b:
-    grad_a = gen_math_ops.mat_mul(b, grad, transpose_a=True, transpose_b=True)
+    grad_a = gen_math_ops.mat_mul(b, grad, transpose_a=True, transpose_b=True, grad_a=True)
   return grad_a, None
 
 
@@ -1662,13 +1662,13 @@ def _MatMulGradAgainstSecondOnly(op, grad):
   t_b = op.get_attr("transpose_b")
   a = math_ops.conj(op.inputs[0])
   if not t_a and not t_b:
-    grad_b = gen_math_ops.mat_mul(a, grad, transpose_a=True)
+    grad_b = gen_math_ops.mat_mul(a, grad, transpose_a=True, grad_b=True)
   elif not t_a and t_b:
-    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True)
+    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True, grad_b=True)
   elif t_a and not t_b:
-    grad_b = gen_math_ops.mat_mul(a, grad)
+    grad_b = gen_math_ops.mat_mul(a, grad, grad_b=True)
   elif t_a and t_b:
-    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True, transpose_b=True)
+    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True, transpose_b=True, grad_b=True)
   return None, grad_b
 
 
@@ -1691,17 +1691,17 @@ def _MatMulGrad(op, grad):
   a = math_ops.conj(op.inputs[0])
   b = math_ops.conj(op.inputs[1])
   if not t_a and not t_b:
-    grad_a = gen_math_ops.mat_mul(grad, b, transpose_b=True)
-    grad_b = gen_math_ops.mat_mul(a, grad, transpose_a=True)
+    grad_a = gen_math_ops.mat_mul(grad, b, transpose_b=True, grad_a=True)
+    grad_b = gen_math_ops.mat_mul(a, grad, transpose_a=True, grad_b=True)
   elif not t_a and t_b:
-    grad_a = gen_math_ops.mat_mul(grad, b)
-    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True)
+    grad_a = gen_math_ops.mat_mul(grad, b, grad_a=True)
+    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True, grad_b=True)
   elif t_a and not t_b:
-    grad_a = gen_math_ops.mat_mul(b, grad, transpose_b=True)
-    grad_b = gen_math_ops.mat_mul(a, grad)
+    grad_a = gen_math_ops.mat_mul(b, grad, transpose_b=True, grad_a=True)
+    grad_b = gen_math_ops.mat_mul(a, grad, grad_b=True)
   elif t_a and t_b:
-    grad_a = gen_math_ops.mat_mul(b, grad, transpose_a=True, transpose_b=True)
-    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True, transpose_b=True)
+    grad_a = gen_math_ops.mat_mul(b, grad, transpose_a=True, transpose_b=True, grad_a=True)
+    grad_b = gen_math_ops.mat_mul(grad, a, transpose_a=True, transpose_b=True, grad_b=True)
   return grad_a, grad_b
 
 
@@ -1788,18 +1788,18 @@ def _BatchMatMul(op, grad):
 
   if not adj_x:
     if not adj_y:
-      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=True)
-      grad_y = math_ops.matmul(x, grad, adjoint_a=True, adjoint_b=False)
+      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=True, grad_a=True)
+      grad_y = math_ops.matmul(x, grad, adjoint_a=True, adjoint_b=False, grad_b=True)
     else:
-      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=False)
-      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=False)
+      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=False, grad_a=True)
+      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=False, grad_b=True)
   else:
     if not adj_y:
-      grad_x = math_ops.matmul(y, grad, adjoint_a=False, adjoint_b=True)
-      grad_y = math_ops.matmul(x, grad, adjoint_a=False, adjoint_b=False)
+      grad_x = math_ops.matmul(y, grad, adjoint_a=False, adjoint_b=True, grad_a=True)
+      grad_y = math_ops.matmul(x, grad, adjoint_a=False, adjoint_b=False, grad_b=True)
     else:
-      grad_x = math_ops.matmul(y, grad, adjoint_a=True, adjoint_b=True)
-      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=True)
+      grad_x = math_ops.matmul(y, grad, adjoint_a=True, adjoint_b=True, grad_a=True)
+      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=True, grad_b=True)
 
   return grad_x, grad_y
 
@@ -1814,18 +1814,18 @@ def _BatchMatMulV2(op, grad):
 
   if not adj_x:
     if not adj_y:
-      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=True)
-      grad_y = math_ops.matmul(x, grad, adjoint_a=True, adjoint_b=False)
+      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=True, grad_a=True)
+      grad_y = math_ops.matmul(x, grad, adjoint_a=True, adjoint_b=False, grad_b=True)
     else:
-      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=False)
-      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=False)
+      grad_x = math_ops.matmul(grad, y, adjoint_a=False, adjoint_b=False, grad_a=True)
+      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=False, grad_b=True)
   else:
     if not adj_y:
-      grad_x = math_ops.matmul(y, grad, adjoint_a=False, adjoint_b=True)
-      grad_y = math_ops.matmul(x, grad, adjoint_a=False, adjoint_b=False)
+      grad_x = math_ops.matmul(y, grad, adjoint_a=False, adjoint_b=True, grad_a=True)
+      grad_y = math_ops.matmul(x, grad, adjoint_a=False, adjoint_b=False, grad_b=True)
     else:
-      grad_x = math_ops.matmul(y, grad, adjoint_a=True, adjoint_b=True)
-      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=True)
+      grad_x = math_ops.matmul(y, grad, adjoint_a=True, adjoint_b=True, grad_a=True)
+      grad_y = math_ops.matmul(grad, x, adjoint_a=True, adjoint_b=True, grad_b=True)
 
   # Reduce along the broadcasted batch dimensions, if broadcasting is required.
   shape_x_static = x.get_shape()

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3130,6 +3130,8 @@ def matmul(a,
            adjoint_b=False,
            a_is_sparse=False,
            b_is_sparse=False,
+           grad_a=False,
+           grad_b=False,
            name=None):
   """Multiplies matrix `a` by matrix `b`, producing `a` * `b`.
 
@@ -3274,7 +3276,8 @@ def matmul(a,
         b = conj(b)
         adjoint_b = True
       return gen_math_ops.batch_mat_mul_v2(
-          a, b, adj_x=adjoint_a, adj_y=adjoint_b, name=name)
+          a, b, adj_x=adjoint_a, adj_y=adjoint_b,
+          grad_x=grad_a, grad_y=grad_b, name=name)
 
     # Neither matmul nor sparse_matmul support adjoint, so we conjugate
     # the matrix and use transpose instead. Conj() is a noop for real
@@ -3312,7 +3315,8 @@ def matmul(a,
       return ret
     else:
       return gen_math_ops.mat_mul(
-          a, b, transpose_a=transpose_a, transpose_b=transpose_b, name=name)
+          a, b, transpose_a=transpose_a, transpose_b=transpose_b, 
+          grad_a=grad_a, grad_b=grad_b, name=name)
 
 
 @tf_export("linalg.batch_gemm", "batch_gemm")
@@ -3324,6 +3328,8 @@ def batch_gemm(a,
            transpose_b=False,
            alpha=1.0,
            beta=0.0,
+           grad_a=False,
+           grad_b=False,
            name=None):
   with ops.name_scope(name, "BatchGemm", [a, b]) as name:
     if context.executing_eagerly():
@@ -3338,7 +3344,8 @@ def batch_gemm(a,
       b = ops.convert_to_tensor(b, name="b")
       c = ops.convert_to_tensor(c, name="c")
 
-    return gen_math_ops.batch_gemm(a, b, c, adj_x=transpose_a, adj_y=transpose_b, alpha=alpha, beta=beta, name=name)
+    return gen_math_ops.batch_gemm(a, b, c, adj_x=transpose_a, adj_y=transpose_b, alpha=alpha, beta=beta, 
+      grad_x=grad_a, grad_y=grad_b, name=name)
 
 @tf_export("linalg.matvec")
 @dispatch.add_dispatch_support

--- a/tensorflow/stream_executor/blas.h
+++ b/tensorflow/stream_executor/blas.h
@@ -109,6 +109,7 @@ enum class ComputationType {
   // to a smaller number of bits.
   kTF32AsF32,  // 32-bit floating-point with reduced (>=10-bit) mantissa
   kBF16AsF32,  // 32-bit floating-point with reduced (7-bit) mantissa
+  kUndefined  // undefined
 };
 
 enum class Epilogue {
@@ -116,6 +117,16 @@ enum class Epilogue {
   kReLU = 2,                      // Apply ReLU func point-wise to the results
   kBias = 4,                      // Add broadcasted bias vector to the results
   kBiasThenReLU = kBias | kReLU,  // Apply bias and then ReLU transform
+};
+
+// Call context information for GEMM API calls
+// This is extra information that can optionally be passed down to the blas
+// library, so that it can pick the efficient imlpementation based on context
+enum class CallContext {
+  kNone = 0,            // No information
+  kForward = 1,         // call happens in "forward" pass
+  kBackpropInput1 = 2,  // call happens in "backprop" pass for the first input
+  kBackpropInput2 = 4,  // call happens in "backprop" pass for the second input
 };
 
 // Converts a ComputationType to a string.
@@ -229,6 +240,68 @@ struct BlasLtMatmulPlanParams {
   int64 stride_a = 0;
   int64 stride_b = 0;
   int64 stride_c = 0;
+};
+
+template <class T>
+struct GemmCallContextAlpha
+{
+  typedef T type;
+};
+
+template <>
+struct GemmCallContextAlpha<Eigen::half>
+{
+  typedef float type;
+};
+
+template <>
+struct GemmCallContextAlpha<int8_t>
+{
+  typedef HostOrDeviceScalar<int> type;
+};
+
+template <class T, class U=T>
+struct GemmCallContext
+{
+  blas::Transpose transa;
+  blas::Transpose transb;
+  uint64 m, n, k;
+  typename GemmCallContextAlpha<T>::type alpha, beta;
+  const DeviceMemory<T> *pa;
+  int lda;
+  const DeviceMemory<T>* pb;
+  int ldb;
+  DeviceMemory<U> *c;
+  int ldc;
+  CallContext context = CallContext::kNone;
+  int64 stride_a = -1;
+  int64 stride_b = -1;
+  int64 stride_c = -1;
+  int batch_count = 1;
+  ComputationType type = ComputationType::kUndefined;
+  ProfileResult *output_profile_result = 0;
+  AlgorithmType algorithm = kDefaultGemmAlgo;
+};
+
+template <class T, class U=T>
+struct BatchedGemmCallContext
+{
+  blas::Transpose transa;
+  blas::Transpose transb;
+  uint64 m, n, k;
+  typename GemmCallContextAlpha<T>::type alpha, beta;
+  const port::ArraySlice<DeviceMemory<T> *> *pa;
+  int lda;
+  const port::ArraySlice<DeviceMemory<T> *> *pb;
+  int ldb;
+  const port::ArraySlice<DeviceMemory<U> *> *pc;
+  int ldc;
+  int batch_count;
+  CallContext context = CallContext::kNone;
+  ScratchAllocator *scratch_allocator = nullptr;
+  ComputationType type = ComputationType::kUndefined;
+  ProfileResult *output_profile_result = 0;
+  AlgorithmType algorithm = kDefaultGemmAlgo;
 };
 
 // BLAS support interface -- this can be derived from a GPU executor when the
@@ -1020,72 +1093,16 @@ class BlasSupport {
   // Note: The half interface uses float precision internally; the version
   // that uses half precision internally is not yet supported. There is no
   // batched version of the half-precision interface.
-  virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          float alpha, const DeviceMemory<Eigen::half> &a,
-                          int lda, const DeviceMemory<Eigen::half> &b, int ldb,
-                          float beta, DeviceMemory<Eigen::half> *c,
-                          int ldc) = 0;
-  virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          float alpha, const DeviceMemory<float> &a, int lda,
-                          const DeviceMemory<float> &b, int ldb, float beta,
-                          DeviceMemory<float> *c, int ldc) = 0;
-  virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          double alpha, const DeviceMemory<double> &a, int lda,
-                          const DeviceMemory<double> &b, int ldb, double beta,
-                          DeviceMemory<double> *c, int ldc) = 0;
-  virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          std::complex<float> alpha,
-                          const DeviceMemory<std::complex<float>> &a, int lda,
-                          const DeviceMemory<std::complex<float>> &b, int ldb,
-                          std::complex<float> beta,
-                          DeviceMemory<std::complex<float>> *c, int ldc) = 0;
-  virtual bool DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          std::complex<double> alpha,
-                          const DeviceMemory<std::complex<double>> &a, int lda,
-                          const DeviceMemory<std::complex<double>> &b, int ldb,
-                          std::complex<double> beta,
-                          DeviceMemory<std::complex<double>> *c, int ldc) = 0;
 
-  virtual bool DoBlasGemmWithProfiling(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
-      int lda, const DeviceMemory<Eigen::half> &b, int ldb, float beta,
-      DeviceMemory<Eigen::half> *c, int ldc,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithProfiling(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
-      const DeviceMemory<float> &b, int ldb, float beta, DeviceMemory<float> *c,
-      int ldc, ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithProfiling(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
-      const DeviceMemory<double> &b, int ldb, double beta,
-      DeviceMemory<double> *c, int ldc,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithProfiling(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, std::complex<float> alpha,
-      const DeviceMemory<std::complex<float>> &a, int lda,
-      const DeviceMemory<std::complex<float>> &b, int ldb,
-      std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithProfiling(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, std::complex<double> alpha,
-      const DeviceMemory<std::complex<double>> &a, int lda,
-      const DeviceMemory<std::complex<double>> &b, int ldb,
-      std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      ProfileResult *output_profile_result) = 0;
+  virtual bool DoBlasGemm(Stream *stream, blas::GemmCallContext<Eigen::half> ctx, blas::ProfileResult *output_profile_result = 0) = 0;
+  virtual bool DoBlasGemm(Stream *stream, blas::GemmCallContext<float> ctx, blas::ProfileResult *output_profile_result = 0) = 0;
+  virtual bool DoBlasGemm(Stream *stream, blas::GemmCallContext<double> ctx, blas::ProfileResult *output_profile_result = 0) = 0;
+  virtual bool DoBlasGemm(Stream *stream, blas::GemmCallContext<std::complex<float> > ctx, blas::ProfileResult *output_profile_result = 0) = 0;
+  virtual bool DoBlasGemm(Stream *stream, blas::GemmCallContext<std::complex<double> > ctx, blas::ProfileResult *output_profile_result = 0) = 0;
+  virtual bool DoBlasGemm(Stream *stream, blas::GemmCallContext<int8, int32> ctx, blas::ProfileResult *output_profile_result = 0) = 0;
 
   // Gets a list of supported algorithms for DoBlasGemmWithAlgorithm.
-  virtual bool GetBlasGemmAlgorithms(
-      std::vector<AlgorithmType> *out_algorithms) = 0;
+  virtual bool GetBlasGemmAlgorithms(std::vector<AlgorithmType> *out_algorithms) = 0;
 
   // Like DoBlasGemm, but accepts an algorithm and an compute type.
   //
@@ -1101,129 +1118,17 @@ class BlasSupport {
   // output_profile_result->is_valid().  This lets you use this function for
   // choosing the best algorithm among many (some of which may fail) without
   // creating a new Stream for each attempt.
-  virtual bool DoBlasGemmWithAlgorithm(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const HostOrDeviceScalar<int> &alpha,
-      const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b,
-      int ldb, const HostOrDeviceScalar<int> &beta, DeviceMemory<int32> *c,
-      int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithAlgorithm(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const HostOrDeviceScalar<Eigen::half> &alpha,
-      const DeviceMemory<Eigen::half> &a, int lda,
-      const DeviceMemory<Eigen::half> &b, int ldb,
-      const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
-      int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithAlgorithm(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const HostOrDeviceScalar<float> &alpha,
-      const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
-      int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
-      int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithAlgorithm(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const HostOrDeviceScalar<double> &alpha,
-      const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
-      int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
-      int ldc, ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithAlgorithm(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const HostOrDeviceScalar<std::complex<float>> &alpha,
-      const DeviceMemory<std::complex<float>> &a, int lda,
-      const DeviceMemory<std::complex<float>> &b, int ldb,
-      const HostOrDeviceScalar<std::complex<float>> &beta,
-      DeviceMemory<std::complex<float>> *c, int ldc,
-      ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
-  virtual bool DoBlasGemmWithAlgorithm(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const HostOrDeviceScalar<std::complex<double>> &alpha,
-      const DeviceMemory<std::complex<double>> &a, int lda,
-      const DeviceMemory<std::complex<double>> &b, int ldb,
-      const HostOrDeviceScalar<std::complex<double>> &beta,
-      DeviceMemory<std::complex<double>> *c, int ldc,
-      ComputationType computation_type, AlgorithmType algorithm,
-      ProfileResult *output_profile_result) = 0;
 
   // Computes a batch of matrix-matrix product with general matrices.
   // This is a batched version of DoBlasGemm.
   // The batched GEMM computes matrix product for each input/output in a, b,
   // and c, which contain batch_count DeviceMemory objects.
-  virtual bool DoBlasGemmBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, float alpha,
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,
-      float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator) = 0;
-  virtual bool DoBlasGemmBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, float alpha,
-      const port::ArraySlice<DeviceMemory<float> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<float> *> &b, int ldb, float beta,
-      const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
-  virtual bool DoBlasGemmBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, double alpha,
-      const port::ArraySlice<DeviceMemory<double> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<double> *> &b, int ldb, double beta,
-      const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
-  virtual bool DoBlasGemmBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, std::complex<float> alpha,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
-      std::complex<float> beta,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
-  virtual bool DoBlasGemmBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, std::complex<double> alpha,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
-      std::complex<double> beta,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator) = 0;
 
-  // Batched gemm with strides instead of pointer arrays.
-  virtual bool DoBlasGemmStridedBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
-      int lda, int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
-      int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
-      int64 stride_c, int batch_count) = 0;
-  virtual bool DoBlasGemmStridedBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
-      int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
-      float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-      int batch_count) = 0;
-  virtual bool DoBlasGemmStridedBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
-      int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
-      double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-      int batch_count) = 0;
-  virtual bool DoBlasGemmStridedBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, std::complex<float> alpha,
-      const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
-      const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
-      std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      int64 stride_c, int batch_count) = 0;
-  virtual bool DoBlasGemmStridedBatched(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, std::complex<double> alpha,
-      const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
-      const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
-      std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      int64 stride_c, int batch_count) = 0;
+  virtual bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<Eigen::half> ctx) = 0;
+  virtual bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<float> ctx) = 0;
+  virtual bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<double> ctx) = 0;
+  virtual bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<std::complex<float> > ctx) = 0;
+  virtual bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<std::complex<double> > ctx) = 0;
 
   // Computes a matrix-matrix product where one input matrix is Hermitian:
   //
@@ -2005,194 +1910,18 @@ class BlasSupport {
                   blas::Transpose trans, blas::Diagonal diag, uint64 n,        \
                   const DeviceMemory<std::complex<double>> &a, int lda,        \
                   DeviceMemory<std::complex<double>> *x, int incx) override;   \
-  bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
-                  blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
-                  float alpha, const DeviceMemory<Eigen::half> &a, int lda,    \
-                  const DeviceMemory<Eigen::half> &b, int ldb, float beta,     \
-                  DeviceMemory<Eigen::half> *c, int ldc) override;             \
-  bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
-                  blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
-                  float alpha, const DeviceMemory<float> &a, int lda,          \
-                  const DeviceMemory<float> &b, int ldb, float beta,           \
-                  DeviceMemory<float> *c, int ldc) override;                   \
-  bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
-                  blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
-                  double alpha, const DeviceMemory<double> &a, int lda,        \
-                  const DeviceMemory<double> &b, int ldb, double beta,         \
-                  DeviceMemory<double> *c, int ldc) override;                  \
-  bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
-                  blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
-                  std::complex<float> alpha,                                   \
-                  const DeviceMemory<std::complex<float>> &a, int lda,         \
-                  const DeviceMemory<std::complex<float>> &b, int ldb,         \
-                  std::complex<float> beta,                                    \
-                  DeviceMemory<std::complex<float>> *c, int ldc) override;     \
-  bool DoBlasGemm(Stream *stream, blas::Transpose transa,                      \
-                  blas::Transpose transb, uint64 m, uint64 n, uint64 k,        \
-                  std::complex<double> alpha,                                  \
-                  const DeviceMemory<std::complex<double>> &a, int lda,        \
-                  const DeviceMemory<std::complex<double>> &b, int ldb,        \
-                  std::complex<double> beta,                                   \
-                  DeviceMemory<std::complex<double>> *c, int ldc) override;    \
-  bool DoBlasGemmWithProfiling(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, float alpha,                               \
-      const DeviceMemory<Eigen::half> &a, int lda,                             \
-      const DeviceMemory<Eigen::half> &b, int ldb, float beta,                 \
-      DeviceMemory<Eigen::half> *c, int ldc,                                   \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithProfiling(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, \
-      int lda, const DeviceMemory<float> &b, int ldb, float beta,              \
-      DeviceMemory<float> *c, int ldc,                                         \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithProfiling(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, double alpha,                              \
-      const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,   \
-      int ldb, double beta, DeviceMemory<double> *c, int ldc,                  \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithProfiling(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, std::complex<float> alpha,                 \
-      const DeviceMemory<std::complex<float>> &a, int lda,                     \
-      const DeviceMemory<std::complex<float>> &b, int ldb,                     \
-      std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc, \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithProfiling(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, std::complex<double> alpha,                \
-      const DeviceMemory<std::complex<double>> &a, int lda,                    \
-      const DeviceMemory<std::complex<double>> &b, int ldb,                    \
-      std::complex<double> beta, DeviceMemory<std::complex<double>> *c,        \
-      int ldc, blas::ProfileResult *output_profile_result) override;           \
-  bool GetBlasGemmAlgorithms(std::vector<blas::AlgorithmType> *out_algorithms) \
-      override;                                                                \
-  bool DoBlasGemmWithAlgorithm(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, const HostOrDeviceScalar<int> &alpha,      \
-      const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b,       \
-      int ldb, const HostOrDeviceScalar<int> &beta, DeviceMemory<int> *c,      \
-      int ldc, blas::ComputationType computation_type,                         \
-      blas::AlgorithmType algorithm,                                           \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithAlgorithm(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k,                                            \
-      const HostOrDeviceScalar<Eigen::half> &alpha,                            \
-      const DeviceMemory<Eigen::half> &a, int lda,                             \
-      const DeviceMemory<Eigen::half> &b, int ldb,                             \
-      const HostOrDeviceScalar<Eigen::half> &beta,                             \
-      DeviceMemory<Eigen::half> *c, int ldc,                                   \
-      blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithAlgorithm(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, const HostOrDeviceScalar<float> &alpha,    \
-      const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,     \
-      int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,  \
-      int ldc, blas::ComputationType computation_type,                         \
-      blas::AlgorithmType algorithm,                                           \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithAlgorithm(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, const HostOrDeviceScalar<double> &alpha,   \
-      const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,   \
-      int ldb, const HostOrDeviceScalar<double> &beta,                         \
-      DeviceMemory<double> *c, int ldc,                                        \
-      blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithAlgorithm(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k,                                            \
-      const HostOrDeviceScalar<std::complex<float>> &alpha,                    \
-      const DeviceMemory<std::complex<float>> &a, int lda,                     \
-      const DeviceMemory<std::complex<float>> &b, int ldb,                     \
-      const HostOrDeviceScalar<std::complex<float>> &beta,                     \
-      DeviceMemory<std::complex<float>> *c, int ldc,                           \
-      blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmWithAlgorithm(                                                \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k,                                            \
-      const HostOrDeviceScalar<std::complex<double>> &alpha,                   \
-      const DeviceMemory<std::complex<double>> &a, int lda,                    \
-      const DeviceMemory<std::complex<double>> &b, int ldb,                    \
-      const HostOrDeviceScalar<std::complex<double>> &beta,                    \
-      DeviceMemory<std::complex<double>> *c, int ldc,                          \
-      blas::ComputationType computation_type, blas::AlgorithmType algorithm,   \
-      blas::ProfileResult *output_profile_result) override;                    \
-  bool DoBlasGemmBatched(                                                      \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, float alpha,                               \
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,         \
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,         \
-      float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,      \
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator) override; \
-  bool DoBlasGemmBatched(                                                      \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, float alpha,                               \
-      const port::ArraySlice<DeviceMemory<float> *> &a, int lda,               \
-      const port::ArraySlice<DeviceMemory<float> *> &b, int ldb, float beta,   \
-      const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,               \
-      int batch_count, ScratchAllocator *scratch_allocator) override;          \
-  bool DoBlasGemmBatched(                                                      \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, double alpha,                              \
-      const port::ArraySlice<DeviceMemory<double> *> &a, int lda,              \
-      const port::ArraySlice<DeviceMemory<double> *> &b, int ldb, double beta, \
-      const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,              \
-      int batch_count, ScratchAllocator *scratch_allocator) override;          \
-  bool DoBlasGemmBatched(                                                      \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, std::complex<float> alpha,                 \
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &a, int lda, \
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb, \
-      std::complex<float> beta,                                                \
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc, \
-      int batch_count, ScratchAllocator *scratch_allocator) override;          \
-  bool DoBlasGemmBatched(                                                      \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, std::complex<double> alpha,                \
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &a,         \
-      int lda,                                                                 \
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b,         \
-      int ldb, std::complex<double> beta,                                      \
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c,         \
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator) override; \
-  bool DoBlasGemmStridedBatched(                                               \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, float alpha,                               \
-      const DeviceMemory<Eigen::half> &a, int lda, int64 stride_a,             \
-      const DeviceMemory<Eigen::half> &b, int ldb, int64 stride_b, float beta, \
-      DeviceMemory<Eigen::half> *c, int ldc, int64 stride_c, int batch_count); \
-  bool DoBlasGemmStridedBatched(                                               \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, \
-      int lda, int64 stride_a, const DeviceMemory<float> &b, int ldb,          \
-      int64 stride_b, float beta, DeviceMemory<float> *c, int ldc,             \
-      int64 stride_c, int batch_count);                                        \
-  bool DoBlasGemmStridedBatched(                                               \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, double alpha,                              \
-      const DeviceMemory<double> &a, int lda, int64 stride_a,                  \
-      const DeviceMemory<double> &b, int ldb, int64 stride_b, double beta,     \
-      DeviceMemory<double> *c, int ldc, int64 stride_c, int batch_count);      \
-  bool DoBlasGemmStridedBatched(                                               \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, std::complex<float> alpha,                 \
-      const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,     \
-      const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,     \
-      std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc, \
-      int64 stride_c, int batch_count);                                        \
-  bool DoBlasGemmStridedBatched(                                               \
-      Stream *stream, blas::Transpose transa, blas::Transpose transb,          \
-      uint64 m, uint64 n, uint64 k, std::complex<double> alpha,                \
-      const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,    \
-      const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,    \
-      std::complex<double> beta, DeviceMemory<std::complex<double>> *c,        \
-      int ldc, int64 stride_c, int batch_count);                               \
+  bool DoBlasGemm(Stream *stream, blas::GemmCallContext<Eigen::half> ctx, blas::ProfileResult *output_profile_result) override; \
+  bool DoBlasGemm(Stream *stream, blas::GemmCallContext<float> ctx, blas::ProfileResult *output_profile_result) override; \
+  bool DoBlasGemm(Stream *stream, blas::GemmCallContext<double> ctx, blas::ProfileResult *output_profile_result) override; \
+  bool DoBlasGemm(Stream *stream, blas::GemmCallContext<std::complex<float> > ctx, blas::ProfileResult *output_profile_result) override; \
+  bool DoBlasGemm(Stream *stream, blas::GemmCallContext<std::complex<double> > ctx, blas::ProfileResult *output_profile_result) override; \
+  bool GetBlasGemmAlgorithms( std::vector<blas::AlgorithmType> *out_algorithms) override; \
+  bool DoBlasGemm(Stream *stream, blas::GemmCallContext<int8, int32> ctx, blas::ProfileResult *output_profile_result) override; \
+  bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<Eigen::half> ctx) override; \
+  bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<float> ctx) override; \
+  bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<double> ctx) override; \
+  bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<std::complex<float> > ctx) override; \
+  bool DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<std::complex<double> > ctx) override; \
   bool DoBlasHemm(Stream *stream, blas::Side side, blas::UpperLower uplo,      \
                   uint64 m, uint64 n, std::complex<float> alpha,               \
                   const DeviceMemory<std::complex<float>> &a, int lda,         \

--- a/tensorflow/stream_executor/cuda/cuda_blas.h
+++ b/tensorflow/stream_executor/cuda/cuda_blas.h
@@ -128,7 +128,8 @@ class CUDABlas : public blas::BlasSupport {
       Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
       uint64 n, uint64 k, const ParamType &alpha, const DeviceMemory<T> &a,
       int lda, const DeviceMemory<T> &b, int ldb, const ParamType &beta,
-      DeviceMemory<T> *c, int ldc, blas::ProfileResult *output_profile_result);
+      DeviceMemory<T> *c, int ldc, blas::ProfileResult *output_profile_result,
+      blas::CallContext context,);
 
   // Helper function for implementing DoBlasGemvWithProfiling.
   template <typename T>

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3035,7 +3035,7 @@ port::Status CudnnSupport::DoConvolve(
     DeviceMemoryBase output_data,
     const dnn::ConvolutionDescriptor& convolution_descriptor,
     dnn::AlgorithmDesc algorithm_desc, DeviceMemory<uint8> scratch_memory,
-    dnn::ProfileResult* output_profile_result) {
+    dnn::CallContext call_context, dnn::ProfileResult* output_profile_result) {
   cudnnDataType_t cudnn_type = ToCudnnDataType(element_type);
   CudnnTensorDescriptor input_nd(input_descriptor, cudnn_type);
   CudnnTensorDescriptor output_nd(output_descriptor,
@@ -4069,7 +4069,8 @@ bool CudnnSupport::DoMatMul(Stream* stream,
     const int64 k = input_dimensions.NodesAcrossFeatureMaps();
     stream->ThenBlasGemm(blas::Transpose::kNoTranspose,
                          blas::Transpose::kNoTranspose, m, n, k, alpha, weights,
-                         m, input_data, k, beta, output_data, m);
+                         m, input_data, k, beta, output_data, m,
+                         blas::CallContext::kNone);
   } else {
     // This is a slower and more complex path that supports output
     // width() * height() > 1, though it only supports the
@@ -4149,7 +4150,7 @@ bool CudnnSupport::DoMatMul(Stream* stream,
     stream->ThenBlasGemmBatched(blas::Transpose::kNoTranspose,
                                 blas::Transpose::kNoTranspose, m, n, k, alpha,
                                 toPtrs(a), lda, toPtrs(b), ldb, beta, toPtrs(c),
-                                ldc, batch_count);
+                                ldc, batch_count, blas::CallContext::kNone);
   }
 
   return stream->ok();

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -275,6 +275,7 @@ class CudnnSupport : public dnn::DnnSupport {
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::AlgorithmDesc algorithm_desc, DeviceMemory<uint8> scratch_memory,
+      dnn::CallContext call_context,
       dnn::ProfileResult* output_profile_result) override;
 
   port::Status DoFusedConvolve(

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -57,6 +57,7 @@ bool DnnSupport::GetMIOpenConvolveAlgorithms(
     DeviceMemoryBase output_data,
     const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
     ScratchAllocator* scratch_allocator,
+    dnn::CallContext call_context,
     std::vector<ProfileResult>* /*out_algorithms*/) {
   return false;
 }

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -58,6 +58,16 @@ enum class DimIndex : int {
   Z = 2,
 };
 
+// Call context information for GEMM API calls
+// This is extra information that can optionally be passed down to the blas
+// library, so that it can pick the efficient imlpementation based on context
+enum class CallContext {
+  kNone = 0,            // No information
+  kForward = 1,         // call happens in "forward" pass
+  kBackpropData = 2,    // call happens in "backprop" pass for data
+  kBackpropFilter = 4,  // call happens in "backprop" pass for filter
+};
+
 // Helper functions to make methods more readable.
 inline int64 GetDim(absl::Span<const int64> data, DimIndex dim) {
   return data.rbegin()[static_cast<int64>(dim)];
@@ -1326,7 +1336,7 @@ class DnnSupport {
       DeviceMemoryBase output_data,
       const ConvolutionDescriptor& convolution_descriptor,
       AlgorithmDesc algorithm_desc, DeviceMemory<uint8> scratch_memory,
-      ProfileResult* output_profile_result) = 0;
+      dnn::CallContext call_context, ProfileResult* output_profile_result) = 0;
 
   template <typename ElementType, typename OutputType>
   bool DoConvolve(Stream* stream, const dnn::BatchDescriptor& input_descriptor,
@@ -1338,13 +1348,15 @@ class DnnSupport {
                   DeviceMemory<OutputType>* output_data,
                   const dnn::AlgorithmDesc& algorithm_desc,
                   DeviceMemory<uint8>* scratch_memory,
+		  dnn::CallContext call_context,
                   ProfileResult* output_profile_result) {
     return IsStatusOk(
         DoConvolve(ConvolutionKind::FORWARD, ToDataType<ElementType>::value,
                    ToDataType<OutputType>::value, stream, input_descriptor,
                    input_data, filter_descriptor, filter_data,
                    output_descriptor, *output_data, convolution_descriptor,
-                   algorithm_desc, *scratch_memory, output_profile_result),
+                   algorithm_desc, *scratch_memory, call_context,
+                   output_profile_result),
         !output_profile_result);
   }
 
@@ -1363,6 +1375,7 @@ class DnnSupport {
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       ScratchAllocator* scratch_allocator,
+      dnn::CallContext call_context,
       std::vector<ProfileResult>* out_algorithms);
 
   // Returns a list of supported rnn algorithms.
@@ -1448,7 +1461,8 @@ class DnnSupport {
             ToDataType<ElementType>::value, stream, input_descriptor,
             *backward_input_data, filter_descriptor, filter_data,
             output_descriptor, backward_output_data, convolution_descriptor,
-            algorithm_desc, *scratch_memory, output_profile_result),
+            algorithm_desc, *scratch_memory, dnn::CallContext::kBackpropData,
+            output_profile_result),
         !output_profile_result);
   }
 
@@ -1495,7 +1509,8 @@ class DnnSupport {
             ToDataType<ElementType>::value, stream, input_descriptor,
             input_data, filter_descriptor, *backward_filter_data,
             output_descriptor, backward_output_data, convolution_descriptor,
-            algorithm_desc, *scratch_memory, output_profile_result),
+            algorithm_desc, *scratch_memory, dnn::CallContext::kBackpropFilter,
+            output_profile_result),
         !output_profile_result);
   }
 

--- a/tensorflow/stream_executor/gpu/gpu_driver.h
+++ b/tensorflow/stream_executor/gpu/gpu_driver.h
@@ -411,7 +411,7 @@ class GpuDriver {
 
 #if TENSORFLOW_USE_ROCM
   // tests the current device for MFMA insn support (ROCm only)
-  static port::Status GetMFMASupport(bool& support);
+  static port::Status GetMFMASupport(bool& support, bool& extra);
 #endif
 
   // Returns the number of multiprocessors on the device (note that the device

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -24,6 +24,7 @@ limitations under the License.
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "rocm/rocm_config.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/gpu/gpu_activation.h"
@@ -1517,151 +1518,100 @@ bool ROCMBlas::DoBlasTrsv(Stream *stream, blas::UpperLower uplo,
   return false;
 }
 
-bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          float alpha, const DeviceMemory<Eigen::half> &a,
-                          int lda, const DeviceMemory<Eigen::half> &b, int ldb,
-                          float beta, DeviceMemory<Eigen::half> *c, int ldc) {
-  blas_log("DoBlasGemm");
-  VLOG(1) << absl::StreamFormat(
-      "doing rocBLAS SGEMM<half>: at=%d bt=%d m=%u n=%u "
-      "k=%llu alpha=%f a=%p lda=%d b=%p ldb=%d beta=%f "
-      "c=%p ldc=%d",
-      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
-      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
-  if (transa == blas::Transpose::kNoTranspose) {
-    if (lda < static_cast<int64>(m)) {
-      LOG(WARNING) << "GEMM lda was smaller than m (no transpose case); "
-                      "precondition violation";
-    }
-  } else {
-    if (lda < static_cast<int64>(k)) {
-      LOG(WARNING) << "GEMM lda (" << lda << ") was smaller than k (" << k
-                   << ") (transpose case); precondition violation";
-    }
+template <class T, class V, class W>
+bool ROCMBlas::DoBlasGemmImpl(Stream *stream, blas::GemmCallContext<T> ctx, V strided_fun, W fun)
+{
+  if(ctx.output_profile_result)
+  {
+      LOG(ERROR) << "rocBLAS does not currently support profiling";
+      return false;
   }
-  if (transb == blas::Transpose::kNoTranspose) {
-    if (ldb < static_cast<int64>(k)) {
-      LOG(WARNING) << "GEMM ldb (" << ldb << ") was smaller than k (" << k
-                   << ") (no transpose case); precondition violation";
-    }
-  } else {
-    if (ldb < static_cast<int64>(n)) {
-      LOG(WARNING) << "GEMM ldb was smaller than n (transpose case); "
-                      "precondition violation";
-    }
-  }
-  bool hasXDLOPS = false;
-  auto status = GpuDriver::GetMFMASupport(hasXDLOPS);
-  if(!hasXDLOPS) {
-    VLOG(1) << "Using rocblas_hgemm";
-    const Eigen::half alpha_half(alpha);
-    const Eigen::half beta_half(beta);
+  const T alpha(ctx.alpha);
+  const T beta(ctx.beta);
+  typedef typename std::conditional<std::is_same<T, Eigen::half>::value, rocblas_half, T>::type DT;
+  // we don't handle CallContext - this would not be called when XDLOPS are available (MI100 and up)
+  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+  if(ctx.stride_a>=0)
+  {
     return DoBlasInternal(
-      wrap::rocblas_hgemm, stream, /* pointer_mode_host = */ true,
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-      reinterpret_cast<const rocblas_half *>(&alpha_half),
-      reinterpret_cast<const rocblas_half *>(GpuMemory(a)), lda,
-      reinterpret_cast<const rocblas_half *>(GpuMemory(b)), ldb,
-      reinterpret_cast<const rocblas_half *>(&beta_half),
-      reinterpret_cast<rocblas_half *>(GpuMemoryMutable(c)), ldc);
-  } else {
-    VLOG(1) << "Using rocblas_gemm_ex";
+        strided_fun, stream,
+        false, /* pointer_mode_host */
+        ROCMBlasTranspose(ctx.transa), ROCMBlasTranspose(ctx.transb), ctx.m, ctx.n, ctx.k,
+        reinterpret_cast<const MAPPED_T *>(&alpha),
+        reinterpret_cast<const MAPPED_T *>(GpuMemory(*ctx.pa)), ctx.lda, ctx.stride_a,
+        reinterpret_cast<const MAPPED_T *>(GpuMemory(*ctx.pb)), ctx.ldb, ctx.stride_b,
+        reinterpret_cast<const MAPPED_T *>(&beta),
+        reinterpret_cast<MAPPED_T *>(GpuMemoryMutable(ctx.c)), ctx.ldc, ctx.stride_c,
+        ctx.batch_count);
+  }
+  else
+  {
+      return DoBlasInternal(
+        fun, stream, /* pointer_mode_host = */ true,
+        ROCMBlasTranspose(ctx.transa), ROCMBlasTranspose(ctx.transb), ctx.m, ctx.n, ctx.k,
+        reinterpret_cast<const MAPPED_T *>(&alpha),
+        reinterpret_cast<const MAPPED_T *>(GpuMemory(*ctx.pa)), ctx.lda, 
+        reinterpret_cast<const MAPPED_T *>(GpuMemory(*ctx.pb)), ctx.ldb, 
+        reinterpret_cast<const MAPPED_T *>(&beta),
+        reinterpret_cast<MAPPED_T *>(GpuMemoryMutable(ctx.c)), ctx.ldc);
+  }
+}
+
+bool ROCMBlas::DoBlasGemm(Stream *stream, blas::GemmCallContext<Eigen::half> ctx, blas::ProfileResult *output_profile_result)
+{
+  bool hasXDLOPS = false, gfx90a = false;
+  auto status = GpuDriver::GetMFMASupport(hasXDLOPS, gfx90a);
+  bool is_backprop =
+      (ctx.context == blas::CallContext::kBackpropInput1) ||
+      (ctx.context == blas::CallContext::kBackpropInput2);
+
+  if(hasXDLOPS)
+  {
+    if(ctx.stride_a>=0)
+    {
+      LOG(ERROR)<<"ROCMBlas::DoBlasGemm does not support denorm workaround in strided GEMM";
+      exit(0);
+    }
+    uint32_t flags = rocblas_gemm_flags_none;
+#if TF_ROCM_VERSION >= 50000
+    if(is_backprop && gfx90a)
+      flags = rocblas_gemm_flags_fp16_alt_impl;
+#endif
     return DoBlasInternal(
       wrap::rocblas_gemm_ex, stream, /* pointer_mode_host = */ true,
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), 
-      (rocblas_int)m, (rocblas_int)n, (rocblas_int)k,
-      reinterpret_cast<const void*>(&alpha),
-      reinterpret_cast<const void*>(GpuMemory(a)), rocblas_datatype_f16_r, lda,
-      reinterpret_cast<const void*>(GpuMemory(b)), rocblas_datatype_f16_r, ldb,
-      reinterpret_cast<const void*>(&beta),
-      reinterpret_cast<const void*>(GpuMemoryMutable(c)), 
-      rocblas_datatype_f16_r, ldc,
-      reinterpret_cast<void*>(GpuMemoryMutable(c)), rocblas_datatype_f16_r, ldc,
-          rocblas_datatype_f32_r, rocblas_gemm_algo_standard, 0, 0);
+      ROCMBlasTranspose(ctx.transa), ROCMBlasTranspose(ctx.transb),
+      (rocblas_int)ctx.m, (rocblas_int)ctx.n, (rocblas_int)ctx.k,
+      reinterpret_cast<const void*>(&ctx.alpha),
+      reinterpret_cast<const void*>(GpuMemory(*ctx.pa)), rocblas_datatype_f16_r, ctx.lda,
+      reinterpret_cast<const void*>(GpuMemory(*ctx.pb)), rocblas_datatype_f16_r, ctx.ldb,
+      reinterpret_cast<const void*>(&ctx.beta),
+      reinterpret_cast<const void*>(GpuMemoryMutable(ctx.c)),
+      rocblas_datatype_f16_r, ctx.ldc,
+      reinterpret_cast<void*>(GpuMemoryMutable(ctx.c)), rocblas_datatype_f16_r, ctx.ldc,
+          rocblas_datatype_f32_r, rocblas_gemm_algo_standard, 0, flags);
   }
+
+  return DoBlasGemmImpl(stream, ctx, wrap::rocblas_hgemm_strided_batched, wrap::rocblas_hgemm);
 }
 
-bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          float alpha, const DeviceMemory<float> &a, int lda,
-                          const DeviceMemory<float> &b, int ldb, float beta,
-                          DeviceMemory<float> *c, int ldc) {
-  blas_log("DoBlasGemm");
-  VLOG(1) << absl::StreamFormat(
-      "doing rocBLAS SGEMM<float>: at=%d bt=%d m=%u n=%u "
-      "k=%llu alpha=%f a=%p lda=%d b=%p ldb=%d beta=%f "
-      "c=%p ldc=%d",
-      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
-      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
-  if (transa == blas::Transpose::kNoTranspose) {
-    if (lda < static_cast<int64>(m)) {
-      LOG(WARNING) << "GEMM lda was smaller than m (no transpose case); "
-                      "precondition violation";
-    }
-  } else {
-    if (lda < static_cast<int64>(k)) {
-      LOG(WARNING) << "GEMM lda (" << lda << ") was smaller than k (" << k
-                   << ") (transpose case); precondition violation";
-    }
-  }
-  if (transb == blas::Transpose::kNoTranspose) {
-    if (ldb < static_cast<int64>(k)) {
-      LOG(WARNING) << "GEMM ldb (" << ldb << ") was smaller than k (" << k
-                   << ") (no transpose case); precondition violation";
-    }
-  } else {
-    if (ldb < static_cast<int64>(n)) {
-      LOG(WARNING) << "GEMM ldb was smaller than n (transpose case); "
-                      "precondition violation";
-    }
-  }
-  return DoBlasInternal(
-      wrap::rocblas_sgemm, stream, true /* = pointer_mode_host */,
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k, &alpha,
-      GpuMemory(a), lda, GpuMemory(b), ldb, &beta, GpuMemoryMutable(c), ldc);
+bool ROCMBlas::DoBlasGemm(Stream *stream, blas::GemmCallContext<float> ctx, blas::ProfileResult *output_profile_result)
+{
+  return DoBlasGemmImpl(stream, ctx, wrap::rocblas_sgemm_strided_batched, wrap::rocblas_sgemm);
 }
 
-bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          double alpha, const DeviceMemory<double> &a, int lda,
-                          const DeviceMemory<double> &b, int ldb, double beta,
-                          DeviceMemory<double> *c, int ldc) {
-  blas_log("DoBlasGemm");
-  return DoBlasInternal(
-      wrap::rocblas_dgemm, stream, true /* = pointer_mode_host */,
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k, &alpha,
-      GpuMemory(a), lda, GpuMemory(b), ldb, &beta, GpuMemoryMutable(c), ldc);
+bool ROCMBlas::DoBlasGemm(Stream *stream, blas::GemmCallContext<double> ctx, blas::ProfileResult *output_profile_result)
+{
+  return DoBlasGemmImpl(stream, ctx, wrap::rocblas_dgemm_strided_batched, wrap::rocblas_dgemm);
 }
 
-bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          std::complex<float> alpha,
-                          const DeviceMemory<std::complex<float>> &a, int lda,
-                          const DeviceMemory<std::complex<float>> &b, int ldb,
-                          std::complex<float> beta,
-                          DeviceMemory<std::complex<float>> *c, int ldc) {
-  blas_log("DoBlasGemm");
-  return DoBlasInternal(
-      wrap::rocblas_cgemm, stream, true /* = pointer_mode_host */,
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-      complex_cast(alpha), complex_cast(a), lda, complex_cast(b), ldb,
-      complex_cast(beta), complex_cast(c), ldc);
+bool ROCMBlas::DoBlasGemm(Stream *stream, blas::GemmCallContext<std::complex<float> > ctx, blas::ProfileResult *output_profile_result)
+{
+  return DoBlasGemmImpl(stream, ctx, wrap::rocblas_cgemm_strided_batched, wrap::rocblas_cgemm);
 }
 
-bool ROCMBlas::DoBlasGemm(Stream *stream, blas::Transpose transa,
-                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
-                          std::complex<double> alpha,
-                          const DeviceMemory<std::complex<double>> &a, int lda,
-                          const DeviceMemory<std::complex<double>> &b, int ldb,
-                          std::complex<double> beta,
-                          DeviceMemory<std::complex<double>> *c, int ldc) {
-  blas_log("DoBlasGemm");
-  return DoBlasInternal(
-      wrap::rocblas_zgemm, stream, true /* = pointer_mode_host */,
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-      complex_cast(alpha), complex_cast(a), lda, complex_cast(b), ldb,
-      complex_cast(beta), complex_cast(c), ldc);
+bool ROCMBlas::DoBlasGemm(Stream *stream, blas::GemmCallContext<std::complex<double> > ctx, blas::ProfileResult *output_profile_result)
+{
+  return DoBlasGemmImpl(stream, ctx, wrap::rocblas_zgemm_strided_batched, wrap::rocblas_zgemm);
 }
 
 bool ROCMBlas::DoBlasGemvWithProfiling(
@@ -1706,62 +1656,6 @@ bool ROCMBlas::DoBlasGemvWithProfiling(
                                      output_profile_result);
 }
 
-bool ROCMBlas::DoBlasGemmWithProfiling(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
-    int lda, const DeviceMemory<Eigen::half> &b, int ldb, float beta,
-    DeviceMemory<Eigen::half> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
-  return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
-                                     lda, b, ldb, beta, c, ldc,
-                                     output_profile_result);
-}
-
-bool ROCMBlas::DoBlasGemmWithProfiling(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
-    const DeviceMemory<float> &b, int ldb, float beta, DeviceMemory<float> *c,
-    int ldc, blas::ProfileResult *output_profile_result) {
-  return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
-                                     lda, b, ldb, beta, c, ldc,
-                                     output_profile_result);
-}
-
-bool ROCMBlas::DoBlasGemmWithProfiling(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
-    const DeviceMemory<double> &b, int ldb, double beta,
-    DeviceMemory<double> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
-  return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
-                                     lda, b, ldb, beta, c, ldc,
-                                     output_profile_result);
-}
-
-bool ROCMBlas::DoBlasGemmWithProfiling(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, std::complex<float> alpha,
-    const DeviceMemory<std::complex<float>> &a, int lda,
-    const DeviceMemory<std::complex<float>> &b, int ldb,
-    std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
-  return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
-                                     lda, b, ldb, beta, c, ldc,
-                                     output_profile_result);
-}
-
-bool ROCMBlas::DoBlasGemmWithProfiling(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, std::complex<double> alpha,
-    const DeviceMemory<std::complex<double>> &a, int lda,
-    const DeviceMemory<std::complex<double>> &b, int ldb,
-    std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-    blas::ProfileResult *output_profile_result) {
-  return DoBlasGemmWithProfilingImpl(stream, transa, transb, m, n, k, alpha, a,
-                                     lda, b, ldb, beta, c, ldc,
-                                     output_profile_result);
-}
-
 template <typename T>
 bool ROCMBlas::DoBlasGemvWithProfilingImpl(
     Stream *stream, blas::Transpose trans, uint64 m, uint64 n, const T &alpha,
@@ -1772,116 +1666,18 @@ bool ROCMBlas::DoBlasGemvWithProfilingImpl(
   return false;
 }
 
-template <typename T, typename ParamType>
-bool ROCMBlas::DoBlasGemmWithProfilingImpl(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const ParamType &alpha, const DeviceMemory<T> &a,
-    int lda, const DeviceMemory<T> &b, int ldb, const ParamType &beta,
-    DeviceMemory<T> *c, int ldc, blas::ProfileResult *output_profile_result) {
-  // ROCM TODO: properly implement the interface
-  return false;
-}
-
-template <typename InT, typename OutT, typename CompT>
-bool ROCMBlas::DoBlasGemmWithAlgorithmImpl(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const CompT &alpha, const DeviceMemory<InT> &a, int lda,
-    const DeviceMemory<InT> &b, int ldb, const CompT &beta,
-    DeviceMemory<OutT> *c, int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
-  // ROCM TODO: properly implement the interface
-  return false;
-}
-
 bool ROCMBlas::GetBlasGemmAlgorithms(
     std::vector<blas::AlgorithmType> *out_algorithms) {
   // ROCM TODO: properly implement the interface
   return true;
 }
 
-bool ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const HostOrDeviceScalar<int> &alpha,
-    const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b, int ldb,
-    const HostOrDeviceScalar<int> &beta, DeviceMemory<int32> *c, int ldc,
-    blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
+bool ROCMBlas::DoBlasGemm(Stream *stream, blas::GemmCallContext<int8, int32> ctx, blas::ProfileResult *output_profile_result) {
   LOG(ERROR)
       << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
       << "for the \"int8\" datatype";
   return false;
 }
-
-bool ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const HostOrDeviceScalar<Eigen::half> &alpha,
-    const DeviceMemory<Eigen::half> &a, int lda,
-    const DeviceMemory<Eigen::half> &b, int ldb,
-    const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
-    int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
-  LOG(ERROR)
-      << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
-      << "for the \"half\" datatype";
-  return false;
-}
-
-bool ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const HostOrDeviceScalar<float> &alpha,
-    const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
-    int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
-    int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
-  LOG(ERROR)
-      << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
-      << "for the \"float\" datatype";
-  return false;
-}
-
-bool ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const HostOrDeviceScalar<double> &alpha,
-    const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
-    int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
-    int ldc, blas::ComputationType computation_type,
-    blas::AlgorithmType algorithm, blas::ProfileResult *output_profile_result) {
-  LOG(ERROR)
-      << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
-      << "for the \"double\" datatype";
-  return false;
-}
-
-bool ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const HostOrDeviceScalar<std::complex<float>> &alpha,
-    const DeviceMemory<std::complex<float>> &a, int lda,
-    const DeviceMemory<std::complex<float>> &b, int ldb,
-    const HostOrDeviceScalar<std::complex<float>> &beta,
-    DeviceMemory<std::complex<float>> *c, int ldc,
-    blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
-  LOG(ERROR)
-      << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
-      << "for the \"complex<float>\" datatype";
-  return false;
-}
-
-bool ROCMBlas::DoBlasGemmWithAlgorithm(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, const HostOrDeviceScalar<std::complex<double>> &alpha,
-    const DeviceMemory<std::complex<double>> &a, int lda,
-    const DeviceMemory<std::complex<double>> &b, int ldb,
-    const HostOrDeviceScalar<std::complex<double>> &beta,
-    DeviceMemory<std::complex<double>> *c, int ldc,
-    blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-    blas::ProfileResult *output_profile_result) {
-  LOG(ERROR)
-      << "rocBLAS does not currently support the GEMMwithAlgorithm operation "
-      << "for the \"complex<double>\" datatype";
-  return false;
-}
-
 
 struct memory_copy_op {
     char* src_ptr;
@@ -1922,14 +1718,15 @@ static bool fold(memory_copy_op& y, const memory_copy_op& x)
 // The below algorithm tries to minimize the number of memcpy by consolidating
 // neighboring memcpy into a single request
 template <typename MAPPED_T>
-port::Status ReorganizeMemory(Stream* stream,
+/*port::Status*/bool ReorganizeMemory(Stream* stream,
       DeviceMemory<MAPPED_T> *device_memory,
         const std::vector<MAPPED_T*>  &raw_ptrs,
     int batch_count, uint64_t batch_stride,
     bool gather)
 {
   if(gather==false)
-    return port::Status(port::error::INTERNAL, "gather=false unsupported");
+    return false;
+    //return port::Status(port::error::INTERNAL, "gather=false unsupported");
   assert(batch_count > 0);
   char *device_memory_ptr = static_cast<char *>(device_memory->opaque());
   char* src_ptr = reinterpret_cast<char*>(raw_ptrs[0]);
@@ -1965,29 +1762,30 @@ port::Status ReorganizeMemory(Stream* stream,
       DeviceMemoryBase target_mem = DeviceMemoryBase(x.dst_ptr, x.size);
       bool a_status = stream->ThenMemcpy(&target_mem, src_mem, x.size).ok();
       if (!a_status) {
+	return false;
+	      /*
         return port::Status(
             port::error::INTERNAL,
           "failed to copy device memory in ROCMBlas::DoBlasGemmBatched");
+	  */
       }
     }
   }
-  return port::Status::OK();
+  //return port::Status::OK();
+  return true;
 }
 
-template <typename T>
+template <typename T, typename U>
 port::Status ROCMBlas::AllocateStridedBuffer(
-    const std::vector<typename RocBlasTypeConversionHelper<T>::mapped_type *>
-        &raw_ptrs,
+    const std::vector<U*> &raw_ptrs,
     int batch_count, uint64_t batch_stride, ScratchAllocator *scratch_allocator,
     Stream *stream,
-    std::unique_ptr<TemporaryDeviceMemory<
-        typename RocBlasTypeConversionHelper<T>::mapped_type>> *temp_memory,
-    DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>
-        *device_memory,
+    std::unique_ptr<TemporaryDeviceMemory<U> > *temp_memory,
+    DeviceMemory<U> *device_memory,
     bool copy_data, bool &reallocated) {
   assert(device_memory != nullptr);
 
-  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+  using MAPPED_T = U;
 
   bool needs_allocate_strided = false;
   for (int i = 1; i < batch_count; ++i) {
@@ -2030,21 +1828,33 @@ port::Status ROCMBlas::AllocateStridedBuffer(
   reallocated = true;
 
   if (copy_data)
+    if (ReorganizeMemory(stream, device_memory, raw_ptrs, batch_count,
+                            batch_stride, true))
+      return port::Status::OK();
+    else
+      return port::Status(port::error::INTERNAL, "failed BLAS call, see log for details"); 
+
+	  /*
     return ReorganizeMemory(stream, device_memory, raw_ptrs, batch_count,
                             batch_stride, true);
+			    */
   return port::Status::OK();
 }
 
+template <class T, class V>
+bool ROCMBlas::DoBlasGemmBatchedImpl(Stream *stream, blas::BatchedGemmCallContext<T> ctx, V rocblas_func) {
+  //const T alpha(ctx.alpha), beta(ctx.beta);
+  blas::Transpose transa = ctx.transa;
+  blas::Transpose transb = ctx.transb;
+  uint64 m = ctx.m, n = ctx.n, k = ctx.k;
+  int lda = ctx.lda, ldb = ctx.ldb, ldc = ctx.ldc, batch_count = ctx.batch_count;
+  const port::ArraySlice<DeviceMemory<T> *> &a_ptrs_to_wrappers = *ctx.pa;
+  const port::ArraySlice<DeviceMemory<T> *> &b_ptrs_to_wrappers = *ctx.pb;
+  const port::ArraySlice<DeviceMemory<T> *> &c_ptrs_to_wrappers = *ctx.pc;
+  ScratchAllocator *scratch_allocator = ctx.scratch_allocator;
+  blas::CallContext context = ctx.context;
 
-template <typename T, typename FuncT>
-port::Status ROCMBlas::DoBlasGemmBatchedInternal(
-    FuncT rocblas_func, Stream *stream, blas::Transpose transa,
-    blas::Transpose transb, uint64 m, uint64 n, uint64 k, T alpha,
-    const port::ArraySlice<DeviceMemory<T> *> &a_ptrs_to_wrappers, int lda,
-    const port::ArraySlice<DeviceMemory<T> *> &b_ptrs_to_wrappers, int ldb,
-    T beta, const port::ArraySlice<DeviceMemory<T> *> &c_ptrs_to_wrappers,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
-  using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
+  //using MAPPED_T = typename RocBlasTypeConversionHelper<T>::mapped_type;
 
   // Sanity checks before making any further progress
   uint64_t batch_stride_a = 0;
@@ -2070,163 +1880,89 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
   }
 
   // Allocate local vectors to hold device pointers to matrices
-  std::vector<MAPPED_T *> a_raw_ptrs, b_raw_ptrs, c_raw_ptrs;
+  //std::vector<MAPPED_T *> a_raw_ptrs, b_raw_ptrs, c_raw_ptrs;
+  std::vector<T*> a_raw_ptrs, b_raw_ptrs, c_raw_ptrs;
   for (int i = 0; i < batch_count; ++i) {
     // static_cast does work when converting Eigen::half* to rocblas_half*,
     // hence the use of reinterpret_cast
-    a_raw_ptrs.push_back(
-        reinterpret_cast<MAPPED_T *>(a_ptrs_to_wrappers[i]->opaque()));
-    b_raw_ptrs.push_back(
-        reinterpret_cast<MAPPED_T *>(b_ptrs_to_wrappers[i]->opaque()));
-    c_raw_ptrs.push_back(
-        reinterpret_cast<MAPPED_T *>(c_ptrs_to_wrappers[i]->opaque()));
+    a_raw_ptrs.push_back(reinterpret_cast<T*>(a_ptrs_to_wrappers[i]->opaque()));
+    b_raw_ptrs.push_back(reinterpret_cast<T*>(b_ptrs_to_wrappers[i]->opaque()));
+    c_raw_ptrs.push_back(reinterpret_cast<T*>(c_ptrs_to_wrappers[i]->opaque()));
   }
 
-  DeviceMemory<MAPPED_T> a;
+  DeviceMemory<T> a;
   // Make sure the temporary memory are in-scope before the function returns
-  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> a_temp;
+  std::unique_ptr<TemporaryDeviceMemory<T>> a_temp;
   bool reallocated_a, reallocated_b, reallocated_c;
   port::Status a_allocation_status = AllocateStridedBuffer<T>(
       a_raw_ptrs, batch_count, batch_stride_a, scratch_allocator, stream,
       &a_temp, &a, true, reallocated_a);
   if (a_allocation_status != port::Status::OK()) {
-    return a_allocation_status;
+    return false;
   }
 
-  DeviceMemory<MAPPED_T> b;
-  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> b_temp;
+  DeviceMemory<T> b;
+  std::unique_ptr<TemporaryDeviceMemory<T>> b_temp;
   port::Status b_allocation_status = AllocateStridedBuffer<T>(
       b_raw_ptrs, batch_count, batch_stride_b, scratch_allocator, stream,
       &b_temp, &b, true, reallocated_b);
   if (b_allocation_status != port::Status::OK()) {
-    return b_allocation_status;
+    return false;
   }
 
-  DeviceMemory<MAPPED_T> c;
-  std::unique_ptr<TemporaryDeviceMemory<MAPPED_T>> c_temp;
+  DeviceMemory<T> c;
+  std::unique_ptr<TemporaryDeviceMemory<T>> c_temp;
   port::Status c_allocation_status = AllocateStridedBuffer<T>(
       c_raw_ptrs, batch_count, batch_stride_c, scratch_allocator, stream,
       &c_temp, &c, true, reallocated_c);  // can disable copy if beta=0
   if (c_allocation_status != port::Status::OK()) {
-    return c_allocation_status;
+    return false;
   }
 
-  MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
-  MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
+  //MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
+  //MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
 
-  bool ok;
-  ok = DoBlasInternal(rocblas_func, stream, true /* = pointer_mode_host */,
-                      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
-                      n, k, GpuComplex(alpha_ptr), GpuMemory(a), lda,
-                      batch_stride_a, GpuMemory(b), ldb, batch_stride_b,
-                      GpuComplex(beta_ptr), GpuMemoryMutable(&c), ldc,
-                      batch_stride_c, batch_count);
+  blas::GemmCallContext<T> newctx{ transa, transb, m, n, k,
+   ctx.alpha, ctx.beta, &a, lda, &b, ldb, &c, ldc, context,
+   batch_stride_a, batch_stride_b, batch_stride_c, batch_count};
+
+  bool ok = DoBlasGemm(stream, newctx, nullptr);
   if (!ok)
-    return port::Status(port::error::INTERNAL,
-                        "failed BLAS call, see log for details");
+    return false;
+    //return port::Status(port::error::INTERNAL,
+    //                    "failed BLAS call, see log for details");
+ 
   if (reallocated_c)
+    if (ReorganizeMemory(stream, &c, c_raw_ptrs, batch_count, batch_stride_c, false))
+      return true;
+    else
+      return false;
+  /*
     return ReorganizeMemory(stream, &c, c_raw_ptrs, batch_count, batch_stride_c,
                             false);
-  return port::Status::OK();
+			    */
+  //return port::Status::OK();
+  return true;
 }
 
-bool ROCMBlas::DoBlasGemmBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, float alpha,
-    const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
-    const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb, float beta,
-    const port::ArraySlice<DeviceMemory<Eigen::half> *> &c, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
-  blas_log("DoBlasGemmBatched");
-  const Eigen::half alpha_half(alpha);
-  const Eigen::half beta_half(beta);
-
-  port::Status status = DoBlasGemmBatchedInternal(
-      wrap::rocblas_hgemm_strided_batched, stream, transa, transb, m, n, k,
-      alpha_half, a, lda, b, ldb, beta_half, c, ldc, batch_count,
-      scratch_allocator);
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-  }
-
-  return status.ok();
+bool ROCMBlas::DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<Eigen::half> ctx) {
+  return DoBlasGemmBatchedImpl(stream, ctx, wrap::rocblas_hgemm_strided_batched);
 }
 
-bool ROCMBlas::DoBlasGemmBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, float alpha,
-    const port::ArraySlice<DeviceMemory<float> *> &a_array, int lda,
-    const port::ArraySlice<DeviceMemory<float> *> &b_array, int ldb, float beta,
-    const port::ArraySlice<DeviceMemory<float> *> &c_array, int ldc,
-    int batch_count, ScratchAllocator *scratch_allocator) {
-  blas_log("DoBlasGemmBatched");
-  port::Status status = DoBlasGemmBatchedInternal(
-      wrap::rocblas_sgemm_strided_batched, stream, transa, transb, m, n, k,
-      alpha, a_array, lda, b_array, ldb, beta, c_array, ldc, batch_count,
-      scratch_allocator);
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-  }
-  return status.ok();
+bool ROCMBlas::DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<float> ctx) {
+  return DoBlasGemmBatchedImpl(stream, ctx, wrap::rocblas_sgemm_strided_batched);
 }
 
-bool ROCMBlas::DoBlasGemmBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, double alpha,
-    const port::ArraySlice<DeviceMemory<double> *> &a_array, int lda,
-    const port::ArraySlice<DeviceMemory<double> *> &b_array, int ldb,
-    double beta, const port::ArraySlice<DeviceMemory<double> *> &c_array,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
-  blas_log("DoBlasGemmBatched");
-  port::Status status = DoBlasGemmBatchedInternal(
-      wrap::rocblas_dgemm_strided_batched, stream, transa, transb, m, n, k,
-      alpha, a_array, lda, b_array, ldb, beta, c_array, ldc, batch_count,
-      scratch_allocator);
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-  }
-  return status.ok();
+bool ROCMBlas::DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<double> ctx) {
+  return DoBlasGemmBatchedImpl(stream, ctx, wrap::rocblas_dgemm_strided_batched);
 }
 
-bool ROCMBlas::DoBlasGemmBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, std::complex<float> alpha,
-    const port::ArraySlice<DeviceMemory<std::complex<float>> *> &a_array,
-    int lda,
-    const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b_array,
-    int ldb, std::complex<float> beta,
-    const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c_array,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
-  blas_log("DoBlasGemmBatched");
-  port::Status status = DoBlasGemmBatchedInternal(
-      wrap::rocblas_cgemm_strided_batched, stream, transa, transb, m, n, k,
-      alpha, a_array, lda, b_array, ldb, beta, c_array, ldc, batch_count,
-      scratch_allocator);
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-  }
-  return status.ok();
+bool ROCMBlas::DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<std::complex<float> > ctx) {
+  return DoBlasGemmBatchedImpl(stream, ctx, wrap::rocblas_cgemm_strided_batched);
 }
 
-
-bool ROCMBlas::DoBlasGemmBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, std::complex<double> alpha,
-    const port::ArraySlice<DeviceMemory<std::complex<double>> *> &a_array,
-    int lda,
-    const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b_array,
-    int ldb, std::complex<double> beta,
-    const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c_array,
-    int ldc, int batch_count, ScratchAllocator *scratch_allocator) {
-  blas_log("DoBlasGemmBatched");
-  port::Status status = DoBlasGemmBatchedInternal(
-      wrap::rocblas_zgemm_strided_batched, stream, transa, transb, m, n, k,
-      alpha, a_array, lda, b_array, ldb, beta, c_array, ldc, batch_count,
-      scratch_allocator);
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-  }
-  return status.ok();
+bool ROCMBlas::DoBlasGemmBatched(Stream *stream, blas::BatchedGemmCallContext<std::complex<double> > ctx) {
+  return DoBlasGemmBatchedImpl(stream, ctx, wrap::rocblas_zgemm_strided_batched);
 }
 
 bool ROCMBlas::DoBlasHemm(Stream *stream, blas::Side side,
@@ -2515,97 +2251,6 @@ bool ROCMBlas::DoBlasTrsm(Stream *stream, blas::Side side,
   LOG(ERROR) << "rocBLAS does not currently support the TRSM operation "
              << "for the \"complex<double>\" datatype";
   return false;
-}
-
-bool ROCMBlas::DoBlasGemmStridedBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, float alpha, const DeviceMemory<Eigen::half> &a,
-    int lda, int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
-    int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
-    int64 stride_c, int batch_count) {
-  blas_log("DoBlasGemmStridedBatched");
-  const Eigen::half alpha_half(alpha);
-  const Eigen::half beta_half(beta);
-
-  return DoBlasInternal(
-      wrap::rocblas_hgemm_strided_batched, stream,
-      false, /* pointer_mode_host */
-      ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-      reinterpret_cast<const rocblas_half *>(&alpha_half),
-      reinterpret_cast<const rocblas_half *>(GpuMemory(a)), lda, stride_a,
-      reinterpret_cast<const rocblas_half *>(GpuMemory(b)), ldb, stride_b,
-      reinterpret_cast<const rocblas_half *>(&beta_half),
-      reinterpret_cast<rocblas_half *>(GpuMemoryMutable(c)), ldc, stride_c,
-      batch_count);
-}
-
-bool ROCMBlas::DoBlasGemmStridedBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
-    int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
-    float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-    int batch_count) {
-  VLOG(1) << absl::StreamFormat(
-      "doing rocBLAS SGEMM Strided Batched<float>: at=%d bt=%d m=%u n=%u "
-      "k=%llu alpha=%f a=%p lda=%d b=%p ldb=%d beta=%f "
-      "c=%p ldc=%d",
-      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
-      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
-  return DoBlasInternal(wrap::rocblas_sgemm_strided_batched, stream,
-                        false, /* pointer_mode_host */
-                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
-                        n, k, &alpha, GpuMemory(a), lda, stride_a, GpuMemory(b),
-                        ldb, stride_b, &beta, GpuMemoryMutable(c), ldc,
-                        stride_c, batch_count);
-}
-bool ROCMBlas::DoBlasGemmStridedBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
-    int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
-    double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-    int batch_count) {
-  VLOG(1) << absl::StreamFormat(
-      "doing rocBLAS SGEMM Strided Batched<double>: at=%d bt=%d m=%u n=%u "
-      "k=%llu alpha=%f a=%p lda=%d b=%p ldb=%d beta=%f "
-      "c=%p ldc=%d",
-      static_cast<int>(transa), static_cast<int>(transb), m, n, k, alpha,
-      a.opaque(), lda, b.opaque(), ldb, beta, c->opaque(), ldc);
-  return DoBlasInternal(wrap::rocblas_dgemm_strided_batched, stream,
-                        false, /* pointer_mode_host */
-                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
-                        n, k, &alpha, GpuMemory(a), lda, stride_a, GpuMemory(b),
-                        ldb, stride_b, &beta, GpuMemoryMutable(c), ldc,
-                        stride_c, batch_count);
-}
-bool ROCMBlas::DoBlasGemmStridedBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, std::complex<float> alpha,
-    const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
-    const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
-    std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-    int64 stride_c, int batch_count) {
-  return DoBlasInternal(wrap::rocblas_cgemm_strided_batched, stream,
-                        false, /* pointer_mode_host */
-                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
-                        n, k, complex_cast(alpha), complex_cast(a), lda,
-                        stride_a, complex_cast(b), ldb, stride_b,
-                        complex_cast(beta), complex_cast(c), ldc, stride_c,
-                        batch_count);
-}
-bool ROCMBlas::DoBlasGemmStridedBatched(
-    Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-    uint64 n, uint64 k, std::complex<double> alpha,
-    const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
-    const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
-    std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-    int64 stride_c, int batch_count) {
-  return DoBlasInternal(wrap::rocblas_zgemm_strided_batched, stream,
-                        false, /* pointer_mode_host */
-                        ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
-                        n, k, complex_cast(alpha), complex_cast(a), lda,
-                        stride_a, complex_cast(b), ldb, stride_b,
-                        complex_cast(beta), complex_cast(c), ldc, stride_c,
-                        batch_count);
 }
 
 port::Status ROCMBlas::GetVersion(string *version) {

--- a/tensorflow/stream_executor/rocm/rocm_blas.h
+++ b/tensorflow/stream_executor/rocm/rocm_blas.h
@@ -122,16 +122,13 @@ class ROCMBlas : public blas::BlasSupport {
 
   // A helper allocation function to convert raw pointers memory layout to
   // strided flavor
-  template <typename T>
+  template <typename T, typename U>
   port::Status AllocateStridedBuffer(
-      const std::vector<typename RocBlasTypeConversionHelper<T>::mapped_type *>
-          &raw_ptrs,
-      int batch_count, uint64_t batch_stride,
-      ScratchAllocator *scratch_allocator, Stream *stream,
-      std::unique_ptr<TemporaryDeviceMemory<
-          typename RocBlasTypeConversionHelper<T>::mapped_type>> *temp_memory,
-      DeviceMemory<typename RocBlasTypeConversionHelper<T>::mapped_type>
-          *device_memory,
+      const std::vector<U*> &raw_ptrs,
+      int batch_count, uint64_t batch_stride, ScratchAllocator *scratch_allocator,
+      Stream *stream,
+      std::unique_ptr<TemporaryDeviceMemory<U> > *temp_memory,
+      DeviceMemory<U> *device_memory,
       bool copy_data, bool &reallocated);
 
   // A helper function to implement DoBlasGemmBatched interfaces for generic
@@ -150,37 +147,8 @@ class ROCMBlas : public blas::BlasSupport {
   // matrix is created by broadcasting from a smaller matrix. When it happens,
   // It will take advantage of the AllocateStridedBuffer subroutine to
   // reallocate the memory layout to be strided batched.
-  template <typename T, typename FuncT>
-  port::Status DoBlasGemmBatchedInternal(
-      FuncT rocblas_func, Stream *stream, blas::Transpose transa,
-      blas::Transpose transb, uint64 m, uint64 n, uint64 k, T alpha,
-      const port::ArraySlice<DeviceMemory<T> *> &a_ptrs_to_wrappers, int lda,
-      const port::ArraySlice<DeviceMemory<T> *> &b_ptrs_to_wrappers, int ldb,
-      T beta, const port::ArraySlice<DeviceMemory<T> *> &c_ptrs_to_wrappers,
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator);
-
-  // Helper function for implementing DoBlasGemmWithAlgorithm.
-  //
-  // We take alpha and beta by const reference because T might be Eigen::half,
-  // and we want to avoid pulling in a dependency on Eigen.  When we pass the
-  // references to rocBLAS, we essentially reinterpret_cast to __half, which is
-  // safe because Eigen::half inherits from __half.
-  template <typename InT, typename OutT, typename CompT>
-  bool DoBlasGemmWithAlgorithmImpl(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const CompT &alpha, const DeviceMemory<InT> &a,
-      int lda, const DeviceMemory<InT> &b, int ldb, const CompT &beta,
-      DeviceMemory<OutT> *c, int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
-
-  // Helper function for implementing DoBlasGemmWithProfiling.
-  template <typename T, typename ParamType>
-  bool DoBlasGemmWithProfilingImpl(
-      Stream *stream, blas::Transpose transa, blas::Transpose transb, uint64 m,
-      uint64 n, uint64 k, const ParamType &alpha, const DeviceMemory<T> &a,
-      int lda, const DeviceMemory<T> &b, int ldb, const ParamType &beta,
-      DeviceMemory<T> *c, int ldc, blas::ProfileResult *output_profile_result);
+  template <class T, class V>
+  bool DoBlasGemmBatchedImpl(Stream *stream, blas::BatchedGemmCallContext<T> ctx, V strided_fun);
 
   // Helper function for implementing DoBlasGemvWithProfiling.
   template <typename T>
@@ -190,6 +158,26 @@ class ROCMBlas : public blas::BlasSupport {
                                    const DeviceMemory<T> &x, int incx,
                                    const T &beta, DeviceMemory<T> *y, int incy,
                                    blas::ProfileResult *output_profile_result);
+
+  bool DoBlasGemm(Stream *stream, blas::Transpose transa,
+                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
+                          float alpha, const DeviceMemory<Eigen::half> &a,
+                          int lda, const DeviceMemory<Eigen::half> &b, int ldb,
+                          float beta, DeviceMemory<Eigen::half> *c, int ldc,
+                          blas::CallContext context);
+  bool DoBlasGemm(Stream *stream, blas::Transpose transa,
+                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
+                          float alpha, const DeviceMemory<float> &a, int lda,
+                          const DeviceMemory<float> &b, int ldb, float beta,
+                          DeviceMemory<float> *c, int ldc);
+  bool DoBlasGemm(Stream *stream, blas::Transpose transa,
+                          blas::Transpose transb, uint64 m, uint64 n, uint64 k,
+                          float alpha, const DeviceMemory<std::complex<float>> &a, int lda,
+                          const DeviceMemory<std::complex<float>> &b, int ldb, float beta,
+                          DeviceMemory<std::complex<float>> *c, int ldc);
+
+  template <class T, class V, class W>
+  bool DoBlasGemmImpl(Stream *stream, blas::GemmCallContext<T> ctx, V strided_fun, W fun);
 
   // mutex that guards the rocBLAS handle for this device.
   absl::Mutex mu_;

--- a/tensorflow/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.h
@@ -239,7 +239,7 @@ class MIOpenSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      ScratchAllocator* scratch_allocator,
+      ScratchAllocator* scratch_allocator, dnn::CallContext call_context,
       std::vector<dnn::ProfileResult>* out_algorithms) override;
 
   bool GetRnnAlgorithms(
@@ -313,6 +313,7 @@ class MIOpenSupport : public dnn::DnnSupport {
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::AlgorithmDesc algorithm_desc, DeviceMemory<uint8> scratch_memory,
+      dnn::CallContext call_context,
       dnn::ProfileResult* output_profile_result) override;
 
   port::Status DoFusedConvolve(
@@ -908,7 +909,7 @@ class MIOpenSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      ScratchAllocator* scratch_allocator,
+      ScratchAllocator* scratch_allocator, dnn::CallContext call_context,
       std::vector<dnn::ProfileResult>* out_algorithms);
 
   bool GetMIOpenConvolveAlgorithmsFindMode(
@@ -919,7 +920,7 @@ class MIOpenSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      ScratchAllocator* scratch_allocator,
+      ScratchAllocator* scratch_allocator, dnn::CallContext call_context,
       std::vector<dnn::ProfileResult>* out_algorithms);
 
   template <class T>

--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -1095,8 +1095,9 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
                       device)};
 }
 
-/* static */ port::Status GpuDriver::GetMFMASupport(bool& supported) {
+/* static */ port::Status GpuDriver::GetMFMASupport(bool& supported, bool& gfx90a) {
   supported = false;
+  gfx90a = false;
   hipDeviceProp_t props;
   int dev = 0;
   hipError_t result = hipGetDevice(&dev);
@@ -1111,7 +1112,8 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
     if(pos!=string::npos)
        gcnArchName = gcnArchName.substr(pos+3);
     VLOG(1)<<"GCN arch name (stripped) " << gcnArchName;
-    supported = (gcnArchName=="908" || gcnArchName=="909");
+    supported = (gcnArchName=="908" || gcnArchName=="910" || gcnArchName=="90a");
+    gfx90a = (gcnArchName=="910" || gcnArchName=="90a");
     return port::Status::OK();
   }
   return port::Status{

--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -1111,9 +1111,9 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
     pos = gcnArchName.find("gfx");
     if(pos!=string::npos)
        gcnArchName = gcnArchName.substr(pos+3);
-    VLOG(1)<<"GCN arch name (stripped) " << gcnArchName;
     supported = (gcnArchName=="908" || gcnArchName=="910" || gcnArchName=="90a");
     gfx90a = (gcnArchName=="910" || gcnArchName=="90a");
+    VLOG(1)<<"GCN arch name (stripped): " << gcnArchName << ", MFMA supported: " << supported;
     return port::Status::OK();
   }
   return port::Status{

--- a/tensorflow/stream_executor/stream.cc
+++ b/tensorflow/stream_executor/stream.cc
@@ -3215,6 +3215,7 @@ Stream &Stream::ThenBlasTrsv(blas::UpperLower uplo, blas::Transpose trans,
               lda, x, incx);
 }
 
+/*
 Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
                              uint64 m, uint64 n, uint64 k, float alpha,
                              const DeviceMemory<Eigen::half> &a, int lda,
@@ -3309,6 +3310,7 @@ Stream &Stream::ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
   return impl(this, &blas::BlasSupport::DoBlasGemm, transa, transb, m, n, k,
               alpha, a, lda, b, ldb, beta, c, ldc);
 }
+*/
 
 namespace {
 // Like ThenBlasImpl, except this expects the last argument of blas_func to be a
@@ -3327,6 +3329,83 @@ struct ThenBlasWithProfileImpl {
   }
 };
 }  // anonymous namespace
+
+template <class T>
+Stream &Stream::ThenBlasGemmImpl(T ctx)
+{
+  if(ctx.output_profile_result == 0)
+  {
+    ThenBlasImpl<T, blas::ProfileResult*> impl;
+    return impl(this, &blas::BlasSupport::DoBlasGemm, ctx, (blas::ProfileResult*)nullptr);
+  }
+  else
+  {
+    ThenBlasWithProfileImpl<T> impl;
+    return impl(this, &blas::BlasSupport::DoBlasGemm, ctx, ctx.output_profile_result);
+  }
+}
+
+Stream &Stream::ThenBlasGemm(blas::GemmCallContext<Eigen::half> ctx)
+{
+  return ThenBlasGemmImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemm(blas::GemmCallContext<float> ctx)
+{
+  return ThenBlasGemmImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemm(blas::GemmCallContext<double> ctx)
+{
+  return ThenBlasGemmImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemm(blas::GemmCallContext<std::complex<float> > ctx)
+{
+  return ThenBlasGemmImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemm(blas::GemmCallContext<std::complex<double> > ctx)
+{
+  return ThenBlasGemmImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemm(blas::GemmCallContext<int8, int32> ctx)
+{
+  return ThenBlasGemmImpl(ctx);
+}
+
+template <class T>
+Stream &Stream::ThenBlasGemmBatchedImpl(T ctx)
+{
+  ThenBlasImpl<T> impl;
+  return impl(this, &blas::BlasSupport::DoBlasGemmBatched, ctx);
+}
+
+Stream &Stream::ThenBlasGemmBatched(blas::BatchedGemmCallContext<Eigen::half> ctx)
+{
+  return ThenBlasGemmBatchedImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemmBatched(blas::BatchedGemmCallContext<float> ctx)
+{
+  return ThenBlasGemmBatchedImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemmBatched(blas::BatchedGemmCallContext<double> ctx)
+{
+  return ThenBlasGemmBatchedImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemmBatched(blas::BatchedGemmCallContext<std::complex<float> > ctx)
+{
+  return ThenBlasGemmBatchedImpl(ctx);
+}
+
+Stream &Stream::ThenBlasGemmBatched(blas::BatchedGemmCallContext<std::complex<double> > ctx)
+{
+  return ThenBlasGemmBatchedImpl(ctx);
+}
 
 Stream &Stream::ThenBlasGemvWithProfiling(
     blas::Transpose trans, uint64 m, uint64 n, float alpha,
@@ -3403,6 +3482,7 @@ Stream &Stream::ThenBlasGemvWithProfiling(
               alpha, a, lda, x, incx, beta, y, incy, output_profile_result);
 }
 
+/*
 Stream &Stream::ThenBlasGemmWithProfiling(
     blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
     uint64 k, float alpha, const DeviceMemory<Eigen::half> &a, int lda,
@@ -3656,6 +3736,7 @@ Stream &Stream::ThenBlasGemmWithAlgorithm(
               m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, computation_type,
               algorithm, output_profile_result);
 }
+*/
 
 Stream &Stream::ThenBlasHemm(blas::Side side, blas::UpperLower uplo, uint64 m,
                              uint64 n, std::complex<float> alpha,
@@ -4117,6 +4198,7 @@ Stream &Stream::ThenBlasTrsm(blas::Side side, blas::UpperLower uplo,
               n, alpha, a, lda, b, ldb);
 }
 
+/*
 Stream &Stream::ThenBlasGemmBatched(
     blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
     uint64 k, float alpha,
@@ -4126,7 +4208,7 @@ Stream &Stream::ThenBlasGemmBatched(
     int batch_count) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=/nullptr);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4159,7 +4241,7 @@ Stream &Stream::ThenBlasGemmBatched(
     int batch_count) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=/nullptr);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4191,7 +4273,7 @@ Stream &Stream::ThenBlasGemmBatched(
     int batch_count) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=/nullptr);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4225,7 +4307,7 @@ Stream &Stream::ThenBlasGemmBatched(
     int batch_count) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=/nullptr);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4264,7 +4346,7 @@ Stream &Stream::ThenBlasGemmBatched(
     int batch_count) {
   return ThenBlasGemmBatchedWithScratch(transa, transb, m, n, k, alpha, a, lda,
                                         b, ldb, beta, c, ldc, batch_count,
-                                        /*scratch_allocator=*/nullptr);
+                                        /*scratch_allocator=/nullptr);
 }
 
 Stream &Stream::ThenBlasGemmBatchedWithScratch(
@@ -4401,6 +4483,7 @@ Stream &Stream::ThenBlasGemmStridedBatched(
               transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b, beta,
               c, ldc, stride_c, batch_count);
 }
+*/
 
 template <typename ABType, typename CType>
 Stream &Stream::ThenBlasLtMatmulImpl(

--- a/tensorflow/stream_executor/stream.h
+++ b/tensorflow/stream_executor/stream.h
@@ -347,7 +347,7 @@ class Stream {
           dnn::ToDataType<OutputType>::value, this, input_descriptor,
           input_data, filter_descriptor, filter_data, output_descriptor,
           *output, convolution_descriptor, algorithm_desc, scratch_memory,
-          output_profile_result);
+          dnn::CallContext::kForward, output_profile_result);
     }
     return port::UnimplementedError("DNN library is not found.");
   }
@@ -460,7 +460,8 @@ class Stream {
           dnn::ToDataType<ElementType>::value, this, input_descriptor,
           *backward_input_data, filter_descriptor, filter_data,
           output_descriptor, backward_output_data, convolution_descriptor,
-          algorithm_desc, scratch_memory, output_profile_result);
+          algorithm_desc, scratch_memory, dnn::CallContext::kBackpropData,
+          output_profile_result);
     }
     return port::UnimplementedError("DNN library is not found.");
   }
@@ -492,7 +493,8 @@ class Stream {
           dnn::ToDataType<ElementType>::value, this, input_descriptor,
           input_data, filter_descriptor, *backward_filter_data,
           output_descriptor, backward_output_data, convolution_descriptor,
-          algorithm_desc, scratch_memory, output_profile_result);
+          algorithm_desc, scratch_memory, dnn::CallContext::kBackpropFilter,
+          output_profile_result);
     }
     return port::UnimplementedError("DNN library is not found.");
   }
@@ -1303,238 +1305,26 @@ class Stream {
                        DeviceMemory<std::complex<double>> *x, int incx);
 
   // See BlasSupport::DoBlasGemm.
-  TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
-                                 uint64 m, uint64 n, uint64 k, float alpha,
-                                 const DeviceMemory<Eigen::half> &a, int lda,
-                                 const DeviceMemory<Eigen::half> &b, int ldb,
-                                 float beta, DeviceMemory<Eigen::half> *c,
-                                 int ldc);
-  TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
-                                 uint64 m, uint64 n, uint64 k, float alpha,
-                                 const DeviceMemory<float> &a, int lda,
-                                 const DeviceMemory<float> &b, int ldb,
-                                 float beta, DeviceMemory<float> *c, int ldc);
-  TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
-                                 uint64 m, uint64 n, uint64 k, double alpha,
-                                 const DeviceMemory<double> &a, int lda,
-                                 const DeviceMemory<double> &b, int ldb,
-                                 double beta, DeviceMemory<double> *c, int ldc);
-  TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
-                                 uint64 m, uint64 n, uint64 k,
-                                 std::complex<float> alpha,
-                                 const DeviceMemory<std::complex<float>> &a,
-                                 int lda,
-                                 const DeviceMemory<std::complex<float>> &b,
-                                 int ldb, std::complex<float> beta,
-                                 DeviceMemory<std::complex<float>> *c, int ldc);
-  TF_EXPORT Stream &ThenBlasGemm(blas::Transpose transa, blas::Transpose transb,
-                                 uint64 m, uint64 n, uint64 k,
-                                 std::complex<double> alpha,
-                                 const DeviceMemory<std::complex<double>> &a,
-                                 int lda,
-                                 const DeviceMemory<std::complex<double>> &b,
-                                 int ldb, std::complex<double> beta,
-                                 DeviceMemory<std::complex<double>> *c,
-                                 int ldc);
-
-  Stream &ThenBlasGemmWithProfiling(blas::Transpose transa,
-                                    blas::Transpose transb, uint64 m, uint64 n,
-                                    uint64 k, float alpha,
-                                    const DeviceMemory<Eigen::half> &a, int lda,
-                                    const DeviceMemory<Eigen::half> &b, int ldb,
-                                    float beta, DeviceMemory<Eigen::half> *c,
-                                    int ldc,
-                                    blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithProfiling(blas::Transpose transa,
-                                    blas::Transpose transb, uint64 m, uint64 n,
-                                    uint64 k, float alpha,
-                                    const DeviceMemory<float> &a, int lda,
-                                    const DeviceMemory<float> &b, int ldb,
-                                    float beta, DeviceMemory<float> *c, int ldc,
-                                    blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithProfiling(blas::Transpose transa,
-                                    blas::Transpose transb, uint64 m, uint64 n,
-                                    uint64 k, double alpha,
-                                    const DeviceMemory<double> &a, int lda,
-                                    const DeviceMemory<double> &b, int ldb,
-                                    double beta, DeviceMemory<double> *c,
-                                    int ldc,
-                                    blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithProfiling(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<float> alpha,
-      const DeviceMemory<std::complex<float>> &a, int lda,
-      const DeviceMemory<std::complex<float>> &b, int ldb,
-      std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithProfiling(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<double> alpha,
-      const DeviceMemory<std::complex<double>> &a, int lda,
-      const DeviceMemory<std::complex<double>> &b, int ldb,
-      std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      blas::ProfileResult *output_profile_result);
 
   // See BlasSupport::DoBlasGemmWithAlgorithm.
-  Stream &ThenBlasGemmWithAlgorithm(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, const HostOrDeviceScalar<Eigen::half> &alpha,
-      const DeviceMemory<Eigen::half> &a, int lda,
-      const DeviceMemory<Eigen::half> &b, int ldb,
-      const HostOrDeviceScalar<Eigen::half> &beta, DeviceMemory<Eigen::half> *c,
-      int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithAlgorithm(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, const HostOrDeviceScalar<int> &alpha,
-      const DeviceMemory<int8> &a, int lda, const DeviceMemory<int8> &b,
-      int ldb, const HostOrDeviceScalar<int> &beta, DeviceMemory<int> *c,
-      int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithAlgorithm(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, const HostOrDeviceScalar<float> &alpha,
-      const DeviceMemory<float> &a, int lda, const DeviceMemory<float> &b,
-      int ldb, const HostOrDeviceScalar<float> &beta, DeviceMemory<float> *c,
-      int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithAlgorithm(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, const HostOrDeviceScalar<double> &alpha,
-      const DeviceMemory<double> &a, int lda, const DeviceMemory<double> &b,
-      int ldb, const HostOrDeviceScalar<double> &beta, DeviceMemory<double> *c,
-      int ldc, blas::ComputationType computation_type,
-      blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithAlgorithm(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, const HostOrDeviceScalar<std::complex<float>> &alpha,
-      const DeviceMemory<std::complex<float>> &a, int lda,
-      const DeviceMemory<std::complex<float>> &b, int ldb,
-      const HostOrDeviceScalar<std::complex<float>> &beta,
-      DeviceMemory<std::complex<float>> *c, int ldc,
-      blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
-  Stream &ThenBlasGemmWithAlgorithm(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, const HostOrDeviceScalar<std::complex<double>> &alpha,
-      const DeviceMemory<std::complex<double>> &a, int lda,
-      const DeviceMemory<std::complex<double>> &b, int ldb,
-      const HostOrDeviceScalar<std::complex<double>> &beta,
-      DeviceMemory<std::complex<double>> *c, int ldc,
-      blas::ComputationType computation_type, blas::AlgorithmType algorithm,
-      blas::ProfileResult *output_profile_result);
 
   // See BlasSupport::DoBlasGemmBatched.
-  Stream &ThenBlasGemmBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, float alpha,
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,
-      float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,
-      int ldc, int batch_count);
-  Stream &ThenBlasGemmBatched(blas::Transpose transa, blas::Transpose transb,
-                              uint64 m, uint64 n, uint64 k, float alpha,
-                              const port::ArraySlice<DeviceMemory<float> *> &a,
-                              int lda,
-                              const port::ArraySlice<DeviceMemory<float> *> &b,
-                              int ldb, float beta,
-                              const port::ArraySlice<DeviceMemory<float> *> &c,
-                              int ldc, int batch_count);
-  Stream &ThenBlasGemmBatched(blas::Transpose transa, blas::Transpose transb,
-                              uint64 m, uint64 n, uint64 k, double alpha,
-                              const port::ArraySlice<DeviceMemory<double> *> &a,
-                              int lda,
-                              const port::ArraySlice<DeviceMemory<double> *> &b,
-                              int ldb, double beta,
-                              const port::ArraySlice<DeviceMemory<double> *> &c,
-                              int ldc, int batch_count);
-  Stream &ThenBlasGemmBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<float> alpha,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
-      std::complex<float> beta,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-      int batch_count);
-  Stream &ThenBlasGemmBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<double> alpha,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
-      std::complex<double> beta,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-      int batch_count);
-  Stream &ThenBlasGemmBatchedWithScratch(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, float alpha,
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<Eigen::half> *> &b, int ldb,
-      float beta, const port::ArraySlice<DeviceMemory<Eigen::half> *> &c,
-      int ldc, int batch_count, ScratchAllocator *scratch_allocator);
-  Stream &ThenBlasGemmBatchedWithScratch(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, float alpha, const port::ArraySlice<DeviceMemory<float> *> &a,
-      int lda, const port::ArraySlice<DeviceMemory<float> *> &b, int ldb,
-      float beta, const port::ArraySlice<DeviceMemory<float> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
-  Stream &ThenBlasGemmBatchedWithScratch(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, double alpha, const port::ArraySlice<DeviceMemory<double> *> &a,
-      int lda, const port::ArraySlice<DeviceMemory<double> *> &b, int ldb,
-      double beta, const port::ArraySlice<DeviceMemory<double> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
-  Stream &ThenBlasGemmBatchedWithScratch(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<float> alpha,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &b, int ldb,
-      std::complex<float> beta,
-      const port::ArraySlice<DeviceMemory<std::complex<float>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
-  Stream &ThenBlasGemmBatchedWithScratch(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<double> alpha,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &a, int lda,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &b, int ldb,
-      std::complex<double> beta,
-      const port::ArraySlice<DeviceMemory<std::complex<double>> *> &c, int ldc,
-      int batch_count, ScratchAllocator *scratch_allocator);
-  Stream &ThenBlasGemmStridedBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, float alpha, const DeviceMemory<Eigen::half> &a, int lda,
-      int64 stride_a, const DeviceMemory<Eigen::half> &b, int ldb,
-      int64 stride_b, float beta, DeviceMemory<Eigen::half> *c, int ldc,
-      int64 stride_c, int batch_count);
-  Stream &ThenBlasGemmStridedBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, float alpha, const DeviceMemory<float> &a, int lda,
-      int64 stride_a, const DeviceMemory<float> &b, int ldb, int64 stride_b,
-      float beta, DeviceMemory<float> *c, int ldc, int64 stride_c,
-      int batch_count);
-  Stream &ThenBlasGemmStridedBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, double alpha, const DeviceMemory<double> &a, int lda,
-      int64 stride_a, const DeviceMemory<double> &b, int ldb, int64 stride_b,
-      double beta, DeviceMemory<double> *c, int ldc, int64 stride_c,
-      int batch_count);
-  Stream &ThenBlasGemmStridedBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<float> alpha,
-      const DeviceMemory<std::complex<float>> &a, int lda, int64 stride_a,
-      const DeviceMemory<std::complex<float>> &b, int ldb, int64 stride_b,
-      std::complex<float> beta, DeviceMemory<std::complex<float>> *c, int ldc,
-      int64 stride_c, int batch_count);
-  Stream &ThenBlasGemmStridedBatched(
-      blas::Transpose transa, blas::Transpose transb, uint64 m, uint64 n,
-      uint64 k, std::complex<double> alpha,
-      const DeviceMemory<std::complex<double>> &a, int lda, int64 stride_a,
-      const DeviceMemory<std::complex<double>> &b, int ldb, int64 stride_b,
-      std::complex<double> beta, DeviceMemory<std::complex<double>> *c, int ldc,
-      int64 stride_c, int batch_count);
+  
+  template <class T> Stream& ThenBlasGemmImpl(T ctx);
+  template <class T> Stream& ThenBlasGemmBatchedImpl(T ctx);
+
+  TF_EXPORT Stream &ThenBlasGemm(blas::GemmCallContext<Eigen::half> ctx);
+  TF_EXPORT Stream &ThenBlasGemm(blas::GemmCallContext<float> ctx);
+  TF_EXPORT Stream &ThenBlasGemm(blas::GemmCallContext<double> ctx);
+  TF_EXPORT Stream &ThenBlasGemm(blas::GemmCallContext<std::complex<float> > ctx);
+  TF_EXPORT Stream &ThenBlasGemm(blas::GemmCallContext<std::complex<double> > ctx);
+  TF_EXPORT Stream &ThenBlasGemm(blas::GemmCallContext<int8, int32> ctx);
+
+  Stream &ThenBlasGemmBatched(blas::BatchedGemmCallContext<Eigen::half> ctx);
+  Stream &ThenBlasGemmBatched(blas::BatchedGemmCallContext<float> ctx);
+  Stream &ThenBlasGemmBatched(blas::BatchedGemmCallContext<double> ctx);
+  Stream &ThenBlasGemmBatched(blas::BatchedGemmCallContext<std::complex<float> > ctx);
+  Stream &ThenBlasGemmBatched(blas::BatchedGemmCallContext<std::complex<double> > ctx);
 
   // See BlasSupport::DoBlasHemm.
   Stream &ThenBlasHemm(blas::Side side, blas::UpperLower uplo, uint64 m,

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -281,7 +281,7 @@ bool StreamExecutor::GetMIOpenConvolveAlgorithms(
     DeviceMemoryBase filter_data, const dnn::BatchDescriptor &output_descriptor,
     DeviceMemoryBase output_data,
     const dnn::ConvolutionDescriptor &convolution_descriptor,
-    ScratchAllocator *scratch_allocator,
+    ScratchAllocator *scratch_allocator, dnn::CallContext call_context,
     std::vector<dnn::ProfileResult> *out_algorithms) {
   dnn::DnnSupport *dnn_support = AsDnn();
   if (!dnn_support) {
@@ -290,7 +290,7 @@ bool StreamExecutor::GetMIOpenConvolveAlgorithms(
   return dnn_support->GetMIOpenConvolveAlgorithms(
       kind, element_type, stream, input_descriptor, input_data,
       filter_descriptor, filter_data, output_descriptor, output_data,
-      convolution_descriptor, scratch_allocator, out_algorithms);
+      convolution_descriptor, scratch_allocator, call_context, out_algorithms);
 }
 
 bool StreamExecutor::GetRnnAlgorithms(

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -376,6 +376,7 @@ class StreamExecutor {
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor &convolution_descriptor,
       ScratchAllocator *scratch_allocator,
+      dnn::CallContext call_context,
       std::vector<dnn::ProfileResult> *out_algorithms);
 
   // Returns the list of supported algorithms for rnn operation.


### PR DESCRIPTION
…ss) for GEMM calls

Changes to track call-context information (forward pass / backprop pass) for CONV calls

Updating rocm_blas.cc to call the rocblas_gemm_ex API with the flag set for the fp16 datatype.

Updating rocm_dnn.cc to set the MIOPEN_CONVOLUTION_ATTRIB_FP16_ALT_IMPL attribute on the convolution descriptor for the fp16 datatype.

GEMM call interface refactor

Adjusting tolerances for some fp16 unit tests