### PR TITLE
[r2.8-rocm-enhanced] Add virtualenv to release builds

### DIFF
--- a/tensorflow/tools/ci_build/release/common.sh
+++ b/tensorflow/tools/ci_build/release/common.sh
@@ -146,7 +146,7 @@ function install_ubuntu_16_python_pip_deps {
   done
 
   # First, upgrade pypi wheels
-  ${PIP_CMD} install --user --upgrade setuptools pip wheel
+  ${PIP_CMD} install --user --upgrade setuptools pip wheel virtualenv
 
   # LINT.IfChange(linux_pip_installations)
   # Remove any historical keras package if they are installed.


### PR DESCRIPTION
Existing release builds attempt to use virtualenv but its not installed.