### PR TITLE
[develop-upstream-QA-rocm54][gfx90a] Add fence to memory barrier in XLA for gfx90a.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -726,5 +726,17 @@ void IrEmitter::BindFusionArguments(const HloInstruction* fusion,
   }
 }
 
+void IrEmitter::MaybeEmitFenceForAMDGPU(
+    llvm::AtomicOrdering atomic_ordering,
+    const char* sync_scope_id) {
+  if (IsEmittingForAMDGPU()) {
+    if (ir_emitter_context_->rocm_compute_capability()
+        .gcn_arch_name().substr(0, 6) == "gfx90a") {
+      Fence(atomic_ordering,
+          b_.getContext().getOrInsertSyncScopeID(sync_scope_id));
+    }
+  }
+}
+
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.h
@@ -182,6 +182,10 @@ class IrEmitter : public DfsHloVisitorWithDefault,
   void BindFusionArguments(const HloInstruction* fusion,
                            FusedIrEmitter* fused_emitter);
 
+  // Emit a fence for AMDGPU if necessary.
+  void MaybeEmitFenceForAMDGPU(llvm::AtomicOrdering atomic_ordering,
+                               const char* sync_scope_id);
+
  private:
   // A helper method for EmitAtomicOperationForNestedComputation. Certain
   // computations, such as floating-point addition and integer maximization, can

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -4217,6 +4217,8 @@ IrEmitterUnnested::EmitTilingKernel(
 }
 
 llvm::CallInst* IrEmitterUnnested::EmitSyncThreads() {
+  MaybeEmitFenceForAMDGPU(llvm::AtomicOrdering::SequentiallyConsistent,
+      "workgroup");
   return EmitCallToTargetIntrinsic(TargetIntrinsicID::kBarrierId, {}, {}, &b_);
 }
 

--- a/tensorflow/compiler/xla/service/llvm_ir/ir_builder_mixin.h
+++ b/tensorflow/compiler/xla/service/llvm_ir/ir_builder_mixin.h
@@ -111,6 +111,11 @@ class IrBuilderMixin {
   }
 
   template <class... Args>
+  llvm::Value* Fence(Args&&... args) {
+    return mixin_builder()->CreateFence(std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
   llvm::Value* FMul(Args&&... args) {
     return mixin_builder()->CreateFMul(std::forward<Args>(args)...);
   }


### PR DESCRIPTION
This was done to compensate for LLVM commit 2c82a126d762c14c2f3df2d03a6ae5fb37c3351a which stops the compiler from emitting fences at barriers by default on gfx90a.

This LLVM change was done to provide more control over the type of fence that is emitted at memory barriers and thus places the onus of emitting the fence on the user.