### PR TITLE
Allow RocmRoot to be set via ROCM_PATH env var

### DIFF
--- a/tensorflow/tsl/platform/default/rocm_rocdl_path.cc
+++ b/tensorflow/tsl/platform/default/rocm_rocdl_path.cc
@@ -28,8 +28,13 @@ namespace tensorflow {
 
 string RocmRoot() {
 #if TENSORFLOW_USE_ROCM
-  VLOG(3) << "ROCM root = " << TF_ROCM_TOOLKIT_PATH;
-  return TF_ROCM_TOOLKIT_PATH;
+  if (const char* rocm_path_env = std::getenv("ROCM_PATH")) {
+    VLOG(3) << "ROCM root = " << rocm_path_env;
+    return rocm_path_env;
+  } else {
+    VLOG(3) << "ROCM root = " << TF_ROCM_TOOLKIT_PATH;
+    return TF_ROCM_TOOLKIT_PATH;
+  }
 #else
   return "";
 #endif


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/2452

This fix is needed at runtime for non-standard ROCM locations with no symlink from /opt/rocm.