### PR TITLE
[r2.12-rocm-enhanced] Add rocm/tensorflow-build:focal; fix pycpp config

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
@@ -1,0 +1,74 @@
+################################################################################
+FROM ubuntu:20.04 as builder
+################################################################################
+
+# Install devtoolset build dependencies
+COPY setup.packages.sh setup.packages.sh
+COPY builder.packages.txt builder.packages.txt
+RUN /setup.packages.sh /builder.packages.txt
+
+# Install devtoolset-9 in /dt9 with glibc 2.17 and libstdc++ 4.8, for building
+# manylinux2014-compatible packages.
+COPY builder.devtoolset/fixlinks.sh /fixlinks.sh
+COPY builder.devtoolset/rpm-patch.sh /rpm-patch.sh
+COPY builder.devtoolset/download_prerequisites /download_prerequisites
+COPY builder.devtoolset/build_devtoolset.sh /build_devtoolset.sh
+COPY builder.devtoolset/glibc2.17-inline.patch /glibc2.17-inline.patch
+RUN /build_devtoolset.sh devtoolset-9 /dt9
+
+################################################################################
+FROM ubuntu:20.04 as devel
+################################################################################
+COPY --from=builder /dt9 /dt9
+
+ARG GPU_DEVICE_TARGETS="gfx900 gfx906 gfx908 gfx90a gfx1030"
+ENV GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
+
+# Install ROCM
+ARG ROCM_VERSION=5.4.0
+ARG CUSTOM_INSTALL
+ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
+ENV ROCM_PATH=${ROCM_PATH}
+COPY ${CUSTOM_INSTALL} /${CUSTOM_INSTALL}
+COPY setup.packages.sh /setup.packages.sh
+COPY setup.rocm.sh /setup.rocm.sh
+COPY devel.packages.rocm.txt /devel.packages.rocm.txt
+RUN /setup.rocm.sh $ROCM_VERSION
+
+# Install various tools.
+# - bats: bash unit testing framework
+# - bazelisk: always use the correct bazel version
+# - buildifier: clean bazel build deps
+# - buildozer: clean bazel build deps
+# - gcloud SDK: communicate with Google Cloud Platform (GCP) for RBE, CI
+RUN git clone --branch v1.7.0 https://github.com/bats-core/bats-core.git && bats-core/install.sh /usr/local && rm -rf bats-core
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel && chmod +x /usr/local/bin/bazel
+RUN wget https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildifier -O /usr/local/bin/buildifier && chmod +x /usr/local/bin/buildifier
+RUN wget https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildozer -O /usr/local/bin/buildozer && chmod +x /usr/local/bin/buildozer
+RUN curl -sSL https://sdk.cloud.google.com > /tmp/gcloud && bash /tmp/gcloud --install-dir=~/usr/local/bin --disable-prompts
+
+
+# All lines past this point are reset when $CACHEBUSTER is set. We need this
+# for Python specifically because we install some nightly packages which are
+# likely to change daily.
+ARG CACHEBUSTER=0
+RUN echo $CACHEBUSTER
+
+# Setup Python environment. PYTHON_VERSION is e.g. "python3.8"
+ARG PYTHON_VERSION
+COPY setup.python.sh /setup.python.sh
+COPY devel.requirements.txt /devel.requirements.txt
+RUN /setup.python.sh $PYTHON_VERSION devel.requirements.txt
+
+# Setup build and environment
+COPY devel.usertools /usertools
+COPY devel.bashrc /root/.bashrc
+
+# Setup ENV variables for tensorflow pip build
+ENV TF_NEED_ROCM=1
+ENV TF_ROCM_GCC=1
+ENV ROCM_TOOLKIT_PATH=${ROCM_PATH}
+
+# Don't use the bazel cache when a new docker image is created.
+RUN echo build --action_env=DOCKER_CACHEBUSTER=$(date +%s%N)$RANDOM >> /etc/bazel.bazelrc
+RUN echo build --host_action_env=DOCKER_HOST_CACHEBUSTER=$(date +%s%N)$RANDOM >> /etc/bazel.bazelrc

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
@@ -1,25 +1,6 @@
 ################################################################################
