### PR TITLE
pin setuptools==65.0 to avoid issue 3772

### DIFF
--- a/tensorflow/tools/ci_build/release/common.sh
+++ b/tensorflow/tools/ci_build/release/common.sh
@@ -122,7 +122,8 @@ function install_ubuntu_16_pip_deps {
   done
 
   # First, upgrade pypi wheels
-  "${PIP_CMD}" install --user --upgrade 'setuptools' pip wheel
+  "${PIP_CMD}" install --user setuptools==65
+  "${PIP_CMD}" install --user --upgrade pip wheel
 
   # LINT.IfChange(linux_pip_installations_orig)
   # Remove any historical keras package if they are installed.
@@ -151,7 +152,8 @@ function install_ubuntu_16_python_pip_deps {
   done
 
   # First, upgrade pypi wheels
-  ${PIP_CMD} install --user --upgrade 'setuptools' pip wheel virtualenv
+  ${PIP_CMD} install --user setuptools==65
+  ${PIP_CMD} install --user --upgrade pip wheel virtualenv
 
   # LINT.IfChange(linux_pip_installations)
   # Remove any historical keras package if they are installed.


### PR DESCRIPTION
setuptools 66 and newer enforce [PEP 440](https://peps.python.org/pep-0440/)
Ubuntu packages do not conform and throw an error when mixed with setuptools 66+

https://github.com/pypa/setuptools/issues/3772
https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3444
https://bugs.launchpad.net/ubuntu/+source/distro-info/+bug/2003583

```
python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-3dwjl5j0/ssdeep_f2bd2f0d9f384d9a92bf4f0f6f3090d3/setup.py", line 108, in <module>
          setup(
        File "/home/vagrant/.local/lib/python3.8/site-packages/setuptools/__init__.py", line 86, in setup
          _install_setup_requires(attrs)
        File "/home/vagrant/.local/lib/python3.8/site-packages/setuptools/__init__.py", line 80, in _install_setup_requires
          dist.fetch_build_eggs(dist.setup_requires)
        File "/home/vagrant/.local/lib/python3.8/site-packages/setuptools/dist.py", line 874, in fetch_build_eggs
          resolved_dists = pkg_resources.working_set.resolve(
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 815, in resolve
          dist = self._resolve_dist(
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 844, in _resolve_dist
          env = Environment(self.entries)
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1044, in __init__
          self.scan(search_path)
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1077, in scan
          self.add(dist)
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1096, in add
          dists.sort(key=operator.attrgetter('hashcmp'), reverse=True)
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2631, in hashcmp
          self.parsed_version,
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2678, in parsed_version
          self._parsed_version = parse_version(self.version)
        File "/home/vagrant/.local/lib/python3.8/site-packages/pkg_resources/_vendor/packaging/version.py", line 266, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '0.23ubuntu1'
      [end of output]
```
