### PR TITLE
[ROCm]: Include rocm_config.h header in rocm_dnn

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_dnn.cc
@@ -45,6 +45,7 @@ limitations under the License.
 #include "tensorflow/tsl/platform/hash.h"
 #include "tensorflow/tsl/util/determinism.h"
 #include "tensorflow/tsl/util/env_var.h"
+#include "rocm/rocm_config.h"
 
 namespace {
 
@@ -251,7 +252,7 @@ namespace wrap {
 
 #endif
 
-#if (TF_ROCM_VERSION >= 50300)
+#if (TF_ROCM_VERSION >= 50000)
 // clang-format off
 #define MIOPEN_DNN_ROUTINE_EACH(__macro)                             \
   __macro(miopenBatchNormalizationBackward)                          \


### PR DESCRIPTION
TF_ROCM_VERSION build flag doesn't get set if rocm_config.h is not included