-FROM ubuntu:20.04 as builder
+FROM ubuntu:20.04
 ################################################################################
-
-# Install devtoolset build dependencies
-COPY setup.packages.sh setup.packages.sh
-COPY builder.packages.txt builder.packages.txt
-RUN /setup.packages.sh /builder.packages.txt
-
-# Install devtoolset-9 in /dt9 with glibc 2.17 and libstdc++ 4.8, for building
-# manylinux2014-compatible packages.
-COPY builder.devtoolset/fixlinks.sh /fixlinks.sh
-COPY builder.devtoolset/rpm-patch.sh /rpm-patch.sh
-COPY builder.devtoolset/download_prerequisites /download_prerequisites
-COPY builder.devtoolset/build_devtoolset.sh /build_devtoolset.sh
-COPY builder.devtoolset/glibc2.17-inline.patch /glibc2.17-inline.patch
-RUN /build_devtoolset.sh devtoolset-9 /dt9
-
-################################################################################
-FROM ubuntu:20.04 as devel
-################################################################################
-COPY --from=builder /dt9 /dt9
 
 ARG GPU_DEVICE_TARGETS="gfx900 gfx906 gfx908 gfx90a gfx1030"
 ENV GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
@@ -58,7 +39,7 @@ RUN echo $CACHEBUSTER
 ARG PYTHON_VERSION
 COPY setup.python.sh /setup.python.sh
 COPY devel.requirements.txt /devel.requirements.txt
-RUN /setup.python.sh $PYTHON_VERSION devel.requirements.txt
+RUN /setup.python.sh $PYTHON_VERSION devel.requirements.txt true
 
 # Setup build and environment
 COPY devel.usertools /usertools

--- a/tensorflow/tools/tf_sig_build_dockerfiles/builder.devtoolset/build_devtoolset.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/builder.devtoolset/build_devtoolset.sh
@@ -123,7 +123,8 @@ esac
 # Apply the devtoolset patches to gcc.
 /rpm-patch.sh "gcc.spec"
 
-./contrib/download_prerequisites
+#./contrib/download_prerequisites
+/download_prerequisites
 
 mkdir -p "${TARGET}-build"
 cd "${TARGET}-build"

