### PR TITLE
Drop ROCm 3.3 support on gpu_executable.cc

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_executable.cc
@@ -143,8 +143,6 @@ GpuExecutable::GpuExecutable(GpuExecutable::Params params)
   binary_.resize(binary_.size() + 16);
   *(uint64_t*)(&binary_[binary_.size() - 16]) = tsl::EnvTime::NowNanos();
   *(uint64_t*)(&binary_[binary_.size() - 8]) = tsl::random::New64();
-  // workaround for a bug in ROCm 3.3 hipModuleLoadData
-  binary_.reserve(binary_.size() + 256);
 #endif
   if (has_module()) {
     XlaDebugInfoManager::Get()->RegisterModule(


### PR DESCRIPTION
Since previous change causes the llvm_compiler_test failed, drop the ROCm3.3 part to suit the upstream's need and reverse the changes. (I will push this change to openXLA upstream)

Thanks