### PR TITLE
[r2.9-rocm-enhanced][ROCm5.3][roctracer] fix fo roctracer_next_record API on longer static

### DIFF
--- a/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/rocm_tracer.cc
@@ -1011,7 +1011,12 @@ Status RocmActivityCallbackImpl::operator()(const char* begin,
     }
 
     RETURN_IF_ROCTRACER_ERROR(static_cast<roctracer_status_t>(
-        roctracer_next_record(record, &record)));
+#if TF_ROCM_VERSION >= 50300
+        wrap::roctracer_next_record(record, &record)
+#else
+        roctracer_next_record(record, &record)
+#endif
+	));
   }
 
   return Status::OK();
@@ -1484,7 +1489,11 @@ void RocmTracer::ActivityCallbackHandler(const char* begin, const char* end) {
     while (record < end_record) {
       DumpActivityRecord(record,
                          "activity_tracing_enabled_ is false. Dropped!");
+#if TF_ROCM_VERSION >= 50300
+      wrap::roctracer_next_record(record, &record);
+#else
       roctracer_next_record(record, &record);
+#endif
     }
     VLOG(3) << "Dropped Activity Records End";
   }

--- a/tensorflow/stream_executor/rocm/roctracer_wrapper.h
+++ b/tensorflow/stream_executor/rocm/roctracer_wrapper.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/stream_executor/lib/env.h"
 #include "tensorflow/stream_executor/platform/dso_loader.h"
 #include "tensorflow/stream_executor/platform/port.h"
+#include "rocm/rocm_config.h"
 
 namespace tensorflow {
 namespace wrap {
@@ -61,6 +62,25 @@ namespace wrap {
 
 #endif  // PLATFORM_GOOGLE
 
+#if TF_ROCM_VERSION >= 50300
+#define FOREACH_ROCTRACER_API(DO_FUNC)           \
+  DO_FUNC(roctracer_default_pool_expl)           \
+  DO_FUNC(roctracer_disable_domain_activity)     \
+  DO_FUNC(roctracer_disable_domain_callback)     \
+  DO_FUNC(roctracer_disable_op_activity)         \
+  DO_FUNC(roctracer_disable_op_callback)         \
+  DO_FUNC(roctracer_enable_domain_activity_expl) \
+  DO_FUNC(roctracer_enable_domain_callback)      \
+  DO_FUNC(roctracer_enable_op_activity_expl)     \
+  DO_FUNC(roctracer_enable_op_callback)          \
+  DO_FUNC(roctracer_error_string)                \
+  DO_FUNC(roctracer_flush_activity_expl)         \
+  DO_FUNC(roctracer_get_timestamp)               \
+  DO_FUNC(roctracer_op_string)                   \
+  DO_FUNC(roctracer_open_pool_expl)              \
+  DO_FUNC(roctracer_set_properties)              \
+  DO_FUNC(roctracer_next_record)
+#else
 #define FOREACH_ROCTRACER_API(DO_FUNC)           \
   DO_FUNC(roctracer_default_pool_expl)           \
   DO_FUNC(roctracer_disable_domain_activity)     \
@@ -77,6 +97,7 @@ namespace wrap {
   DO_FUNC(roctracer_op_string)                   \
   DO_FUNC(roctracer_open_pool_expl)              \
   DO_FUNC(roctracer_set_properties)
+#endif
 
 FOREACH_ROCTRACER_API(ROCTRACER_API_WRAPPER)
 


### PR DESCRIPTION
Cherry-pick this roctracer update from ROCm5.3 into r2.9-rocm-enhanced