### PR TITLE
Fixed batch matmul in bf16

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
@@ -901,21 +901,25 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
     return c_allocation_status;
   }
 
-  MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
-  MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
-
   bool ok;
-  if constexpr (std::is_same<T, Eigen::bfloat16>::value) {
+  if constexpr (std::is_same_v<T, Eigen::bfloat16>) {
+    float alpha_ = static_cast<float> (alpha);
+    float beta_ = static_cast<float> (beta);
+    const void* *alpha_ptr = reinterpret_cast<const void* *>(&alpha_);
+    const void* *beta_ptr = reinterpret_cast<const void* *>(&beta_);
+
     ok = DoBlasInternal(
         rocblas_func, stream, /* pointer_mode_host = */ true,
         ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m, n, k,
-        GpuComplex(alpha_ptr), GpuMemory(a), rocblas_datatype_bf16_r, lda,
-        batch_stride_a, GpuMemory(b), rocblas_datatype_bf16_r, ldb,
-        batch_stride_b, GpuComplex(beta_ptr), GpuMemoryMutable(&c),
-        rocblas_datatype_bf16_r, ldc, batch_stride_c, GpuMemoryMutable(&c),
+        alpha_ptr, a.opaque(), rocblas_datatype_bf16_r, lda,
+        batch_stride_a, b.opaque(), rocblas_datatype_bf16_r, ldb,
+        batch_stride_b, beta_ptr, c.opaque(),
+        rocblas_datatype_bf16_r, ldc, batch_stride_c, c.opaque(),
         rocblas_datatype_bf16_r, ldc, batch_stride_c, batch_count,
         rocblas_datatype_f32_r, rocblas_gemm_algo_standard, 0, 0);
   } else {
+    MAPPED_T *alpha_ptr = reinterpret_cast<MAPPED_T *>(&alpha);
+    MAPPED_T *beta_ptr = reinterpret_cast<MAPPED_T *>(&beta);
     ok = DoBlasInternal(rocblas_func, stream, /* pointer_mode_host = */ true,
                         ROCMBlasTranspose(transa), ROCMBlasTranspose(transb), m,
                         n, k, GpuComplex(alpha_ptr), GpuMemory(a), lda,

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
@@ -905,8 +905,8 @@ port::Status ROCMBlas::DoBlasGemmBatchedInternal(
   if constexpr (std::is_same_v<T, Eigen::bfloat16>) {
     float alpha_ = static_cast<float> (alpha);
     float beta_ = static_cast<float> (beta);
-    const void* *alpha_ptr = reinterpret_cast<const void* *>(&alpha_);
-    const void* *beta_ptr = reinterpret_cast<const void* *>(&beta_);
+    const void* alpha_ptr = reinterpret_cast<const void*>(&alpha_);
+    const void* beta_ptr = reinterpret_cast<const void*>(&beta_);
 
     ok = DoBlasInternal(
         rocblas_func, stream, /* pointer_mode_host = */ true,

--- a/tensorflow/python/kernel_tests/math_ops/BUILD
+++ b/tensorflow/python/kernel_tests/math_ops/BUILD
@@ -89,8 +89,6 @@ cuda_py_test(
     name = "batch_matmul_op_test",
     size = "medium",
     srcs = ["batch_matmul_op_test.py"],
-    tags = ["no_rocm",
-	    "no_mac_arm64"],
     shard_count = 20,
     deps = [
         "//tensorflow/python:array_ops",


### PR DESCRIPTION
Previous PR https://github.com/tensorflow/tensorflow/pull/58743 has incorrectly casted alpha and beta type, I have refactored it without added another template function and cast it within the same place.

PR is already to upstream https://github.com/tensorflow/tensorflow/pull/59216 and we can merge it our develop-upstream and enable batch matmul test now.