### PR TITLE
[r2.10-rocm-enhanced] Increase timeout times in test scripts

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py310_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py310_pip.sh
@@ -51,7 +51,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
  --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
  --test_env=HSA_TOOLS_LIB=libroctracer64.so \
- --test_timeout 600,900,2400,7200 \
+ --test_timeout 920,2400,7200,9600 \
  --build_tests_only \
  --test_output=errors \
  --test_sharding_strategy=disabled \

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py37_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py37_pip.sh
@@ -51,7 +51,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
  --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
  --test_env=HSA_TOOLS_LIB=libroctracer64.so \
- --test_timeout 600,900,2400,7200 \
+ --test_timeout 920,2400,7200,9600 \
  --build_tests_only \
  --test_output=errors \
  --test_sharding_strategy=disabled \

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py38_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py38_pip.sh
@@ -51,7 +51,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
  --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
  --test_env=HSA_TOOLS_LIB=libroctracer64.so \
- --test_timeout 600,900,2400,7200 \
+ --test_timeout 920,2400,7200,9600 \
  --build_tests_only \
  --test_output=errors \
  --test_sharding_strategy=disabled \

--- a/tensorflow/tools/ci_build/linux/rocm/rocm_py39_pip.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/rocm_py39_pip.sh
@@ -51,7 +51,7 @@ export TF_TEST_FLAGS="--test_tag_filters=${TF_TEST_FILTER_TAGS} --build_tag_filt
  --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
  --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
  --test_env=HSA_TOOLS_LIB=libroctracer64.so \
- --test_timeout 600,900,2400,7200 \
+ --test_timeout 920,2400,7200,9600 \
  --build_tests_only \
  --test_output=errors \
  --test_sharding_strategy=disabled \

--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -36,7 +36,7 @@ bazel test \
       --test_tag_filters=-no_oss,-oss_serial,-gpu,-multi_gpu,-tpu,-no_rocm,-benchmark-test,-v1only \
       --jobs=${N_BUILD_JOBS} \
       --local_test_jobs=${N_BUILD_JOBS} \
-      --test_timeout 900,2400,7200,9600 \
+      --test_timeout 920,2400,7200,9600 \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -45,7 +45,7 @@ bazel test \
       --test_tag_filters=-no_gpu,-no_rocm \
       --jobs=${N_BUILD_JOBS} \
       --local_test_jobs=${N_TEST_JOBS} \
-      --test_timeout 900,2400,7200,9600 \
+      --test_timeout 920,2400,7200,9600 \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -50,7 +50,7 @@ bazel test \
       --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
       --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
       --test_env=HSA_TOOLS_LIB=libroctracer64.so \
-      --test_timeout 600,900,2400,7200 \
+      --test_timeout 920,2400,7200,9600 \
       --build_tests_only \
       --test_output=errors \
       --test_sharding_strategy=disabled \


### PR DESCRIPTION
Increase timeout needed in //tensorflow/python/kernel_tests/linalg:linear_operator_circulant_test_gpu test
SWDEV-375542