### PR TITLE
Revert: Switching compiler to clang

### DIFF
--- a/third_party/gpus/crosstool/BUILD.rocm.tpl
+++ b/third_party/gpus/crosstool/BUILD.rocm.tpl
@@ -87,16 +87,14 @@ cc_toolchain_config(
         "-fuse-ld=gold",
         "-Wl,-no-as-needed",
         "-Wl,-z,relro,-z,now",
-#        "-pass-exit-codes",
+        "-pass-exit-codes",
         "-lstdc++",
         "-lm",
-        "-L%{rocm_toolkit_path}/lib",
-        "-Wl,-rpath,%{rocm_toolkit_path}/lib",
-        "-lamdhip64"
     ],
     link_libs = [],
     opt_link_flags = [],
     unfiltered_compile_flags = [
+        "-fno-canonical-system-headers",
         "-Wno-builtin-macro-redefined",
         "-D__DATE__=\"redacted\"",
         "-D__TIMESTAMP__=\"redacted\"",

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_rocm.tpl
@@ -74,7 +74,7 @@ def GetHostCompilerOptions(argv):
   parser.add_argument('-iquote', nargs='*', action='append')
   parser.add_argument('--sysroot', nargs=1)
   parser.add_argument('-g', nargs='*', action='append')
-#  parser.add_argument('-fno-canonical-system-headers', action='store_true')
+  parser.add_argument('-fno-canonical-system-headers', action='store_true')
 
   args, _ = parser.parse_known_args(argv)
 
@@ -86,6 +86,8 @@ def GetHostCompilerOptions(argv):
     opts += ' -iquote ' + ' -iquote '.join(sum(args.iquote, []))
   if args.g:
     opts += ' -g' + ' -g'.join(sum(args.g, []))
+  #if args.fno_canonical_system_headers:
+  #  opts += ' -fno-canonical-system-headers'
   if args.sysroot:
     opts += ' --sysroot ' + args.sysroot[0]
 

--- a/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
+++ b/third_party/gpus/crosstool/hipcc_cc_toolchain_config.bzl.tpl
@@ -393,14 +393,12 @@ def _impl(ctx):
                             flag_group(
                                 flags = [
                                     "-Wl,-rpath,$EXEC_ORIGIN/%{runtime_library_search_directories}",
-#                                    "-Wl,-rpath,$ROCM_PATH/lib",
                                 ],
                                 expand_if_true = "is_cc_test",
                             ),
                             flag_group(
                                 flags = [
                                     "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
-#                                    "-Wl,-rpath,$ROCM_PATH/lib",
                                 ],
                                 expand_if_false = "is_cc_test",
                             ),
@@ -1048,6 +1046,7 @@ def _impl(ctx):
                     flag_group(
                         flags = [
                             "-no-canonical-prefixes",
+                            "-fno-canonical-system-headers",
                         ]
                     ),
                 ],

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -66,13 +66,6 @@ def verify_build_defines(params):
         )
 
 def find_cc(repository_ctx):
-    rocm_path = get_host_environ(repository_ctx, "ROCM_PATH")
-    if rocm_path == None:
-      rocm_path = "/opt/rocm"
-    rocm_gcc = get_host_environ(repository_ctx, "TF_ROCM_GCC")
-    if rocm_gcc != "1":
-      return rocm_path+"/llvm/bin/clang"
-
     """Find the C++ compiler."""
 
     # Return a dummy value for GCC detection here to avoid error
@@ -723,8 +716,6 @@ def _create_local_rocm_repository(repository_ctx):
     )
 
     verify_build_defines(rocm_defines)
-
-    rocm_defines["%{rocm_toolkit_path}"] = rocm_config.rocm_toolkit_path
 
     # Only expand template variables in the BUILD file
     repository_ctx.template(


### PR DESCRIPTION
Reverts: Switching compiler to clang
Workarounds for clang compiler errors
 [develop-upstream](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream) ([#1695](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1695))

This was causing a fail when building manylinux2014 (on RH7). The TF_ROCM_GCC env var wasn't enough to disable.

Also: the original issue for this commit was a compile fail with gcc-8 on Ubuntu18. We no longer build that combo. Ubuntu20+gcc9 works fine.