### PR TITLE
Disable the llvm.roundeven op for MHLO on ROCm.

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1446,7 +1446,6 @@ tf_xla_py_test(
     tags = [
         "no_cuda_asan",  # times out
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
-	"no_rocm", # TODO(#2517): Disabled due to LLVM ERROR
     ],
     deps = [
         ":xla_test",

--- a/tensorflow/compiler/xla/client/lib/BUILD
+++ b/tensorflow/compiler/xla/client/lib/BUILD
@@ -198,7 +198,6 @@ cc_library(
 xla_test(
     name = "math_test",
     srcs = ["math_test.cc"],
-    tags = ["no_rocm"], # TODO (#2516) Disable due to LLVM ERROR
     deps = [
         ":constants",
         ":math",

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/gpu_fusion_rewrite.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/gpu_fusion_rewrite.cc
@@ -338,7 +338,10 @@ ConversionTarget FusionRewritePattern::getRewritableTarget(MLIRContext* ctx) {
       mhlo::AddOp, mhlo::AbsOp, mhlo::CbrtOp, mhlo::CeilOp, mhlo::CosineOp,
       mhlo::DivOp, mhlo::ExpOp, mhlo::Expm1Op, mhlo::FloorOp, mhlo::LogOp,
       mhlo::Log1pOp, mhlo::LogisticOp, mhlo::MulOp, mhlo::NegOp, mhlo::RoundOp,
-      mhlo::RoundNearestEvenOp, mhlo::RsqrtOp, mhlo::SignOp, mhlo::SineOp,
+#if !TENSORFLOW_USE_ROCM
+      mhlo::RoundNearestEvenOp,
+#endif
+      mhlo::RsqrtOp, mhlo::SignOp, mhlo::SineOp,
       mhlo::SqrtOp, mhlo::SubtractOp, mhlo::TanhOp>();
   return target;
 }


### PR DESCRIPTION
The llvm.roundeven op is supported for f32 in the AMDGPU backend, but there are other AMDGPU specific LLVM issues.

The op doesn't seem to be supported for f16 for AMDGPU.

So this op must be excluded for AMDGPU until the aforementioned LLVM issues are addressed.