### PR TITLE
[r2.7-rocm-enhanced] Set HSA_TOOLS_LIB=libroctracer.so for single GPU unit tests

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -49,6 +49,7 @@ bazel test \
       --local_test_jobs=${N_TEST_JOBS} \
       --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
       --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+      --test_env=HSA_TOOLS_LIB=libroctracer64.so \
       --test_timeout 600,900,2400,7200 \
       --build_tests_only \
       --test_output=errors \


### PR DESCRIPTION
Recent changes to roctracer require a change to enable some of the single GPU unit tests to pass.

The change is needed because:

For the HSA API intercept to work correctly, the roctracer library must be loaded before hsa_init(). hsa_init() scans the (already) loaded shared objects and intializes tool libraries exporting an OnLoad() symbol. hsa_init() also loads tool libraries specified in HSA_TOOLS_LIB if they weren't already loaded.

hsa_init() is the only time when it is safe to replace the HSA API function pointers with wrappers to collect timestamps. This wasn't done correcly before, and as a result the tracer library had some issues with HSA tracing. To fix HSA tracing, we had to impose this requirement.