### PR TITLE
ROCM: disable iterator test due to manylinux build on cs7

### DIFF
--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -543,6 +543,9 @@ cuda_py_test(
     size = "small",
     srcs = ["iterator_test.py"],
     grpc_enabled = True,
+    tags = [
+        "no_rocm",
+    ],
     deps = [
         ":test_base",
         "//tensorflow/core:protos_all_py",


### PR DESCRIPTION
A subtest in tensorflow/python/data/kernel_tests:iterator_test_gpu fails when built on cs7, which we do for our manylinux2014 compatibility.
The subtest is testOneShotIterator() which tests an API designed for TF1 (https://www.tensorflow.org/api_docs/python/tf/compat/v1/data/make_one_shot_iterator)

The risk is low on this one. Disabling this test.