### PR TITLE
[r2.6-rocm-enhanced] Allow RocmRoot to be set via ROCM_PATH env var

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -442,10 +442,10 @@ TEST_F(GPUDeviceTest, DeviceDetails) {
   for (int i = 0; i < devices.size(); i++) {
     std::unordered_map<string, string> details;
     TF_ASSERT_OK(factory->GetDeviceDetails(i, &details));
-    EXPECT_NE(details["device_name"], "");
 #if TENSORFLOW_USE_ROCM
     EXPECT_EQ(details.count("compute_capability"), 0);
 #else
+    EXPECT_NE(details["device_name"], "");
     EXPECT_NE(details["compute_capability"], "");
 #endif
   }

--- a/tensorflow/core/platform/default/rocm_rocdl_path.cc
+++ b/tensorflow/core/platform/default/rocm_rocdl_path.cc
@@ -28,8 +28,13 @@ namespace tensorflow {
 
 string RocmRoot() {
 #if TENSORFLOW_USE_ROCM
-  VLOG(3) << "ROCM root = " << TF_ROCM_TOOLKIT_PATH;
-  return TF_ROCM_TOOLKIT_PATH;
+  if (const char* rocm_path_env = std::getenv("ROCM_PATH")) {
+    VLOG(3) << "ROCM root = " << rocm_path_env;
+    return rocm_path_env;
+  } else {
+    VLOG(3) << "ROCM root = " << TF_ROCM_TOOLKIT_PATH;
+    return TF_ROCM_TOOLKIT_PATH;
+  }
 #else
   return "";
 #endif

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1010,7 +1010,10 @@ cuda_py_test(
     size = "small",
     srcs = ["config_test.py"],
     python_version = "PY3",
-    tags = ["no_pip"],  # test_ops are not available in pip.
+    tags = [
+        "no_pip",  # test_ops are not available in pip
+        "no_rocm",
+    ],
     deps = [
         ":config",
         ":constant_op",


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/2452

This fix is needed at runtime for non-standard ROCM locations with no symlink from /opt/rocm.