### PR TITLE
Fixed gpu device info test for AMD

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -248,21 +248,25 @@ cc_library(
 
 xla_cc_test(
     name = "gpu_device_info_test",
-    srcs = if_cuda_is_configured(["gpu_device_info_test.cc"]),
-    tags = tf_cuda_tests_tags() + ["no_rocm"],
-    deps = if_cuda_is_configured([
+    srcs = ["gpu_device_info_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    deps = [
         ":gpu_device_info",
         ":gpu_device_info_for_tests",
         "@com_google_absl//absl/strings",
-        "@local_config_cuda//cuda:cuda_headers",
+        "//tensorflow/tsl/platform:test",              
+        "//tensorflow/compiler/xla/tests:xla_internal_test_main",
         "//tensorflow/compiler/xla/service:pattern_matcher_gmock",
         "//tensorflow/compiler/xla/stream_executor/gpu:gpu_executor_header",
         "//tensorflow/compiler/xla/stream_executor",
-        "//tensorflow/compiler/xla/stream_executor:device_description",
+        "//tensorflow/compiler/xla/stream_executor:device_description",        
+        ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
         "//tensorflow/compiler/xla/stream_executor/cuda:cuda_gpu_executor_header",
-        "//tensorflow/compiler/xla/tests:xla_internal_test_main",
-        "//tensorflow/tsl/platform:test",
-    ]),
+        ]) + if_rocm_is_configured([
+        "@local_config_rocm//rocm:rocm_headers",
+        "//tensorflow/compiler/xla/stream_executor/rocm:rocm_gpu_executor_header",
+        ])
 )
 
 cc_library(

--- a/tensorflow/compiler/xla/service/gpu/gpu_device_info_for_tests.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_device_info_for_tests.cc
@@ -41,5 +41,28 @@ GpuDeviceInfo TestGpuDeviceInfo::RTXA6000DeviceInfo() {
   return info;
 }
 
+GpuDeviceInfo TestGpuDeviceInfo::AMDMI210DeviceInfo() {
+  GpuDeviceInfo info;
+  info.name = "AMD Instinct MI210";
+  info.threads_per_block_limit = 1024;
+  info.threads_per_warp = 64;
+  info.shared_memory_per_block = 64 * 1024;
+  info.shared_memory_per_block_optin = 0;
+  info.shared_memory_per_core = 64 * 1024;
+  info.threads_per_core_limit = 2048;
+  info.core_count = 104;
+  info.fpus_per_core = 0;
+  info.block_dim_limit_x = 2'147'483'647;
+  info.block_dim_limit_y = 2'147'483'647;
+  info.block_dim_limit_z = 2'147'483'647;
+  info.memory_bandwidth = 1'638'400'000'000; 
+  info.l2_cache_size = 8 * 1024 * 1024;
+  info.clock_rate_ghz = 1.7;
+  info.device_memory_size = 67'628'957'696;
+  return info;
+}
+
+
+
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/gpu_device_info_for_tests.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_device_info_for_tests.h
@@ -24,6 +24,7 @@ namespace gpu {
 class TestGpuDeviceInfo {
  public:
   static GpuDeviceInfo RTXA6000DeviceInfo();
+  static GpuDeviceInfo AMDMI210DeviceInfo();  
 };
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/stream_executor/rocm/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/rocm/BUILD
@@ -85,6 +85,7 @@ cc_library(
 cc_library(
     name = "rocm_gpu_executor",
     srcs = if_rocm_is_configured(["rocm_gpu_executor.cc"]),
+    hdrs = if_rocm_is_configured(["rocm_gpu_executor.h"]),
     deps = if_rocm_is_configured([
         ":rocm_diagnostics",
         ":rocm_driver",
@@ -108,6 +109,18 @@ cc_library(
         "//tensorflow/tsl/platform:env",
     ]),
     alwayslink = True,
+)
+
+cc_library(
+    name = "rocm_gpu_executor_header",
+    textual_hdrs = if_rocm_is_configured(["rocm_gpu_executor.h"]),
+    visibility = ["//visibility:public"],
+    deps = if_rocm_is_configured([
+        ":rocm_kernel",
+        "//tensorflow/compiler/xla/stream_executor:event",
+        "//tensorflow/compiler/xla/stream_executor/gpu:gpu_executor_header",
+        "//tensorflow/compiler/xla/stream_executor/platform",
+    ]),
 )
 
 cc_library(

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_gpu_executor.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_gpu_executor.cc
@@ -915,6 +915,8 @@ GpuExecutor::CreateDeviceDescription(int device_ordinal) {
     int64_t memory_bandwidth = 2 * (int64_t(prop.memoryBusWidth) / 8) *
                                (int64_t(prop.memoryClockRate) * 1000);
     builder.set_memory_bandwidth(memory_bandwidth);
+    
+    builder.set_l2_cache_size(prop.l2CacheSize);
   }
 
   {

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_gpu_executor.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_gpu_executor.h
@@ -1,0 +1,32 @@
+/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// The ROCm implementation of the StreamExecutorInterface functionality.
+// ROCm inclusions are ideally confined to this implementation file.
+//
+// The notions from the StreamExecutor basically correspond to the ROCm streams
+// programming model provided by the librocm.so driver APIs, so we don't have
+// to do much more than wrap the calls to the libraries appropriately.
+#ifndef TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_CUDA_ROCM_GPU_EXECUTOR_H_
+#define TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_CUDA_ROCM_GPU_EXECUTOR_H_
+
+#include "tensorflow/compiler/xla/stream_executor/gpu/gpu_executor.h"
+
+namespace stream_executor {
+namespace rocm {
+
+using ROCMExecutor = gpu::GpuExecutor;
+
+}  // namespace rocm
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_CUDA_ROCM_GPU_EXECUTOR_H_


### PR DESCRIPTION
This brings back gpu_device_info_test since ROCm 5.5 can print out device name. 

I have added and tested without problem on MI50/60, MI100 and MI210, and I will push this change to openXLA upstream as well. 

As a side note, I have tried TENSORFLOW_USE_ROCM && TF_ROCM_VERSION >= 50500 to keep it only in ROCm 5.5, but it cannot detect ROCm 5.5, any better suggestion? 

Thanks!

