### PR TITLE
Backdate keras-nightly to 22/10/28

### DIFF
--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -95,7 +95,7 @@ pip3 install --upgrade gast
 pip3 install --upgrade termcolor
 
 # Keras
-pip3 install keras-nightly==2.12.0.dev2022111408 --no-deps
+pip3 install keras-nightly==2.12.0.dev2022102807 --no-deps
 pip3 install --upgrade h5py==3.1.0
 
 # Estimator

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -23,7 +23,7 @@ gast == 0.4.0
 # Note that here we want the latest version that matches TF major.minor version
 # Note that we must use nightly here as these are used in nightly jobs
 # For release jobs, we will pin these on the release branch
-keras-nightly == 2.12.0.dev2022111408
+keras-nightly == 2.12.0.dev2022102807
 tb-nightly ~= 2.9.0.a
 tf-estimator-nightly == 2.12.0.dev2022111409
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -157,7 +157,7 @@ REQUIRED_PACKAGES = [
     standard_or_nightly('tensorflow_estimator >= 2.11.0rc0, < 2.12',
                         'tf-estimator-nightly == 2.12.0.dev2022111409'),
     standard_or_nightly('keras >= 2.11.0rc1, < 2.12',
-                        'keras-nightly == 2.12.0.dev2022111408'),
+                        'keras-nightly == 2.12.0.dev2022102807'),
 ]
 REQUIRED_PACKAGES = [p for p in REQUIRED_PACKAGES if p is not None]
 


### PR DESCRIPTION
We merged a workaround to keras for Padded RNNs (https://github.com/keras-team/keras/commit/add6c1d81f45ac7ac016927a60043b00fb1f706a)

This causes MiOpen to not work at all in certain models, including perfZero.

This PR backdates keras-nightly to before the commit. 