### PR TITLE
[r2.11-rocm-enhanced] Update bazel version in install scripts

### DIFF
--- a/tensorflow/tools/ci_build/install/install_bazel_from_source.sh
+++ b/tensorflow/tools/ci_build/install/install_bazel_from_source.sh
@@ -18,7 +18,7 @@
 # It will compile bazel from source and install it in /usr/local/bin
 
 # Select bazel version.
-BAZEL_VERSION="5.1.1"
+BAZEL_VERSION="5.3.0"
 
 set +e
 local_bazel_ver=$(bazel version 2>&1 | grep -i label | awk '{print $3}')

--- a/tensorflow/tools/ci_build/release/common.sh
+++ b/tensorflow/tools/ci_build/release/common.sh
@@ -17,7 +17,7 @@
 
 # Keep in sync with tensorflow_estimator and configure.py.
 # LINT.IfChange
-LATEST_BAZEL_VERSION=5.1.1
+LATEST_BAZEL_VERSION=5.3.0
 # LINT.ThenChange(
 #   //tensorflow_estimator/google/kokoro/common.sh,
 #   //tensorflow/tools/ci_build/install/install_bazel.sh,


### PR DESCRIPTION
Update a few of the various bazel installer scripts for 2.11.
Outdated since these are no longer maintained upstream.