### PR TITLE
[r2.9-rocm-enhanced] Revert: [kernel_gen] Allow specifying leading dimension of tile_size a…

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -653,7 +653,6 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
-    unroll_factors = "16B",
 )
 
 gpu_kernel_library(
@@ -1110,13 +1109,13 @@ gpu_kernel_library(
         "i32",
         "i64",
     ],
-    unroll_factors = "4",
     # For complex MulOp kernels, we don't use unrolling, it would only cause
     # slowdowns.
-    unroll_factors_override = {
-        "c64": None,
-        "c128": None,
-    },
+    types_with_unrolling_disabled = [
+        "c64",
+        "c128",
+    ],
+    unroll_factors = "4",
 )
 
 gpu_kernel_library(
@@ -1130,13 +1129,13 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
-    unroll_factors = "4",
     # For complex MulNoNanOp kernels, we don't use unrolling, it would only
     # cause slowdowns.
-    unroll_factors_override = {
-        "c64": None,
-        "c128": None,
-    },
+    types_with_unrolling_disabled = [
+        "c64",
+        "c128",
+    ],
+    unroll_factors = "4",
 )
 
 # Bitwise operations.
@@ -1182,7 +1181,7 @@ gpu_kernel_library(
 gpu_kernel_library(
     name = "gpu_atan2_kernels",
     op = "atan2",
-    tile_size = "256",
+    tile_size = "256,1,1",
     types = [
         "f16",
         "f32",
@@ -1706,13 +1705,13 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
-    unroll_factors = "4",
     # For complex XlogyOp kernels, we don't use unrolling, it would only cause
     # slowdowns.
-    unroll_factors_override = {
-        "c64": None,
-        "c128": None,
-    },
+    types_with_unrolling_disabled = [
+        "c64",
+        "c128",
+    ],
+    unroll_factors = "4",
 )
 
 gpu_kernel_library(
@@ -1740,13 +1739,13 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
-    unroll_factors = "4",
     # For complex Xlog1pyOp kernels, we don't use unrolling, it would only cause
     # slowdowns.
-    unroll_factors_override = {
-        "c64": None,
-        "c128": None,
-    },
+    types_with_unrolling_disabled = [
+        "c64",
+        "c128",
+    ],
+    unroll_factors = "4",
 )
 
 cpu_kernel_library(

--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -139,9 +139,14 @@ def _gen_kernel_bin_impl(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    cmd_args = list(ctx.attr.extra_args)
+    name = ctx.attr.name
+    cmd_args = []
     if ctx.attr.unroll_factors:
         cmd_args.append("--unroll_factors=%s" % ctx.attr.unroll_factors)
+    if ctx.attr.extra_args:
+        cmd_args.extend(ctx.attr.extra_args)
+    tile_sizes = ctx.attr.tile_size.replace("x", ",")
+    arch_flag = ",".join(ctx.attr.gpu_archs)
     gpu_bin = ctx.outputs.kernel
 
     # cc_binary seems not to bring its dependencies with it, so do that explicitly here.
@@ -150,9 +155,9 @@ def _gen_kernel_bin_impl(ctx):
         outputs = [gpu_bin],
         executable = ctx.executable._tool,
         arguments = cmd_args + [
-            "--tile_sizes=%s" % ctx.attr.tile_size,
+            "--tile_sizes=%s" % tile_sizes,
             "--max-supported-rank=%s" % ctx.attr.max_supported_rank,
-            "--arch=%s" % ",".join(ctx.attr.gpu_archs),
+            "--arch=%s" % arch_flag,
             "--input=%s" % ctx.file.mlir_op.path,
             "--output=%s" % gpu_bin.path,
             "--enable_ftz=%s" % (ctx.attr.data_type == "f32"),
@@ -188,8 +193,8 @@ _gen_kernel_bin_rule = rule(
         "unroll_factors": attr.string(),
         "max_supported_rank": attr.int(),
         "gpu_archs": attr.string_list(),
-        "jit": attr.bool(),
-        "cpu_codegen": attr.bool(),
+        "jit": attr.bool(mandatory = False),
+        "cpu_codegen": attr.bool(mandatory = False),
         "extra_args": attr.string_list(),
         # cc_binary seems not to bring its dependencies with it, so do that explicitly here.
         "_tfso": attr.label(
@@ -210,47 +215,20 @@ _gen_kernel_bin_rule = rule(
     implementation = _gen_kernel_bin_impl,
 )
 
-# Returns the shape string (e.g. "4x4" or "16Bx2") as comma-separated integers.
-# If the leading dimension is specified as bytes, the value is divided by the
-# size of 'type'. 'overrides' is a type -> shape dict.
-def _get_shape(shape, type, overrides):
-    shape = overrides.get(type, shape)
-    if not shape:
-        return None
-    shape = shape.split("x")
-    if shape[0].endswith("B"):
-        shape[0] = str(int(shape[0][:-1]) // {
-            "i8": 1,
-            "i16": 2,
-            "i32": 4,
-            "i64": 8,
-            "ui8": 1,
-            "ui16": 2,
-            "ui32": 4,
-            "ui64": 8,
-            "f16": 2,
-            "f32": 4,
-            "f64": 8,
-            "c64": 8,
-            "c128": 16,
-        }[type])
-    return ",".join(shape)
-
 def _gen_kernel_library(
         name,
         op,
         types,
         platform,
         tile_size,
-        tile_size_override = {},
         max_supported_rank = 5,
-        output_types = [],
-        jit_types = [],
-        output_jit_types = [],
+        output_types = None,
+        jit_types = None,
+        output_jit_types = None,
         gpu_archs = [],
         tags = [],
         unroll_factors = None,
-        unroll_factors_override = {},
+        types_with_unrolling_disabled = [],
         extra_args = [],
         test_tags = [],
         test_size = "medium"):
@@ -260,8 +238,7 @@ def _gen_kernel_library(
       name: The name of the produced library with kernels.
       op: The name of the tensorflow op.
       types: The types ("f16", "f32", "f64") for which a kernel should be generated.
-      tile_size: The tiling specification, e.g. "16x16" or "16Bx16".
-      tile_size_override: dict of type-specific tile_size.
+      tile_size: The tiling specification, e.g. "16x16".
       max_supported_rank: Maximum supported rank for rank specialization.
       jit_types: The types ("f16", "f32", "f64") for which a kernel should be
                  generated. These kernels are different in that they are only
@@ -278,8 +255,7 @@ def _gen_kernel_library(
       gpu_archs: The list of GPU architectures to compile for. If empty, then
                  the compilation will happen for CPU.
       tags: The tags which should be added to the library.
-      unroll_factors: The unrolling specification, e.g. "4x4" or "16B"
-      unroll_factors_override: dict of type-specific unroll_factors.
+      unroll_factors: The unrolling specification, e.g. "4,4"
       types_with_unrolling_disabled: The types for which unrolling should be disabled.
       extra_args: Extra arguments to pass to the generator tool.
       test_tags: The tags to pass to the generated test.
@@ -287,19 +263,27 @@ def _gen_kernel_library(
     """
 
     enable_cpu = bool(platform == "cpu")
+    if not output_types:
+        output_types = types
+    if not jit_types:
+        jit_types = []
+    if not output_jit_types:
+        output_jit_types = jit_types
 
-    aot_kernels = zip(types, output_types or types, [False for t in types])
-    jit_kernels = zip(jit_types, output_jit_types or jit_types, [True for t in jit_types])
-    all_kernels = aot_kernels + jit_kernels
+    true_jits = [True for i in range(len(jit_types))]
+    all_jit_kernels = zip(jit_types, output_jit_types, true_jits)
+    false_jits = [False for i in range(len(types))]
+    all_aot_kernels = zip(types, output_types, false_jits)
+    all_kernels = all_aot_kernels + all_jit_kernels
 
     if cuda_gpu_architectures() or rocm_gpu_architectures() or enable_cpu:
         for (type, output_type, jit) in all_kernels:
             # Disable unrolling for integer types while LLVM does not vectorize these.
             # See b/182343395 for context.
-            integer_types = ["i1", "i8", "i16", "i32", "i64", "ui8", "ui16", "ui32", "ui64"]
-            typed_unroll_factors = None if type in integer_types else unroll_factors
-            typed_unroll_factors = _get_shape(typed_unroll_factors, type, unroll_factors_override)
-            typed_tile_size = _get_shape(tile_size, type, tile_size_override)
+            unrolling_disabled = (types_with_unrolling_disabled + ["i1", "i8", "i16", "i32", "i64"])
+            filtered_unroll_factors = ""
+            if type not in unrolling_disabled:
+                filtered_unroll_factors = unroll_factors
             _gen_mlir_op(
                 op = op,
                 output_type = output_type,
@@ -325,8 +309,8 @@ def _gen_kernel_library(
                     type = type,
                     output_type = output_type,
                 ),
-                tile_size = typed_tile_size,
-                unroll_factors = typed_unroll_factors,
+                tile_size = tile_size,
+                unroll_factors = filtered_unroll_factors,
             )
 
             # We have to use a sh_test instead of build_test because it doesn't properly find the dependent targets.
@@ -340,11 +324,11 @@ def _gen_kernel_library(
                     output_type = output_type,
                 ),
                 "--cpu_codegen=true" if enable_cpu else "--arch={}".format(gpu_arch_option),
-                "--tile_sizes=%s" % typed_tile_size,
+                "--tile_sizes=%s" % tile_size,
                 "--enable_ftz=%s" % (type == "f32"),
             ]
-            if typed_unroll_factors:
-                test_args.append("--unroll_factors=%s" % typed_unroll_factors)
+            if filtered_unroll_factors:
+                test_args.append("--unroll_factors=%s" % filtered_unroll_factors)
             native.sh_test(
                 name = "{op}_{platform}_{type}_{output_type}_gen_test".format(
                     op = op,


### PR DESCRIPTION
…nd unroll_factors

Reverts: b8263919112cb63e4389dbd0c7b39e27a30cc17d

This was found to cause a 5-6% performance drop in resnet101 (tf_cnn_benchmark) FP16

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1921