### PR TITLE
Enable img_ops_test again

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -816,8 +816,7 @@ tf_xla_py_test(
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
         "optonly",  # Times out frequently in fastbuild mode.
-        "requires-gpu-nvidia",
-        "no_rocm"
+        "requires-gpu-nvidia"
     ],
     deps = [
         ":xla_test",


### PR DESCRIPTION
Based on upstream changes, img_ops_test is passed now