### PR TITLE
[r2.7-rocm-enhanced] build_rocm_python3 - removing all the options that has been parsed by…

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -9,15 +9,7 @@
 # press enter all the way
 #
 
-# First positional argument (if any) specifies the ROCM_INSTALL_DIR
-ROCM_INSTALL_DIR=/opt/rocm-5.1.3
-if [[ -n $1 ]]; then
-    ROCM_INSTALL_DIR=$1
-fi
-
-ROCM_PATH=$ROCM_INSTALL_DIR
-
-while getopts "h:r" opt; do
+while getopts "hr" opt; do
   case ${opt} in
     h)
         echo "Options:"
@@ -25,11 +17,19 @@ while getopts "h:r" opt; do
         exit 0
         ;;
     r)
-        restriction=true 
+        restriction=true
         ;;
     esac
 done
+shift "$((OPTIND-1))"
 
+# First positional argument (if any) specifies the ROCM_INSTALL_DIR
+ROCM_INSTALL_DIR=/opt/rocm-5.1.0
+if [[ -n $1 ]]; then
+    ROCM_INSTALL_DIR=$1
+fi
+
+ROCM_PATH=$ROCM_INSTALL_DIR
 
 # Explicitly delete the old whl packages in the /tmp/tensorflow_pkg dir
 # Doing so comes in handy when the TF version number changes, because


### PR DESCRIPTION
… getopts from the parameters list, and so after that point, $1 will refer to the first non-option argument passed to the script.

Signed-off-by: Brij Lathia <brij.lathia@amd.com>