### PR TITLE
Reenable multi-gpu tests.

### DIFF
--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -1119,7 +1119,6 @@ cuda_py_test(
     python_version = "PY3",
     tags = [
         "multi_and_single_gpu",
-	"no_rocm"
     ],
     deps = [
         ":combinations",
@@ -1707,7 +1706,6 @@ distribute_py_test(
     tags = [
         "multi_and_single_gpu",
         "no_oss",  # TODO(b/227211015)
-	"no_rocm"
     ],
     tpu_tags = [
         "no_oss",  # Target too big to run serially reliably.
@@ -1867,7 +1865,6 @@ distribute_py_test(
     main = "metrics_v1_test.py",
     tags = [
         "multi_and_single_gpu",
-	"no_rocm"
     ],
     deps = [
         ":combinations",
@@ -1906,7 +1903,6 @@ cuda_py_test(
         "multi_and_single_gpu",
         "nomsan",  # b/154224457: Re-enable when fixed.
         "notsan",  # TODO(b/220133218)
-	"no_rocm"
     ],
     # b/155301154 broken with XLA:GPU
     xla_enable_strict_auto_jit = True,
@@ -1994,7 +1990,6 @@ cuda_py_test(
     tags = [
         "multi_and_single_gpu",
         "notsan",  # TODO(b/220133218)
-	"no_rocm"
     ],
     # b/141096229: Non-atomic AssignAdd
     xla_enable_strict_auto_jit = False,
@@ -2191,7 +2186,6 @@ distribute_py_test(
     main = "tf_function_test.py",
     tags = [
         "multi_and_single_gpu",
-	"no_rocm"
     ],
     deps = [
         ":combinations",

--- a/tensorflow/python/distribute/collective_all_reduce_strategy_test.py
+++ b/tensorflow/python/distribute/collective_all_reduce_strategy_test.py
@@ -120,7 +120,7 @@ class CollectiveAllReduceStrategyTestBase(
         num_gpus=num_gpus,
         num_tpus=num_tpus)
 
-    if use_devices_arg:
+    if use_devices_arg and num_gpus > 0:
       devices = ['GPU:%d' % i for i in range(num_gpus)]
       # Temporary workaround to manually set the `_extended` field before device
       # initialization is exposed as a public interface.


### PR DESCRIPTION
There is also a fix for //tensorflow/python/distribute:collective_all_reduce_strategy_test_xla_2gpu