### PR TITLE
Revert:[kernel_gen] Allow specifying leading dimension of tile_size a…

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -654,7 +654,9 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
-    unroll_factors = "16B",
+# TODO: The causes a performance regression on ROCm
+#     : https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1921
+#    unroll_factors = "16B", 
 )
 
 gpu_kernel_library(


### PR DESCRIPTION
…nd unroll_factors

Reverts part of: b8263919112cb63e4389dbd0c7b39e27a30cc17d

This was found to cause a 5-6% performance drop in resnet101 (tf_cnn_benchmark) FP16

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1921