### PR TITLE
The following commit enabled MLIR generation for fusion ops by defaul…

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -96,11 +96,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
   opts.set_xla_gpu_shape_checks(DebugOptions::RUNTIME);
   opts.set_xla_cpu_enable_mlir_lowering(false);
-#if TENSORFLOW_USE_ROCM
-  opts.set_xla_gpu_enable_mlir_lowering(false);
-#else
   opts.set_xla_gpu_enable_mlir_lowering(true);
-#endif
   opts.set_xla_gpu_normalize_layouts(false);
   return opts;
 }

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/hlo_to_gpu_pipeline.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/hlo_to_gpu_pipeline.cc
@@ -67,7 +67,11 @@ void mlir::createHloToGpuPipeline(OpPassManager &pm,
   pm.addNestedPass<GPUModuleOp>(createCanonicalizerPass());
   pm.addNestedPass<GPUModuleOp>(createConvertSCFToCFPass());
   // GPU -> low-level IR
+#if TENSORFLOW_USE_ROCM
+  pm.addNestedPass<GPUModuleOp>(createGpuKernelToRocdlPass());
+#else
   pm.addNestedPass<GPUModuleOp>(createGpuKernelToNvvmPass());
+#endif
   pm.addPass(createPropagateStaticShapesToKernelPass());
   // Some instructions crash ptxas down the line if they have debug info
   // attached.


### PR DESCRIPTION
…t on GPU: https://github.com/tensorflow/tensorflow/commit/e3fb392bad8c79a65131ca2470ee4db2c5860b8c

This caused Nvidia CUDA IR to be generated even on the ROCm platform.

This commit fixes this by emitting AMDGPU IR on ROCm builds.