### PR TITLE
Fixed pooling_ops_test due to testAvgPoolGradInvalidStrideRaiseErrorProperly

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -515,7 +515,7 @@ cuda_py_test(
     srcs = ["pooling_ops_test.py"],
     shard_count = 10,
     # Some operations in this test can only be checked on sm61+.
-    tags = ["prefer-sm70", "no_rocm"],
+    tags = ["prefer-sm70"],
     deps = [
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
@@ -2546,7 +2546,7 @@ class PoolingTest(test.TestCase, parameterized.TestCase):
             orig_input_shape=orig_input_shape,
             grad=grad,
             ksize=[1, 40, 128, 1],
-            strides=[1, 128, 128, 30],
+            strides=[1, 128, 128, 30, 1],
             padding="SAME",
             data_format="NHWC")
         self.evaluate(t)


### PR DESCRIPTION
testAvgPoolGradInvalidStrideRaiseErrorProperly is testing whether AvgPoolGrad will raise error when the input stride is invalid, the original testcase is no problem on our side (we will fail to pass it).

So we can add one extra dimention to invalid the input stride to pass this test.