### PR TITLE
[develop-upstream-QA-rocm56] Fixed a number of issues related to MKL OneDNN API

### DIFF
--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -96,7 +96,7 @@ bool IsMklEnabled() {
   });
   return (!oneDNN_disabled);
 #else
-  static bool oneDNN_enabled = DefaultOneDnnPolicy();
+  static bool oneDNN_enabled = false; //DefaultOneDnnPolicy();
   absl::call_once(once, [&] {
     auto status = ReadBoolFromEnvVar("TF_ENABLE_ONEDNN_OPTS", oneDNN_enabled,
                                      &oneDNN_enabled);


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-399253

The failed test_conv_bn_dropout1 is becuase Intel CPU instruction (anyone of AVX512_VNNI, AVX512_BF16, AVX_VNNI, AMX_TILE, AMX_INT8 or AMX_BF16 instruction) triggers onednn MKL library that we have not installed it in the Intel's machine, and the full analysis in here.

https://github.com/ROCmSoftwarePlatform/frameworks-internal/issues/3655#issuecomment-1468387784 
https://github.com/ROCmSoftwarePlatform/tensorflow-private/pull/14 
You can disable onednn by this commit or installed onednn MKL library to fix it.

