### PR TITLE
[r2.8-rocm-enhanced] Add upper limit pin for numpy to <1.23

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -79,7 +79,7 @@ REQUIRED_PACKAGES = [
     'h5py >= 2.9.0',
     'keras_preprocessing >= 1.1.1', # 1.1.0 needs tensorflow==1.7
     'libclang >= 9.0.1',
-    'numpy >= 1.20',
+    'numpy >= 1.20, < 1.23',  # 1.23 is causing some unit test fails
     'opt_einsum >= 2.3.2',
     'protobuf >= 3.9.2, < 3.20',
     'setuptools',


### PR DESCRIPTION
numpy 1.23 is causing some unit tests to fail on py38.

This PR adds an upper limit runtime pin to keep numpy at 1.20-1.22

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/2088