### PR TITLE
Remove references to nightly flag from build_rocm_python3

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -40,7 +40,7 @@ ROCM_PATH=$ROCM_INSTALL_DIR
 # can lead to a lot of frustation and lost time trying to figure why the
 # changes made in the current build are not working!
 TF_PKG_LOC=/tmp/tensorflow_pkg
-rm -f $TF_PKG_LOC/tf_nightly_rocm*.whl
+rm -f $TF_PKG_LOC/tensorflow*.whl
 
 yes "" | ROCM_PATH=$ROCM_INSTALL_DIR TF_NEED_ROCM=1 PYTHON_BIN_PATH=/usr/bin/python3 ./configure
 # Explicitly define resource constraints on bazel to avoid overload on rocm-ci
@@ -51,5 +51,5 @@ if [[ -n $restriction ]]; then
     exit 0
 fi
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
-bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC --rocm --nightly_flag &&
-pip3 install --upgrade $TF_PKG_LOC/tf_nightly_rocm*.whl
+bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC --rocm &&
+pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl


### PR DESCRIPTION
Use correct name for the tensorflow package. Otherwise, the container image has incorrect package name