### PR TITLE
add overflow check for gpu driver memo

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_driver.cc
@@ -1243,26 +1243,35 @@ static tsl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   return true;
 }
 
-static uint64 GetReservedMemory() {
-  uint64 reserve = 0;
+/* static */ bool GetReservedMemory(uint64_t* reserve) {
   hipDeviceProp_t props;
   hipDevice_t dev;
   hipError_t res = wrap::hipGetDevice(&dev);
-  if(res == hipSuccess) {
-    res = wrap::hipGetDeviceProperties(&props, dev);
-    if (res == hipSuccess) {
-      std::string gcnArchName = props.gcnArchName;
-  // On gfx90a, we hide 1 GB of GPU memory from TF, to allow for late
-  // allocations by internal ROCm libraries (e.g. rocBLAS alone needs
-  // ~200 MB to put its kernels as of ROCm 4.1)
-      if (gcnArchName.substr(0,6)=="gfx908")
-        reserve = 1048576*512;
-      else if (gcnArchName.substr(0,6)=="gfx90a"
-          || gcnArchName.substr(0,6)=="gfx910")
-        reserve = 1048576*1024;
-    }
+  
+  if (res != hipSuccess) {
+    LOG(FATAL) << "failed to query current device: " << ToString(res);
+    return false;    
   }
-  return reserve;
+  res = wrap::hipGetDeviceProperties(&props, dev);
+  if (res != hipSuccess){
+    LOG(ERROR) << "failed to query device properties: " << ToString(res);
+    return false;
+  }
+
+  std::string gcnArchName = props.gcnArchName;
+  // On gfx90a, we hide 1 GB of GPU memory (512MB for gfx908) from TF, 
+  // to allow for late allocations by internal ROCm libraries 
+  // (e.g. rocBLAS alone needs~200 MB to put its kernels as of ROCm 4.1)
+  const uint64_t reserve_gfx908 = 1048576 * 512;
+  const uint64_t reserve_gfx9_x = 1048576 * 1024;
+  if (gcnArchName.substr(0, 6) == "gfx908"){
+      *reserve = reserve_gfx908;
+  }
+  else if (gcnArchName.substr(0, 6) == "gfx90a"
+        || gcnArchName.substr(0, 6) == "gfx940"){
+      *reserve = reserve_gfx9_x;
+  }
+  return true;
 }
 
 /* static */ bool GpuDriver::GetDeviceMemoryInfo(GpuContext* context,
@@ -1276,12 +1285,25 @@ static uint64 GetReservedMemory() {
     LOG(ERROR) << "failed to query device memory info: " << ToString(res);
     return false;
   }
-  uint64 reserve = GetReservedMemory();
+
+  uint64_t reserve = 0;
+  if (!GetReservedMemory(&reserve)){
+      LOG(ERROR) << "failed to reserved device memory for ROCm libraries";
+      return false;
+  }
+
   VLOG(1) << "Device memory: " << total/1048576 << " MB total, "
           << free/1048576 << " MB free, reserving " 
           << reserve/1048576 << " MB";
-  *free_out = free>=reserve ? free-reserve : 0;
-  *total_out = total-reserve;
+
+  // overflow check
+  if (free > std::numeric_limits<int64_t>::max()){
+      LOG(ERROR) << "free memory (" << free << ") is overflow int64_t";
+      return false; 
+  }
+
+  *free_out = free >= reserve ? free - reserve : 0;
+  *total_out = total - reserve;
   return true;
 }
 
@@ -1293,8 +1315,12 @@ static uint64 GetReservedMemory() {
     LOG(ERROR) << "failed to query total available memory: " << ToString(res);
     return false;
   }
-  uint64 reserve = GetReservedMemory();
-  *result = value-reserve;
+  uint64_t reserve = 0;
+  if (!GetReservedMemory(&reserve)){
+      LOG(ERROR) << "failed to reserved device memory for ROCm libraries";
+      return false;    
+  }
+  *result = value - reserve;
   return true;
 }
 


### PR DESCRIPTION
This is based on https://github.com/ROCmSoftwarePlatform/tensorflow-private/pull/7 and it can help us have a better overflow check debug info and find the root cause easiler next time, like this following

```
2023-03-09 11:24:10.691886: E tensorflow/compiler/xla/stream_executor/rocm/rocm_driver.cc:1282] free memory (18446744073701163008) is overflow int64_t
2023-03-09 11:24:10.691905: F tensorflow/core/common_runtime/gpu/gpu_device_test.cc:289] Non-OK-status: DeviceFactory::GetFactory("GPU")->CreateDevices( opts, kDeviceNamePrefix, &devices) status: UNKNOWN: Failed to query available memory for GPU 0
```