### PR TITLE
Fixed the rocm all_runtime alias to point to the new XLA folder.

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/BUILD
@@ -790,7 +790,7 @@ alias(
 
 alias(
     name = "rocm_platform",
-    actual = "//tensorflow/stream_executor/rocm:all_runtime",
+    actual = "//tensorflow/compiler/xla/stream_executor/rocm:all_runtime",
 )
 
 # TODO(se-owner): document or remove this.


### PR DESCRIPTION
This alias is not used ATM but it seems prudent to fix this for a possible future use.