### PR TITLE
add xla_cpp for XLA CI 

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu_gcc.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu_gcc.bazelrc
@@ -180,3 +180,8 @@ test:pycpp_large_filters --test_tag_filters=-no_oss,-oss_serial,-benchmark-test,
 test:pycpp_large_filters --build_tag_filters=-no_oss,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-no_rocm
 test:pycpp_large_filters --test_lang_filters=cc,py --flaky_test_attempts=3 --test_size_filters=small,medium,large
 test:pycpp_large --config=pycpp_large_filters -- //tensorflow/... -//tensorflow/python/integration_testing/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/compiler/xrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
+
+# For XLA (rocm)
+test:xla_cpp_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-no_rocm --keep_going
+test:xla_cpp_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-no_rocm
+test:xla_cpp --config=xla_cpp_filters -- //xla/... //build_tools/..


### PR DESCRIPTION
Now, XLA CI command should be:

```
docker exec openxla bazel --bazelrc=/usertools/rocm.bazelrc test --config=rocm --config=xla_cpp --profile=/tf/pkg/profile.json.gz --flaky_test_attempts=3 --test_env=TF_TESTS_PER_GPU=1 --test_env=TF_GPU_COUNT=2 --local_test_jobs=1 --run_under=//tools/ci_build/gpu_build:parallel_gpu_execute -- //xla/... //build_tools/...
```

Maybe this following one needs to be changed?  @jayfurmanek 

```--test_env=TF_TESTS_PER_GPU=1 --test_env=TF_GPU_COUNT=2```