--- a/tensorflow/tools/tf_sig_build_dockerfiles/builder.devtoolset/download_prerequisites
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/builder.devtoolset/download_prerequisites
@@ -1,0 +1,264 @@
+#! /bin/sh
+#! -*- coding:utf-8; mode:shell-script; -*-
+
+# Download some prerequisites needed by GCC.
+# Run this from the top level of the GCC source tree and the GCC build will do
+# the right thing.  Run it with the `--help` option for more information.
+#
+# (C) 2010-2016 Free Software Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+
+program='download_prerequisites'
+version='(unversioned)'
+
+# MAINTAINERS: If you update the package versions below, please
+# remember to also update the files `contrib/prerequisites.sha512` and
+# `contrib/prerequisites.md5` with the new checksums.
+
+gmp='gmp-6.1.0.tar.bz2'
+mpfr='mpfr-3.1.4.tar.bz2'
+mpc='mpc-1.0.3.tar.gz'
+isl='isl-0.18.tar.bz2'
+
+base_url='https://gcc.gnu.org/pub/gcc/infrastructure/'
+
+echo_archives() {
+    echo "${gmp}"
+    echo "${mpfr}"
+    echo "${mpc}"
+    if [ ${graphite} -gt 0 ]; then echo "${isl}"; fi
+}
+
+graphite=1
+verify=1
+force=0
+OS=$(uname)
+
+case $OS in
+  "Darwin"|"FreeBSD"|"DragonFly")
+    chksum='shasum -a 512 --check'
+  ;;
+  *)
+    chksum='sha512sum -c'
+  ;;
+esac
+
+if type wget > /dev/null ; then
+  fetch='wget'
+else
+  fetch='curl -LO -u anonymous:'
+fi
+chksum_extension='sha512'
+directory='.'
+
+helptext="usage: ${program} [OPTION...]
+
+Downloads some prerequisites needed by GCC.  Run this from the top level of the
+GCC source tree and the GCC build will do the right thing.
+
+The following options are available:
+
+ --directory=DIR  download and unpack packages into DIR instead of '.'
+ --force          download again overwriting existing packages
+ --no-force       do not download existing packages again (default)
+ --isl            download ISL, needed for Graphite loop optimizations (default)
+ --graphite       same as --isl
+ --no-isl         don't download ISL
+ --no-graphite    same as --no-isl
+ --verify         verify package integrity after download (default)
+ --no-verify      don't verify package integrity
+ --sha512         use SHA512 checksum to verify package integrity (default)
+ --md5            use MD5 checksum to verify package integrity
+ --help           show this text and exit
+ --version        show version information and exit
+"
+
+versiontext="${program} ${version}
+Copyright (C) 2016 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+
+die() {
+    echo "error: $@" >&2
+    exit 1
+}
+
+for arg in "$@"
+do
+    case "${arg}" in
+        --help)
+            echo "${helptext}"
+            exit
+            ;;
+        --version)
+            echo "${versiontext}"
+            exit
+            ;;
+    esac
+done
+unset arg
+
+# Emulate Linux's 'md5 --check' on macOS
+md5_check() {
+  # Store the standard input: a line from contrib/prerequisites.md5:
+  md5_checksum_line=$(cat -)
+  # Grab the text before the first space
+  md5_checksum_expected="${md5_checksum_line%% *}"
+  # Grab the text after the first space
+  file_to_check="${md5_checksum_line##* }"
+  # Calculate the md5 checksum for the downloaded file
+  md5_checksum_output=$(md5 -r "${file_to_check}")
+  # Grab the text before the first space
+  md5_checksum_detected="${md5_checksum_output%% *}"
+  [ "${md5_checksum_expected}" == "${md5_checksum_detected}" ] \
+    || die "Cannot verify integrity of possibly corrupted file ${file_to_check}"
+  echo "${file_to_check}: OK"
+}
+
+
+argnext=
+for arg in "$@"
+do
+    if [ "x${argnext}" = x ]
+    then
+        case "${arg}" in
+            --directory)
+                argnext='directory'
+                ;;
+            --directory=*)
+                directory="${arg#--directory=}"
+                ;;
+            --force)
+                force=1
+                ;;
+            --no-force)
+                force=0
+                ;;
+            --isl|--graphite)
+                graphite=1
+                ;;
+            --no-isl|--no-graphite)
+                graphite=0
+                ;;
+            --verify)
+                verify=1
+                ;;
+            --no-verify)
+                verify=0
+                ;;
+            --sha512)
+                case $OS in
+                  "Darwin")
+                    chksum='shasum -a 512 --check'
+                  ;;
+                  *)
+                    chksum='sha512sum --check'
+                  ;;
+                esac
+                chksum_extension='sha512'
+                verify=1
+                ;;
+            --md5)
+                case $OS in
+                  "Darwin")
+                    chksum='md5_check'
+                  ;;
+                  *)
+                    chksum='md5 --check'
+                  ;;
+                esac
+                chksum_extension='md5'
+                verify=1
+                ;;
+            -*)
+                die "unknown option: ${arg}"
+                ;;
+            *)
+                die "too many arguments"
+                ;;
+        esac
+    else
+        case "${arg}" in
+            -*)
+                die "Missing argument for option --${argnext}"
+                ;;
+        esac
+        case "${argnext}" in
+            directory)
+                directory="${arg}"
+                ;;
+            *)
+                die "The impossible has happened"
+                ;;
+        esac
+        argnext=
+    fi
+done
+[ "x${argnext}" = x ] || die "Missing argument for option --${argnext}"
+unset arg argnext
+
+[ -e ./gcc/BASE-VER ]                                                         \
+    || die "You must run this script in the top-level GCC source directory"
+
+[ -d "${directory}" ]                                                         \
+    || die "No such directory: ${directory}"
+
+for ar in $(echo_archives)
+do
+    if [ ${force} -gt 0 ]; then rm -f "${directory}/${ar}"; fi
+    [ -e "${directory}/${ar}" ]                                               \
+        || ${fetch} --no-verbose -O "${directory}/${ar}" "${base_url}${ar}"       \
+        || die "Cannot download ${ar} from ${base_url}"
+done
+unset ar
+
+if [ ${verify} -gt 0 ]
+then
+    chksumfile="contrib/prerequisites.${chksum_extension}"
+    [ -r "${chksumfile}" ] || die "No checksums available"
+    for ar in $(echo_archives)
+    do
+        grep "${ar}" "${chksumfile}"                                          \
+            | ( cd "${directory}" && ${chksum} )                              \
+            || die "Cannot verify integrity of possibly corrupted file ${ar}"
+    done
+    unset chksumfile
+fi
+unset ar
+
+for ar in $(echo_archives)
+do
+    package="${ar%.tar*}"
+    if [ ${force} -gt 0 ]; then rm -rf "${directory}/${package}"; fi
+    [ -e "${directory}/${package}" ]                                          \
+        || ( cd "${directory}" && tar -xf "${ar}" )                           \
+        || die "Cannot extract package from ${ar}"
+    unset package
+done
+unset ar
+
+for ar in $(echo_archives)
+do
+    target="${directory}/${ar%.tar*}/"
+    linkname="${ar%-*}"
+    if [ ${force} -gt 0 ]; then rm -f "${linkname}"; fi
+    [ -e "${linkname}" ]                                                      \
+        || ln -s "${target}" "${linkname}"                                    \
+        || die "Cannot create symbolic link ${linkname} --> ${target}"
+    unset target linkname
+done
+unset ar
+
+echo "All prerequisites downloaded successfully."

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -68,7 +68,7 @@ build:rocm --copt="-Wno-error=unused-result"
 # Test-related settings below this point.
 test:cuda --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
 test:rocm --test_env=HSA_TOOLS_LIB=libroctracer64.so
