### PR TITLE
Fix the issue of the return code

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -48,7 +48,7 @@ if [[ -n $restriction ]]; then
     bazel build --local_ram_resources=60000 --local_cpu_resources=35 --jobs=70 --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
     bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC --rocm &&
     pip3 install --upgrade $TF_PKG_LOC/tensorflow*.whl
-    exit 0
+    exit $?
 fi
 bazel build --config=opt --config=rocm //tensorflow/tools/pip_package:build_pip_package --verbose_failures &&
 bazel-bin/tensorflow/tools/pip_package/build_pip_package $TF_PKG_LOC --rocm &&


### PR DESCRIPTION
The return code was hard coded and set to 0. Therefore, it already pass no matter if the build failed or not. Fix by checking the return code.