### PR TITLE
Fix for multiple NCCL manager issue.

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/transforms/constant_fold.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/constant_fold.cc
@@ -150,6 +150,9 @@ LogicalResult ConstantFoldFallbackHook(
     // This is conceptually equal to what we do in python/eager/context.py but
     // with all GPU/TPU devices ignored and CPU only set to 1.
     (*config_proto.mutable_device_count())["CPU"] = 1;
+#if TENSORFLOW_USE_ROCM
+    (*config_proto.mutable_device_count())["GPU"] = 0;
+#endif
     config_proto.add_device_filters("/device:CPU:*");
     std::unique_ptr<TF_Buffer, decltype(&TF_DeleteBuffer)> config(
         TF_NewBuffer(), TF_DeleteBuffer);


### PR DESCRIPTION
The following upstream commit caused multiple NCCL managers to be instantiated:

https://github.com/tensorflow/tensorflow/commit/e4cd69d5de3b555ace0fda2cdc0d825fec798293

This was discovered when testing an MLPerf Resnet50 model.

AMDGPUs do not support multiple NCCL managers due to the way the hardware queues are designed, so if such an attempt is detected, Tensorflow will throw a runtime error.