### PR TITLE
enable jit_test on rocm

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -1735,7 +1735,6 @@ cuda_py_test(
     tags = [
         "no_cuda_asan",  # Times out.
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
-        "no_rocm"
     ],
     xla_enable_strict_auto_jit = False,
     xla_enabled = True,


### PR DESCRIPTION
this jit test is no problem on the latest develop-upstream now and we can enable it again.

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3178