### PR TITLE
disable sysconfig_test due to sysconfig.get_path breakage

### DIFF
--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -117,6 +117,7 @@ tf_py_test(
     tags = [
         "no_pip",
         "no_windows",
+	"no_oss",  # TODO(b/259319686) : Disable the tes
     ],
     deps = [
         ":platform",


### PR DESCRIPTION
There is a problem with this test. Disabled upstream in a few places:
https://github.com/tensorflow/tensorflow/commit/695aaf9d9905bb2abb955e68525598af0984d10c
https://github.com/tensorflow/tensorflow/commit/b7fcfdf1f1ed9bca05d596732a4de5ef0db893d3

Seeing locally as well - disabling for now.