### PR TITLE
[r2.12-rocm-enhanced] Fix virtualenv in wheel_verification.bats for urllib dependency issue

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/wheel_verification.bats
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/wheel_verification.bats
@@ -58,6 +58,8 @@ teardown_file() {
     python3 -m venv /tf/venv
     source /tf/venv/bin/activate
     python3 -m pip install "$TF_WHEEL"
+    # needed to avoid a dependency conflcit with `requests`
+    python3 -m pip install "urllib3<2"
 }
 
 @test "TensorFlow is importable" {


### PR DESCRIPTION
The venv that gets set up in wheel_verification.bats also must avoid urllib>2.* for now.
This will fix the wheel verification step in the release builds.