### PR TITLE
Rocm miopen deterministic pre rocm 53 test updates

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -289,6 +289,7 @@ cuda_py_test(
     srcs = ["cudnn_deterministic_ops_test.py"],
     tags = [
         "no_cuda_asan",  # TODO(b/171509035): re-enable.
+        "no_rocm_pre_53",
     ],
     xla_enable_strict_auto_jit = True,
     deps = [

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py310_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py310_pip.sh
@@ -42,8 +42,18 @@ export N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 
+#Add filter tags specific to ROCm version
+rocm_major_version=`cat /opt/rocm/.info/version | cut -d "." -f 1`
+rocm_minor_version=`cat /opt/rocm/.info/version | cut -d "." -f 2`
+TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=""
+if [[ $rocm_major_version == *"5"* ]]; then
+	if [[ $rocm_minor_version -lt 3 ]]; then
+		TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=",no_rocm_pre_53"	
+	fi
+fi
+
 # # Export optional variables for running pip.sh
-export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py39,-no_rocm'
+export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py39,-no_rocm${TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC}'
 export TF_BUILD_FLAGS="--config=release_base "
 export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filters=${TF_TEST_FILTER_TAGS} \
  --test_env=TF2_BEHAVIOR=1 \

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py37_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py37_pip.sh
@@ -42,8 +42,18 @@ export N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 
+#Add filter tags specific to ROCm version
+rocm_major_version=`cat /opt/rocm/.info/version | cut -d "." -f 1`
+rocm_minor_version=`cat /opt/rocm/.info/version | cut -d "." -f 2`
+TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=""
+if [[ $rocm_major_version == *"5"* ]]; then
+	if [[ $rocm_minor_version -lt 3 ]]; then
+		TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=",no_rocm_pre_53"	
+	fi
+fi
+
 # # Export optional variables for running pip.sh
-export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py37,-no_rocm'
+export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py39,-no_rocm'${TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC}
 export TF_BUILD_FLAGS="--config=release_base "
 export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filters=${TF_TEST_FILTER_TAGS} \
  --test_env=TF2_BEHAVIOR=1 \

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py38_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py38_pip.sh
@@ -42,8 +42,18 @@ export N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 
+#Add filter tags specific to ROCm version
+rocm_major_version=`cat /opt/rocm/.info/version | cut -d "." -f 1`
+rocm_minor_version=`cat /opt/rocm/.info/version | cut -d "." -f 2`
+TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=""
+if [[ $rocm_major_version == *"5"* ]]; then
+	if [[ $rocm_minor_version -lt 3 ]]; then
+		TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=",no_rocm_pre_53"	
+	fi
+fi
+
 # # Export optional variables for running pip.sh
-export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py38,-no_rocm'
+export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py39,-no_rocm'${TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC}
 export TF_BUILD_FLAGS="--config=release_base "
 export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filters=${TF_TEST_FILTER_TAGS} \
  --test_env=TF2_BEHAVIOR=1 \

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py39_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py39_pip.sh
@@ -42,8 +42,18 @@ export N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 
+#Add filter tags specific to ROCm version
+rocm_major_version=`cat /opt/rocm/.info/version | cut -d "." -f 1`
+rocm_minor_version=`cat /opt/rocm/.info/version | cut -d "." -f 2`
+TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=""
+if [[ $rocm_major_version == *"5"* ]]; then
+	if [[ $rocm_minor_version -lt 3 ]]; then
+		TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC=",no_rocm_pre_53"	
+	fi
+fi
+
 # # Export optional variables for running pip.sh
-export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py39,-no_rocm'
+export TF_TEST_FILTER_TAGS='gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_oss_py39,-no_rocm'${TF_TEST_FILTER_TAGS_ROCM_VERSION_SPECIFIC}
 export TF_BUILD_FLAGS="--config=release_base "
 export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filters=${TF_TEST_FILTER_TAGS} \
  --test_env=TF2_BEHAVIOR=1 \


### PR DESCRIPTION
Wheel builds for TF against pre ROCm5.3 are failing due to deterministic tests. This PR filters them out for ROCm5.2 and lower.

Issue
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/2834

