### PR TITLE
[2.10-rocm-enhanced] Remove uneeded radix_merge_compare implementation from Tensorf…

### DIFF
--- a/tensorflow/core/kernels/gpu_prim_helpers.h
+++ b/tensorflow/core/kernels/gpu_prim_helpers.h
@@ -26,50 +26,6 @@ limitations under the License.
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/stream_executor/stream.h"
 
-#if TENSORFLOW_USE_ROCM
-
-BEGIN_ROCPRIM_NAMESPACE
-namespace detail
-{
-
-template<bool Descending>
-struct radix_merge_compare<Descending, true, Eigen::half>
-{
-    using key_codec = radix_key_codec<rocprim::half, true>;
-    using bit_key_type = typename key_codec::bit_key_type;
-
-    unsigned int bit, length;
-
-    radix_merge_compare(const unsigned int bit, const unsigned int current_radix_bits)
-    {
-        this->bit = bit;
-        this->length = current_radix_bits;
-    }
-
-    ROCPRIM_DEVICE ROCPRIM_INLINE
-    bool operator()(const rocprim::half& a, const rocprim::half& b) const
-    {
-        __half ha = reinterpret_cast<const __half&>(a);
-        __half hb = reinterpret_cast<const __half&>(b);
-
-        const bit_key_type encoded_key_a = key_codec::encode(ha);
-        const bit_key_type masked_key_a  = key_codec::extract_digit(encoded_key_a, bit, length);
-
-        const bit_key_type encoded_key_b = key_codec::encode(hb);
-        const bit_key_type masked_key_b  = key_codec::extract_digit(encoded_key_b, bit, length);
-
-        if(Descending)
-          return __hgt(key_codec::decode(masked_key_a), key_codec::decode(masked_key_b));
-        else
-          return __hgt(key_codec::decode(masked_key_b), key_codec::decode(masked_key_a));
-    }
-};
-
-} // end namespace detail
-END_ROCPRIM_NAMESPACE
-
-#endif
-
 namespace tensorflow {
 
 namespace detail {


### PR DESCRIPTION
…low in favor of the rocPrim implementation.

This fixes a build fail on ROCM5.3 and 5.4 builds.
It was added as a build fix during ROCM5.2 here: https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/7953775b61347ad0e2ad4cac4b9ea8963ed3d5ca

Removing this doesn't break the build on 5.2 now, so we'll just remove it altogether now.