### PR TITLE
img_ops_jit_compile test is passed now

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -2205,8 +2205,7 @@ tf_xla_py_test(
     shard_count = 5,
     tags = [
         "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
-        "optonly",
-        "no_rocm"
+        "optonly"
     ],
     use_xla_device = False,
     deps = [


### PR DESCRIPTION
XLA JIT can launch gpu without any problem at the latest weeklysync.