### PR TITLE
tensorflow-build: Fix whl check

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_wheels.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_wheels.sh
@@ -30,5 +30,5 @@ for wheel in /tf/pkg/*.whl; do
     wheel="$new_wheel"
   fi
 
-  auditwheel show $NEW_TF_WHEEL
+  TF_WHEEL="$wheel" bats /usertools/wheel_verification.bats --timing
 done

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_wheels.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_wheels.sh
@@ -30,5 +30,5 @@ for wheel in /tf/pkg/*.whl; do
     wheel="$new_wheel"
   fi
 
-  TF_WHEEL="$wheel" bats /usertools/wheel_verification.bats --timing
+  auditwheel show $NEW_TF_WHEEL
 done


### PR DESCRIPTION
This PRl makes the tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh script smarter.

This fixes 2 problems:
  - renaming an already renamed file
  - running whl verification on all whls that are present even if they don't match the currently installed python version