### PR TITLE
[r2.12-rocm-enhanced] Add environment variable to point the location of test repos

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt
@@ -41,6 +41,8 @@ ENV ROCM_TOOLKIT_PATH=${ROCM_PATH}
 RUN pip install --no-cache-dir /${TF_PKGS_DIR}/${TENSORFLOW_PACKAGE}
 RUN echo 'ALL ALL=NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
+ARG TF_TESTING_FL
+ENV TF_TESTING_FL=${TF_TESTING_FL}
 RUN git clone https://github.com/tensorflow/models.git
 RUN git clone https://github.com/tensorflow/examples.git
 RUN git clone https://github.com/tensorflow/autograph.git


### PR DESCRIPTION
set TF_TESTING_FL environment variable in the Dockerfile.rocm.rt