### PR TITLE
[Opt] Use rocprim to optimize argmax op performance

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3416,7 +3416,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "argmax_op",
     prefix = "argmax_op",
-    deps = MATH_DEPS,
+    deps = MATH_DEPS + if_cuda_or_rocm([":reduction_ops"]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/argmax_op.cc
+++ b/tensorflow/core/kernels/argmax_op.cc
@@ -42,6 +42,36 @@ namespace tensorflow {
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
+
+template <typename Device>
+struct CustomArgOp;
+
+template <>
+struct CustomArgOp<CPUDevice> {
+    template <typename T, typename Tout, typename ArgFunctor>
+    // Determines whether the custom kernel in argmax_op_gpu.cu.cc should be
+    // used, and if so, runs it by calling DoGpuArgOp. If it was run,
+    // returns true. Otherwise, it returns false and the caller must calculate the
+    // arg min or max itself.
+    static bool CustomArgFunc(OpKernelContext* context, const Tensor& input,
+        int axis, Tensor* output) {
+        return false;
+    }
+};
+
+template <>
+struct CustomArgOp<GPUDevice> {
+    template <typename T, typename Tout, typename ArgFunctor>
+    static bool CustomArgFunc(OpKernelContext* context, const Tensor& input,
+    int axis, Tensor* output) {
+        DoGpuArgOp<T, Tout, ArgFunctor::is_argmax>(context, input, axis, output);
+        return true;
+    } 
+};
+
+
+
+
 template <typename Device, typename T, typename Tout, typename ArgFunctor>
 class ArgOp : public OpKernel {
  public:
@@ -81,6 +111,11 @@ class ArgOp : public OpKernel {
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
 
     if (output_shape.num_elements() == 0) {
+      return;
+    }
+
+    if (CustomArgOp<Device>::template CustomArgFunc<T, Tout, ArgFunctor>(
+      context, input, axis, output)) {
       return;
     }
 
@@ -175,49 +210,71 @@ TF_CALL_bool(REGISTER_ARGMAX);
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 
 // Forward declarations of the functor specializations for GPU.
-namespace functor {
+#define DECLARE_GPU_ARG_OPS(T)                                            \
+  extern template void DoGpuArgOp<T, int64, true>(OpKernelContext * context,      \
+                                         const Tensor& input, int axis,  \
+                                         Tensor* output);                \
+  extern template void DoGpuArgOp<T, int64, false>(OpKernelContext * context,     \
+                                          const Tensor& input, int axis, \
+                                          Tensor* output);               \
+  extern template void DoGpuArgOp<T, int32, true>(OpKernelContext * context,      \
+                                          const Tensor& input, int axis, \
+                                          Tensor* output);               \
+  extern template void DoGpuArgOp<T, int32, false>(OpKernelContext * context,     \
+                                          const Tensor& input, int axis, \
+                                          Tensor* output);
 
-#define DECLARE_GPU_SPEC(T, Tout, Dims)                                       \
-  template <>                                                                 \
-  void ArgMax<GPUDevice, T, Tout>::Reduce##Dims(                              \
-      const GPUDevice& d, typename TTypes<T, Dims>::ConstTensor input,        \
-      const int32 dimension, typename TTypes<Tout, Dims - 1>::Tensor output); \
-  template <>                                                                 \
-  void ArgMin<GPUDevice, T, Tout>::Reduce##Dims(                              \
-      const GPUDevice& d, typename TTypes<T, Dims>::ConstTensor input,        \
-      const int32 dimension, typename TTypes<Tout, Dims - 1>::Tensor output);
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_ARG_OPS);
 
-#define DECLARE_GPU_SPECS(T)       \
-  DECLARE_GPU_SPEC(T, int64_t, 1); \
-  DECLARE_GPU_SPEC(T, int64_t, 2); \
-  DECLARE_GPU_SPEC(T, int64_t, 3); \
-  DECLARE_GPU_SPEC(T, int64_t, 4); \
-  DECLARE_GPU_SPEC(T, int64_t, 5); \
-  DECLARE_GPU_SPEC(T, int64_t, 6); \
-  DECLARE_GPU_SPEC(T, int64_t, 7); \
-  DECLARE_GPU_SPEC(T, int32, 1);   \
-  DECLARE_GPU_SPEC(T, int32, 2);   \
-  DECLARE_GPU_SPEC(T, int32, 3);   \
-  DECLARE_GPU_SPEC(T, int32, 4);   \
-  DECLARE_GPU_SPEC(T, int32, 5);   \
-  DECLARE_GPU_SPEC(T, int32, 6);   \
-  DECLARE_GPU_SPEC(T, int32, 7);
+#undef DECLARE_GPU_ARG_OPS
 
-#define DECLARE_GPU_CLASS(T)                            \
-  extern template struct ArgMax<GPUDevice, T, int64_t>; \
-  extern template struct ArgMin<GPUDevice, T, int64_t>; \
-  extern template struct ArgMax<GPUDevice, T, int32>;   \
-  extern template struct ArgMin<GPUDevice, T, int32>;
 
-TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPECS);
-TF_CALL_bool(DECLARE_GPU_SPECS);
-TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_CLASS);
-TF_CALL_bool(DECLARE_GPU_CLASS);
+//namespace functor {
+//
+//#define DECLARE_GPU_SPEC(T, Tout, Dims)                                       \
+//  template <>                                                                 \
+//  void ArgMax<GPUDevice, T, Tout>::Reduce##Dims(                              \
+//      const GPUDevice& d, typename TTypes<T, Dims>::ConstTensor input,        \
+//      const int32 dimension, typename TTypes<Tout, Dims - 1>::Tensor output); \
+//  template <>                                                                 \
+//  void ArgMin<GPUDevice, T, Tout>::Reduce##Dims(                              \
+//      const GPUDevice& d, typename TTypes<T, Dims>::ConstTensor input,        \
+//      const int32 dimension, typename TTypes<Tout, Dims - 1>::Tensor output);
+//
+//#define DECLARE_GPU_SPECS(T)       \
+//  DECLARE_GPU_SPEC(T, int64_t, 1); \
+//  DECLARE_GPU_SPEC(T, int64_t, 2); \
+//  DECLARE_GPU_SPEC(T, int64_t, 3); \
+//  DECLARE_GPU_SPEC(T, int64_t, 4); \
+//  DECLARE_GPU_SPEC(T, int64_t, 5); \
+//  DECLARE_GPU_SPEC(T, int64_t, 6); \
+//  DECLARE_GPU_SPEC(T, int64_t, 7); \
+//  DECLARE_GPU_SPEC(T, int32, 1);   \
+//  DECLARE_GPU_SPEC(T, int32, 2);   \
+//  DECLARE_GPU_SPEC(T, int32, 3);   \
+//  DECLARE_GPU_SPEC(T, int32, 4);   \
+//  DECLARE_GPU_SPEC(T, int32, 5);   \
+//  DECLARE_GPU_SPEC(T, int32, 6);   \
+//  DECLARE_GPU_SPEC(T, int32, 7);
+//
+//#define DECLARE_GPU_CLASS(T)                            \
+//  extern template struct ArgMax<GPUDevice, T, int64_t>; \
+//  extern template struct ArgMin<GPUDevice, T, int64_t>; \
+//  extern template struct ArgMax<GPUDevice, T, int32>;   \
+//  extern template struct ArgMin<GPUDevice, T, int32>;
+//
+//TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPECS);
+//TF_CALL_bool(DECLARE_GPU_SPECS);
+//TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_CLASS);
+//TF_CALL_bool(DECLARE_GPU_CLASS);
+//
+//#undef DECLARE_GPU_SPECS
+//#undef DECLARE_GPU_CLASS
+//
+//}  // namespace functor
 
