### PR TITLE
[develop-upstream-QA-rocm55] Disable //tensorflow/python/platform/sysconfig_test.

### DIFF
--- a/tensorflow/python/platform/BUILD
+++ b/tensorflow/python/platform/BUILD
@@ -117,6 +117,7 @@ tf_py_test(
     tags = [
         "no_pip",
         "no_windows",
+        "no_oss",  # TODO(b/259319686) : Disable the test
     ],
     deps = [
         ":platform",


### PR DESCRIPTION
Cherry-pick to disable sysconfig test for 55 QA branch