-test --build_tests_only --keep_going --test_output=errors --verbose_failures=true
+test --build_tests_only --keep_going --test_output=errors --verbose_failures=true --test_sharding_strategy=disabled
 # Set the default local test jobs to 2
 test --test_timeout=920,2400,7200,9600 --local_test_jobs=2 --test_env=TF_TESTS_PER_GPU=1 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
 # Give only the list of failed tests at the end of the log

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -184,7 +184,12 @@ build:rbe --repo_env=TF_NCCL_CONFIG_REPO="@sigbuild-r2.12_config_nccl"
 build:rbe --repo_env=TF_PYTHON_CONFIG_REPO="@sigbuild-r2.12_config_python"
 
 # For continuous builds
-test:pycpp_filters --test_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
-test:pycpp_filters --build_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
+test:pycpp_filters --test_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-no_rocm
+test:pycpp_filters --build_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-no_rocm
 test:pycpp_filters --test_lang_filters=cc,py --flaky_test_attempts=3 --test_size_filters=small,medium
 test:pycpp --config=pycpp_filters -- //tensorflow/... -//tensorflow/python/integration_testing/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/compiler/xrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
+
+test:pycpp_large_filters --test_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-no_rocm
+test:pycpp_large_filters --build_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-no_rocm
+test:pycpp_large_filters --test_lang_filters=cc,py --flaky_test_attempts=3 --test_size_filters=small,medium,large
+test:pycpp_large --config=pycpp_large_filters -- //tensorflow/... -//tensorflow/python/integration_testing/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/compiler/xrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...


### PR DESCRIPTION
- Add Ubuntu20 version of rocm/tensorflow-build for the 2.12 branch
- This image will use that native gcc9 toolchain in Ubuntu20; and the native glibc
- resulting whl files are therefore not manylinux2014 compliant
- This is being added because we have seen some issue running unit tests against the older glibc/stdc++ so this is a way to get complete test coverage.
- This will also provide a nice dev image

- This also adds pycpp_large and no_rocm tags to both pycpp and pycpp_large for PR tests
- This also includes a fix for the buildtoolset scripts for dt9 which fail as is at the moment.

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/4210