### PR TITLE
Fix for JAX build breakage on ROCm.

### DIFF
--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -39,6 +39,10 @@ load(
     "tf_cuda_library",
 )
 load(
+    "//tensorflow/tsl/platform/default:cuda_build_defs.bzl",
+    "if_cuda_is_configured",
+)
+load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_is_configured",
 )
@@ -1046,9 +1050,9 @@ cc_binary(
 cc_library(
     name = "private_static_dep",
     visibility = ["//visibility:private"],
-    deps = if_static(
+    deps = if_cuda_is_configured(if_static(
         ["//tensorflow/compiler/xla/stream_executor/cuda:all_runtime"],
-    ),
+    )),
 )
 
 tf_cuda_library(


### PR DESCRIPTION
The following upstream commit caused JAX on ROCm to fail to build:

https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/f03950067329636899e81173b3650c78ce78c432

It caused the following link time error:

/usr/bin/ld.gold: error: bazel-out/k8-opt/bin/_solib_local/_U@local_Uconfig_Ucuda_S_Scuda_Ccudart___Ucuda_Scuda_Slib/libcudart.so: file is empty