### PR TITLE
[r2.8-rocm-enhanced] Upgrading TF CI to Ubuntu 20.04

### DIFF
--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -905,7 +905,11 @@ cc_library(
     hdrs = [
         "functionalize_control_flow.h",
     ],
-    visibility = [":friends"],
+    visibility = [
+        ":friends",
+        "//tensorflow/core/lib/core:__pkg__",
+        "//tensorflow/core/lib/gtl:__pkg__",
+    ],
     deps = [
         ":functionalize_cond",
         ":functionalize_control_flow_util",

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -1,6 +1,6 @@
 # This Dockerfile provides a starting point for a ROCm installation of
 # MIOpen and tensorflow.
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
 ARG ROCM_DEB_REPO=https://repo.radeon.com/rocm/apt/5.1.3/
@@ -56,7 +56,7 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
   libnuma-dev \
   pciutils \
   virtualenv \
-  python-pip \
+  python3-pip \
   libxml2 \
   libxml2-dev \
   wget && \

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -108,6 +108,11 @@ RUN /install/install_deb_packages.sh
 RUN /install/install_bootstrap_deb_packages.sh
 RUN /install/install_pi_python3.9_toolchain.sh
 
+# Install gcc 7
+RUN apt -y install gcc-7 g++-7
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 \
+                         --slave /usr/bin/g++ g++ /usr/bin/g++-7
+
 SHELL ["/bin/bash", "-c"]
 RUN /install/install_bazel.sh
 RUN /install/install_golang.sh

--- a/tensorflow/tools/ci_build/install/install_deb_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_deb_packages.sh
@@ -55,7 +55,7 @@ apt-get install -y --no-install-recommends \
     pkg-config \
     python-dev \
     python-setuptools \
-    python-virtualenv \
+    virtualenv \
     python3-dev \
     python3-setuptools \
     rsync \

--- a/third_party/llvm/workspace.bzl
+++ b/third_party/llvm/workspace.bzl
@@ -14,6 +14,7 @@ def repo(name):
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
             "https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
+	    "https://github.com/ROCmSoftwarePlatform/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
         ],
         build_file = "//third_party/llvm:llvm.BUILD",
         patch_file = ["//third_party/llvm:macos_build_fix.patch"],


### PR DESCRIPTION
Upgrading r2.8 CI image to Ubuntu 20.04

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1744