### PR TITLE
[develop-upstream-QA-rocm53] Revert:[kernel_gen] Allow specifying lea…

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -653,7 +653,9 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
-    unroll_factors = "16B",
+# TODO: The causes a performance regression on ROCm
+#     : https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/1921
+#    unroll_factors = "16B",
 )
 
 gpu_kernel_library(


### PR DESCRIPTION
…ding dimension of tile_size and unroll factors

Reverts part of: https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/b8263919112cb63e4389dbd0c7b39e27a30cc17d

This was found to cause a 5-6% performance drop in resnet101 (tf_cnn_benchmark) FP16
as well as vgg11, vgg16, vgg19