### PR TITLE
[ROCm]: Add device ordinal in device description str

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -978,8 +978,8 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
   //
   // TODO(jlebar): This really should be more unique.  In CUDA land, we mix in
   // the clock speed and L2 cache size.
-  builder.set_model_str(absl::StrFormat("cc_%d.%d with %dB RAM, %d cores",
-                                        cc_major, cc_minor, device_memory_size,
+  builder.set_model_str(absl::StrFormat("cc_%d.%d.%d with %dB RAM, %d cores",
+                                        cc_major, cc_minor, device_ordinal, device_memory_size,
                                         core_count));
 
   return builder.Build();


### PR DESCRIPTION
Device description string is used as key in the gpu_conv_algorithm_picker and gemm_algorithm_picker cache. We need it to be unique for each GPU device.