### PR TITLE
fixed typo in bazelrc

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu_gcc.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu_gcc.bazelrc
@@ -184,4 +184,4 @@ test:pycpp_large --config=pycpp_large_filters -- //tensorflow/... -//tensorflow/
 # For XLA (rocm)
 test:xla_cpp_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-no_rocm --keep_going
 test:xla_cpp_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-no_rocm
-test:xla_cpp --config=xla_cpp_filters -- //xla/... //build_tools/..
+test:xla_cpp --config=xla_cpp_filters -- //xla/... //build_tools/...


### PR DESCRIPTION
there is a typo in https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/2162

XLA CI command to run the whole unit test
```
docker exec openxla bazel --bazelrc=/usertools/rocm.bazelrc test --config=rocm --config=xla_cpp --profile=/tf/pkg/profile.json.gz --test_env=TF_TESTS_PER_GPU=1 --test_env=TF_GPU_COUNT=2 --local_test_jobs=1 --run_under=//tools/ci_build/gpu_build:parallel_gpu_execute -- //xla/... //build_tools/...
```


the example command for run the xla container
```
docker run --name openxla -w /tf/xla -it -d --network=host --device=/dev/kfd --device=/dev/dri --ipc=host --shm-size 16G --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v /home/jenkins/workspace/tensorflow/OpenXLA/XLA-nightly/tensorflow_pkg:/tf/pkg -v /home/jenkins/workspace/tensorflow/OpenXLA/XLA-nightly/xla:/tf/xla -v /home/jenkins/workspace/tensorflow/OpenXLA/XLA-nightly//tmp/bazelcache:/tf/cache rocm/tensorflow-build:latest-focal-python3.9-rocm5.6.0
```