### PR TITLE
Reenable the testAdd subtest in xla_ops_test.py.

### DIFF
--- a/tensorflow/compiler/tests/xla_ops_test.py
+++ b/tensorflow/compiler/tests/xla_ops_test.py
@@ -53,8 +53,6 @@ class XlaOpsNumericalTest(xla_test.XLATestCase, parameterized.TestCase):
       equality_fn(result, expected)
 
   def testAdd(self):
-    if xla_test.test.is_built_with_rocm():
-      self.skipTest('Broken with rocm')
     for dtype in self.numeric_types:
       self._assertOpOutputMatchesExpected(
           xla.add,


### PR DESCRIPTION
Apparently some recent LLVM commit fixed this.