### PR TITLE
[develop-upstream-QA-rocm54] Disable //tensorflow/python/platform/sysconfig_test.

### DIFF
--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -127,6 +127,7 @@ tf_py_test(
     tags = [
         "no_pip",
         "no_windows",
+        "no_oss",  # TODO(b/259319686) : Disable the test
     ],
     deps = [
         ":platform",


### PR DESCRIPTION
This CPU test is failing due to JAX related issues.

It was disabled upstream here: https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/695aaf9d9905bb2abb955e68525598af0984d10c