### PR TITLE
[r2.8-rocm-enhanced] Add a fallback download location for llvm-raw

### DIFF
--- a/third_party/llvm/workspace.bzl
+++ b/third_party/llvm/workspace.bzl
@@ -14,6 +14,7 @@ def repo(name):
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
             "https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
+	    "https://github.com/ROCmSoftwarePlatform/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
         ],
         build_file = "//third_party/llvm:llvm.BUILD",
         patch_file = ["//third_party/llvm:macos_build_fix.patch"],


### PR DESCRIPTION
This has been timing out lately. Let's add a third fallback option here so we can get CI back online.