-#undef DECLARE_GPU_SPECS
-#undef DECLARE_GPU_CLASS
 
-}  // namespace functor
+  
 
 // Registration of the GPU implementations.
 #define REGISTER_ARGMAX_GPU(type)                                     \

--- a/tensorflow/core/kernels/argmax_op.h
+++ b/tensorflow/core/kernels/argmax_op.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor.h"
 
 namespace tensorflow {
 
@@ -43,6 +45,7 @@ struct ArgMax {
   DECLARE_COMPUTE_SPEC(7);
 
 #undef DECLARE_COMPUTE_SPEC
+  enum { is_argmax = true };
 };
 
 template <typename Device, typename T, typename Tout>
@@ -63,9 +66,14 @@ struct ArgMin {
   DECLARE_COMPUTE_SPEC(7);
 
 #undef DECLARE_COMPUTE_SPEC
+  enum { is_argmax = false };
 };
 
 }  // namespace functor
+
+template <typename T, typename Tout, bool is_argmax>
+void DoGpuArgOp(OpKernelContext* context, const Tensor& input, int axis,
+		                Tensor* output);
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/argmax_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/argmax_op_gpu.cu.cc
@@ -43,9 +43,7 @@ namespace {
   struct MaxOrMinFunc<T, true> {
       __host__ __device__ __forceinline__ KeyValuePair<T> operator()(
       const KeyValuePair<T>& lhs, const KeyValuePair<T>& rhs) const {
-          // If one value is NaN, we choose the other value. This behavior is not
-          // guaranteed by the op and may change in the future.
-          return (lhs.value > rhs.value || Eigen::numext::isnan(rhs.value)) ? lhs
+          return (lhs.value >= rhs.value || Eigen::numext::isnan(rhs.value)) ? lhs
                                                                             : rhs;
       }
   };
@@ -54,7 +52,7 @@ namespace {
   struct MaxOrMinFunc<T, false> {
       __host__ __device__ __forceinline__ KeyValuePair<T> operator() (
       const KeyValuePair<T>& lhs, const KeyValuePair<T>& rhs) const {
-          return (lhs.value < rhs.value || Eigen::numext::isnan(rhs.value)) ? lhs
+          return (lhs.value <= rhs.value || Eigen::numext::isnan(rhs.value)) ? lhs
 	                                                                    : rhs;
       }
   };

--- a/tensorflow/core/kernels/argmax_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/argmax_op_gpu.cu.cc
@@ -20,10 +20,126 @@ limitations under the License.
 
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/argmax_op.h"
+#include "tensorflow/core/kernels/reduction_gpu_kernels.cu.h"
+#include "tensorflow/core/kernels/reduction_ops_common.h"
 
 namespace tensorflow {
 
 typedef Eigen::GpuDevice GPUDevice;
+
+
+typedef tensorflow::TTypes<float>::Tensor::Index Index;
+
+// To compute the argmax/argmin, we perform a reduction on KeyValuePairs, which
+// are (flattened index, value) pairs.
+template <typename T>
+using KeyValuePair = gpuprim::KeyValuePair<Index, T>;
+
+namespace {
+  template <typename T, bool is_argmax>
+  struct MaxOrMinFunc;
+
+  template <typename T>
+  struct MaxOrMinFunc<T, true> {
+      __host__ __device__ __forceinline__ KeyValuePair<T> operator()(
+      const KeyValuePair<T>& lhs, const KeyValuePair<T>& rhs) const {
+          // If one value is NaN, we choose the other value. This behavior is not
+          // guaranteed by the op and may change in the future.
+          return (lhs.value > rhs.value || Eigen::numext::isnan(rhs.value)) ? lhs
+                                                                            : rhs;
+      }
+  };
+
+  template <typename T>
+  struct MaxOrMinFunc<T, false> {
+      __host__ __device__ __forceinline__ KeyValuePair<T> operator() (
+      const KeyValuePair<T>& lhs, const KeyValuePair<T>& rhs) const {
+          return (lhs.value < rhs.value || Eigen::numext::isnan(rhs.value)) ? lhs
+	                                                                    : rhs;
+      }
+  };
+
+  template <typename T, typename Tout>
+  struct OutputConverter {
+      OutputConverter(Index dim1, Index dim2) : dim1_(dim1), dim2_(dim2) {}
+
+      __host__ __device__ __forceinline__ Tout
+      operator()(const KeyValuePair<T>& key_value_pair) const {
+          return static_cast<Tout>((key_value_pair.key / dim2_) % dim1_);
+      }
+      Index dim1_;
+      Index dim2_;
+  };
+}  // namespace
+
+namespace functor {
+namespace reduction_op_helper {
+    template <typename T>
+    struct IdentityValue<KeyValuePair<T>, MaxOrMinFunc<T, true>> {
+	 KeyValuePair<T> operator()() {
+             return {0, -std::numeric_limits<T>::infinity()};
+         }
+    };
+
+    template <typename T>
+    struct IdentityValue<KeyValuePair<T>, MaxOrMinFunc<T, false>> {
+         KeyValuePair<T> operator()() {
+	     return {0, std::numeric_limits<T>::infinity()};
+         }
+    };
+}  // namespace reduction_op_helper
+}  // namespace functor
+
+
+template <typename T, typename Tout, bool is_argmax>
+void DoGpuArgOp(OpKernelContext* context, const Tensor& input, int axis,
+		Tensor* output) {
+    Index dim0 = 1;
+    for (Index i = 0; i < axis; i++) {
+        dim0 *= input.dim_size(i);
+    }
+    Index dim1 = input.dim_size(axis);
+    Index dim2 = 1;
+    for (Index i = axis + 1; i < input.dims(); i++) {
+        dim2 *= input.dim_size(i);
+    }
+    DCHECK_EQ(dim0 * dim1 * dim2, input.NumElements());
+
+    auto inp = input.shaped<T, 3>({dim0, dim1, dim2});
+    auto out = output->shaped<Tout, 2>({dim0, dim2});
+
+    using InputIterType = gpuprim::ArgIndexInputIterator<const T*>;
+    using Functor = MaxOrMinFunc<T, is_argmax>;
+    using OutputIterType =
+          TransformOutputIterator<Tout, KeyValuePair<T>, OutputConverter<T, Tout>>;
+
+    InputIterType inp_wrapper(inp.data());
+    OutputIterType out_wrapper(out.data(), OutputConverter<T, Tout>(dim1, dim2));
+
+    typedef const Eigen::array<TTypes<float>::Tensor::Index, 1>& ReductionAxes;
+    Constants<GPUDevice> constants;
+
+    functor::ReduceImpl<KeyValuePair<T>, Functor, OutputIterType, InputIterType,
+         ReductionAxes>(context, out_wrapper, inp_wrapper, 3, dim0,
+         dim1, dim2, 2, constants.kOne, Functor());
+}
+
+#define DEFINE_GPU_ARG_OPS(T)                                              \
+  template void DoGpuArgOp<T, int64, true>(OpKernelContext * context,      \
+				           const Tensor& input, int axis,  \
+				           Tensor* output);                \
+  template void DoGpuArgOp<T, int64, false>(OpKernelContext * context,     \
+			                   const Tensor& input, int axis,  \
+					   Tensor* output);                \
+  template void DoGpuArgOp<T, int32, true>(OpKernelContext * context,      \
+		                           const Tensor& input, int axis,  \
+					   Tensor* output);                \
+  template void DoGpuArgOp<T, int32, false>(OpKernelContext * context,     \
+		                           const Tensor& input, int axis,  \
+					   Tensor* output);
+
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_GPU_ARG_OPS);
+TF_CALL_bool(DEFINE_GPU_ARG_OPS);
 
 #define DEFINE_GPU_SPEC(T)                              \
   template struct functor::ArgMax<GPUDevice, T, int64>; \


### PR DESCRIPTION
Use the reduction api of rocprim to optimize argmax op.