### PR TITLE
Add ROCM version to packaging

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -32,6 +32,7 @@ import fnmatch
 import os
 import re
 import sys
+import io
 
 from setuptools import Command
 from setuptools import find_packages
@@ -62,6 +63,35 @@ if '--project_name' in sys.argv:
 # tf_nightly-* package is being built.
 def standard_or_nightly(standard, nightly):
   return nightly if 'tf_nightly' in project_name else standard
+
+## AMD ##
+# For tensorflow-rocm, add the rocm version we're building against as a
+# semver compatible buid metadata string (https://semver.org/#spec-item-10)
+# This is not pip public version compatible (see: https://peps.python.org/pep-0440/),
+# so for pip we will convert the '+' to a "."
+def _get_default_rocm_path():
+  return "/opt/rocm"
+
+def _get_rocm_install_path():
+  """Determines and returns the ROCm installation path."""
+  rocm_install_path = _get_default_rocm_path()
+  if "ROCM_PATH" in os.environ:
+    rocm_install_path = os.environ["ROCM_PATH"]
+  return rocm_install_path
+
+def _rocm_version(rocm_install_path):
+  version_file = os.path.join(rocm_install_path, ".info/version-dev")
+  if not os.path.exists(version_file):
+    return ""
+  version_numbers = []
+  with open(version_file) as f:
+    version_string = f.read().strip()
+    version_numbers = version_string.split(".")
+  return str(version_numbers[0] + "." + version_numbers[1] + "." + version_numbers[2].split("-")[0])
+
+if project_name.endswith('_rocm'):
+  _VERSION = _VERSION + "+rocm" + str(_rocm_version(_get_rocm_install_path()))
+
 
 # All versions of TF need these packages. We indicate the widest possible range
 # of package releases possible to be as up-to-date as possible as well as to
@@ -281,7 +311,7 @@ headers = (
 
 setup(
     name=project_name,
-    version=_VERSION.replace('-', ''),
+    version=_VERSION.replace('-', '').replace('+', '.'),
     description=DOCLINES[0],
     long_description='\n'.join(DOCLINES[2:]),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Background:
Tensorflow versioning is semvar (https://semver.org/). This is partially compatible with the whl package version scheme defined in PEP 440 (https://peps.python.org/pep-0440). TensorFlow does use semvar spec item 9 for Release Candidate (pre-release) purposes by appending "-rc1" or similar to the version number.  This is technically incompatible with PEP440 (https://peps.python.org/pep-0440/#semantic-versioning) but is worked around by just removing the "-" at packaging time.

For TensorFlow-rocm, we need a way to version the whl files we publish when new ROCM versions are released. Currently we co-opt the third TensorFlow version digit. This mapping is documented (https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/blob/develop-upstream/rocm_docs/tensorflow-rocm-release.md) This works and is compliant with PEP440 and with semvar.

The downside of this is we lose the fidelity of upstream point release versioning in the package naming. The content itself is versioned in  `tensorflow/core/public/version.h` however and that remains untouched. So we have a scenario where we have a package called tensorflow-rocm2.9.2 and that means "TF2.9.0 but built with ROCM5.2.0".

Proposal:

Let's change how we version the whl package. We'll no longer co-opt the third TF digit. That will return to matching the actual content version. Instead, we'll append a build metadata string compliant with semvar spec item 10 (https://semver.org/#spec-item-10). For example tensorflow_rocm-2.9.0+rocm5.2.0. Since PEP440 isn't compatible with semvar spec item10, we'll just convert the '+' to a '.' and give it an extra version tuple for the package public name:  tensorflow-rocm-2.9.0.rocm5.2.0

For RCs, its a little awkward but still valid:
   tf_nightly_rocm-2.10.0rc2.rocm5.2.0