### PR TITLE
Fix roctracer includes for ROCM5.2 and earlier

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/roctracer_wrapper.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/roctracer_wrapper.h
@@ -22,11 +22,15 @@ limitations under the License.
 
 #include "rocm/include/roctracer/roctracer.h"
 #include "rocm/include/roctracer/roctracer_hip.h"
+#include "rocm/rocm_config.h"
+#if TF_ROCM_VERSION >= 50300
 #include "rocm/include/roctracer/roctracer_roctx.h"
+#else
+#include "rocm/include/roctracer/roctracer_hcc.h"
+#endif
 #include "tensorflow/compiler/xla/stream_executor/lib/env.h"
 #include "tensorflow/compiler/xla/stream_executor/platform/dso_loader.h"
 #include "tensorflow/compiler/xla/stream_executor/platform/port.h"
-#include "rocm/rocm_config.h"
 
 namespace stream_executor {
 namespace wrap {


### PR DESCRIPTION
Fixes a build error for ROCM5.2 and earlier introduced in this commit:
https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/commit/d10bf8a0fac099588019a5084c9a795873dba83e