### PR TITLE
[ROCM]Disable clang builds on CPU builds when using tf-build

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc
@@ -23,16 +23,17 @@ build --define=tf_api_version=2 --action_env=TF2_BEHAVIOR=1
 # Target the AVX instruction set
 build --copt=-mavx --host_copt=-mavx
 
+# TODO: Fix clang CPU builds
 # Use lld as the linker
-build --linkopt="-fuse-ld=lld"
-build --linkopt="-lm"
+#build --linkopt="-fuse-ld=lld"
+#build --linkopt="-lm"
 
 # Disable clang extention that rejects type definitions within offsetof. 
 # This was added in clang-16 by https://reviews.llvm.org/D133574.
 # Can be removed once upb is updated, since a type definition is used within
 # offset of in the current version of ubp.
 # See https://github.com/protocolbuffers/upb/blob/9effcbcb27f0a665f9f345030188c0b291e32482/upb/upb.c#L183.
-build --copt=-Wno-gnu-offsetof-extensions
+#build --copt=-Wno-gnu-offsetof-extensions
 
 # Store performance profiling log in the mounted artifact directory.
 # The profile can be viewed by visiting chrome://tracing in a Chrome browser.

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu_gcc.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu_gcc.bazelrc
@@ -62,7 +62,7 @@ test --build_tests_only --keep_going --test_output=errors --verbose_failures=tru
 test:cuda --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
 test:rocm --test_env=HSA_TOOLS_LIB=libroctracer64.so --test_sharding_strategy=disabled
 # Local test jobs has to be 4 because parallel_gpu_execute is fragile, I think
-test --test_timeout=300,450,1200,3600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
+test --test_timeout=920,2400,7200,9600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
 # Give only the list of failed tests at the end of the log
 test --test_summary=short
 


### PR DESCRIPTION
CPU builds had moved to clang as well. There is no separate cpu_gcc.bazelrc, so just comment out the differences for now.

- Also includes a commit to increase timeouts in the new gpu_gcc.bazelrc file.