### PR TITLE
Add a ROCM version check for the matrix inverse kernel. This only works on 5.3+

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_inverse_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_inverse_op.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/kernels/linalg/eye_functor.h"
 #include "tensorflow/core/kernels/transpose_functor.h"
@@ -83,7 +84,7 @@ class MatrixInverseOp : public LinearAlgebraOp<Scalar> {
   TF_DISALLOW_COPY_AND_ASSIGN(MatrixInverseOp);
 };
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA || ( TENSORFLOW_USE_ROCM && TF_ROCM_VERSION >= 50300)
 
 typedef Eigen::GpuDevice GPUDevice;
 


### PR DESCRIPTION
The matrix inverse kernel was enabled in: https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/1900

This only works in ROCM 5.3 so this adds a ROCM version check.