### PR TITLE
[ROCM] Enable matrix inverse core kernel for large matrices

### DIFF
--- a/tensorflow/core/util/rocm_solvers.cc
+++ b/tensorflow/core/util/rocm_solvers.cc
@@ -16,21 +16,20 @@
 /*
 Mapping of GpuSolver Methods to respective ROCm Library APIs.
 /-----------------------------------------------------------=-----------------------------/
-/ GpuSolverMethod  //    rocblasAPI    //   rocsolverAPI    //   hipsolverAPI
-(ROCM>4.5)  / / Geam             //  rocblas_Xgeam   //    ----           //
-----                   / / Getrf            //      ----        //
-rocsolver_Xgetrf  //   hipsolverXgetrf          / / GetrfBatched     // ---- //
-""_Xgetrf_batched //     ----                   / / GetriBatched     // ---- //
-""_Xgetri_batched //     ----                   / / Getrs            // ---- //
-rocsolver_Xgetrs  //   hipsolverXgetrs          / / GetrsBatched     // ---- //
-""_Xgetrs_batched //     ----                   / / Geqrf            // ---- //
-rocsolver_Xgeqrf  //   hipsolverXgeqrf          / / Heevd            // ---- //
-----           //   hipsolverXheevd          / / Potrf            //      ----
-// rocsolver_Xpotrf  //   hipsolverXpotrf          / / PotrfBatched     // ----
-// ""_Xpotrf_batched //   ""XpotrfBatched          / / Trsm             //
-rocblas_Xtrsm   //    ----           //     ----                   / / Ungqr //
-----        // rocsolver_Xungqr  //   hipsolverXungqr          / / Unmqr // ----
-// rocsolver_Xunmqr  //   hipsolverXunmqr          /
+/ GpuSolverMethod  //    rocblasAPI    //   rocsolverAPI    //   hipsolverAPI (ROCM>4.5)/ / 
+Geam               //  rocblas_Xgeam   //    ----           //   ----                   / / 
+Getrf              //      ----        // rocsolver_Xgetrf  //   hipsolverXgetrf        / / 
+GetrfBatched       //      ----        // ""_Xgetrf_batched //     ----                 / / 
+GetriBatched       //      ----        // ""_Xgetri_batched //     ----                 / / 
+Getrs              //      ----        // rocsolver_Xgetrs  //   hipsolverXgetrs        / / 
+GetrsBatched       //      ----        // ""_Xgetrs_batched //     ----                 / / 
+Geqrf              //      ----        // rocsolver_Xgeqrf  //   hipsolverXgeqrf        / / 
+Heevd              //      ----        //    ----           //   hipsolverXheevd        / / 
+Potrf              //      ----        // rocsolver_Xpotrf  //   hipsolverXpotrf        / / 
+PotrfBatched       //      ----        // ""_Xpotrf_batched //   ""XpotrfBatched        / / 
+Trsm               //  rocblas_Xtrsm   //    ----           //     ----                 / / 
+Ungqr              //      ----        // rocsolver_Xungqr  //   hipsolverXungqr        / / 
+Unmqr              //      ----        // rocsolver_Xunmqr  //   hipsolverXunmqr          /
 /-----------------------------------------------------------------------------------------/
 */
 #if TENSORFLOW_USE_ROCM


### PR DESCRIPTION
This enables the matrix inverse op for ROCM.

Here we use the hipSolver methods GETRF/GETRS because they are faster than their batched rocBlas equivalents for large matrices. 
Unlike the CUDA path, small matrices also use hipSolver since there is currently no matinvBatched function in rocBlas.