### PR TITLE
Update tf_sig_build_dockerfile README and rename ROCM script

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm
@@ -37,9 +37,9 @@ RUN echo $CACHEBUSTER
 ARG PYTHON_VERSION
 ENV PYTHON_LIB_PATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages
 ENV PYTHON_BIN_PATH=/usr/local/bin/python${PYTHON_VERSION}
-COPY setup.python.rocm.sh /setup.python.rocm.sh
-COPY devel.requirements.rocm.txt /devel.requirements.rocm.txt
-RUN /setup.python.rocm.sh $PYTHON_VERSION /devel.requirements.rocm.txt
+COPY setup.build-python.sh /setup.build-python.sh
+COPY devel.requirements.txt /devel.requirements.txt
+RUN /setup.build-python.sh $PYTHON_VERSION /devel.requirements.txt
 
 # Setup build and environment
 COPY devel.usertools /usertools

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -52,3 +52,5 @@ twine ~= 3.6.0
 junitparser ~= 2.2.0
 lxml ~= 4.9.1
 pylint ~= 2.13.9
+virtualenv
+requests

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -101,7 +101,7 @@ test:pip_venv --action_env PYTHON_LIB_PATH="/bazel_pip/lib/python3/site-packages
 test:pip_venv --python_path="/bazel_pip/bin/python3"
 test:pip_venv --define=no_tensorflow_py_deps=true
 # Yes, we don't exclude the gpu tests on pip for some reason.
-test:pip_filters --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11,-no_pip,-nopip
+test:pip_filters --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11,-no_pip,-nopip,-no_rocm
 test:pip_filters --build_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_serial,-no_cuda11,-no_pip,-nopip
 test:pip_filters --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium
 test:pip --config=pip_venv --config=pip_filters -- //bazel_pip/tensorflow/... -//bazel_pip/tensorflow/python/integration_testing/... -//bazel_pip/tensorflow/compiler/tf2tensorrt/... -//bazel_pip/tensorflow/compiler/xrt/... -//bazel_pip/tensorflow/core/tpu/... -//bazel_pip/tensorflow/lite/... -//tensorflow/tools/toolchains/...

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -37,29 +37,38 @@ build --copt=-mavx --host_copt=-mavx
 build --profile=/tf/pkg/profile.json.gz
 
 # CUDA: Set up compilation CUDA version and paths
-build --@local_config_cuda//:enable_cuda
-build --repo_env TF_NEED_CUDA=1
-build --action_env=TF_CUDA_VERSION="11"
-build --action_env=TF_CUDNN_VERSION="8"
-build --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.8"
-build --action_env=GCC_HOST_COMPILER_PATH="/dt9/usr/bin/gcc"
-build --action_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
-build --crosstool_top="@sigbuild-r2.12_config_cuda//crosstool:toolchain"
+build:cuda --@local_config_cuda//:enable_cuda
+build:cuda --repo_env TF_NEED_CUDA=1
+build:cuda --action_env=TF_CUDA_VERSION="11"
+build:cuda --action_env=TF_CUDNN_VERSION="8"
+build:cuda --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.8"
+build:cuda --action_env=GCC_HOST_COMPILER_PATH="/dt9/usr/bin/gcc"
+build:cuda --action_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
+build:cuda --crosstool_top="@sigbuild-r2.12_config_cuda//crosstool:toolchain"
 
 # CUDA: Enable TensorRT optimizations
 # https://developer.nvidia.com/tensorrt
-build --repo_env TF_NEED_TENSORRT=1
+build:cuda --repo_env TF_NEED_TENSORRT=1
 
 # CUDA: Select supported compute capabilities (supported graphics cards).
 # This is the same as the official TensorFlow builds.
 # See https://developer.nvidia.com/cuda-gpus#compute
 # TODO(angerson, perfinion): What does sm_ vs compute_ mean?
 # TODO(angerson, perfinion): How can users select a good value for this?
