### PR TITLE
The following commit enabled MLIR generation for fusion ops by defaul…

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/hlo_to_gpu_pipeline.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/hlo_to_gpu_pipeline.cc
@@ -67,7 +67,11 @@ void mlir::createHloToGpuPipeline(OpPassManager &pm,
   pm.addNestedPass<GPUModuleOp>(createCanonicalizerPass());
   pm.addNestedPass<GPUModuleOp>(createConvertSCFToCFPass());
   // GPU -> low-level IR
+#if TENSORFLOW_USE_ROCM
+  pm.addNestedPass<GPUModuleOp>(createGpuKernelToRocdlPass());
+#else
   pm.addNestedPass<GPUModuleOp>(createGpuKernelToNvvmPass());
+#endif
   pm.addPass(createPropagateStaticShapesToKernelPass());
   // Some instructions crash ptxas down the line if they have debug info
   // attached.

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -98,11 +98,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
   opts.set_xla_gpu_shape_checks(DebugOptions::RUNTIME);
   opts.set_xla_cpu_enable_mlir_lowering(false);
-#if TENSORFLOW_USE_ROCM
-  opts.set_xla_gpu_enable_mlir_lowering(false);
-#else
   opts.set_xla_gpu_enable_mlir_lowering(true);
-#endif
   opts.set_xla_gpu_normalize_layouts(false);
   return opts;
 }

--- a/tensorflow/core/tfrt/graph_executor/BUILD
+++ b/tensorflow/core/tfrt/graph_executor/BUILD
@@ -1,3 +1,4 @@
+31
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 
 package(
@@ -35,7 +36,7 @@ cc_library(
     tags = ["no_oss"],
     deps = [
         ":graph_execution_options",
-        "//learning/brain/experimental/tfrt/native_lowering/saved_model:saved_model_translate",
+#        "//learning/brain/experimental/tfrt/native_lowering/saved_model:saved_model_translate",
         "//tensorflow/compiler/mlir/tensorflow:import_model",
         "//tensorflow/compiler/mlir/tfrt:import_model",
         "//tensorflow/compiler/mlir/tfrt:tf_jitrt_request_context",

--- a/tensorflow/lite/experimental/remat/BUILD
+++ b/tensorflow/lite/experimental/remat/BUILD
@@ -3,7 +3,7 @@ cc_library(
     srcs = ["metadata_util.cc"],
     hdrs = ["metadata_util.h"],
     deps = [
-        "//base",
+#        "//base",
         "//tensorflow/lite:graph_info",
     ],
 )


### PR DESCRIPTION
…t on GPU: https://github.com/tensorflow/tensorflow/commit/e3fb392bad8c79a65131ca2470ee4db2c5860b8c

This caused Nvidia CUDA IR to be generated even on the ROCm platform.

This commit fixes this by emitting AMDGPU IR on ROCm builds.