-build --repo_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm_75,compute_80"
+build:cuda --repo_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm_75,compute_80"
+
+# ROCM: Set up compilation ROCM version and paths
+build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
+build:rocm --define=using_rocm_hipcc=true
+build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
+build:rocm --repo_env TF_NEED_ROCM=1
+# Disable unused-result on rocm builds.
+build:rocm --copt="-Wno-error=unused-result"
 
 # Test-related settings below this point.
+test:cuda --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+test:rocm --test_tag_filters=gpu,-no_oss,-oss_serial,-no_gpu,-no_rocm,-benchmark-test,-tpu,-v1only
 test --build_tests_only --keep_going --test_output=errors --verbose_failures=true
-test --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
 # Local test jobs has to be 4 because parallel_gpu_execute is fragile, I think
 test --test_timeout=300,450,1200,3600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
 # Give only the list of failed tests at the end of the log

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh
@@ -24,10 +24,6 @@ for wheel in /tf/pkg/*.whl; do
   # Change linux to manylinux
   NEW_TF_WHEEL=${wheel/linux/"manylinux2014"}
 
-  # Underscores need to be dashes; fix if nightly or regular
-  NEW_TF_WHEEL=${NEW_TF_WHEEL/tf_nightly_rocm/"tf-nightly-rocm"}
-  NEW_TF_WHEEL=${NEW_TF_WHEEL/tensorflow_rocm/"tensorflow-rocm"}
-
   mv $wheel $NEW_TF_WHEEL
   auditwheel show $NEW_TF_WHEEL
 done

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh
@@ -19,8 +19,15 @@
 # "manylinux_xyz" into the wheel filename.
 set -euxo pipefail
 
-TF_WHEEL=$(ls -Art /tf/pkg/tensorflow*-linux_x86_64.whl | tail -n 1)
-echo "Checking and renaming $TF_WHEEL..."
-NEW_TF_WHEEL=${TF_WHEEL/linux/"manylinux2014"}
-mv $TF_WHEEL $NEW_TF_WHEEL
-auditwheel show $NEW_TF_WHEEL
+for wheel in /tf/pkg/*.whl; do
+  echo "Checking and renaming $wheel..."
+  # Change linux to manylinux
+  NEW_TF_WHEEL=${wheel/linux/"manylinux2014"}
+
+  # Underscores need to be dashes; fix if nightly or regular
+  NEW_TF_WHEEL=${NEW_TF_WHEEL/tf_nightly_rocm/"tf-nightly-rocm"}
+  NEW_TF_WHEEL=${NEW_TF_WHEEL/tensorflow_rocm/"tensorflow-rocm"}
+
+  mv $wheel $NEW_TF_WHEEL
+  auditwheel show $NEW_TF_WHEEL
+done

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
@@ -1,0 +1,1 @@
+gpu.bazelrc

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.build-python.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.build-python.sh
@@ -66,12 +66,19 @@ else
     exit 1
 fi
 
+# Setup links for TensorFlow to compile.
+# Referenced in devel.usertools/*.bazelrc
+ln -sf /usr/local/bin/$VERSION /usr/bin/python3
+ln -sf /usr/local/bin/$VERSION /usr/bin/python
+ln -sf /usr/local/lib/$VERSION /usr/lib/tf_python
+
 export PYTHON_LIB_PATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages
 export PYTHON_BIN_PATH=/usr/local/bin/python${PYTHON_VERSION}
 
-# Pip version required by manylinux2014
-pip3 install --upgrade pip
-cat $REQUIREMENTS
-echo -e "\nnumpy==${NUMPY_VERSION}" | tee -a ${REQUIREMENTS}
-cat $REQUIREMENTS
-pip3 --no-cache-dir install -r ${REQUIREMENTS}
+# Install pip
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+python3 -m pip install --no-cache-dir --upgrade pip
+
+# Disable the cache dir to save image space, and install packages
+python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U


### PR DESCRIPTION
Updates the README to reference published build containers at `rocm/tensorflow-build`
This also updates the rename script to be able to handle tf_nightly_rocm => tf-nightly-rocm