### PR TITLE
[r2.13-rocm-enhanced] Force incarnation_id of 1 in multi_device_iterator

### DIFF
--- a/tensorflow/core/kernels/data/multi_device_iterator_ops.cc
+++ b/tensorflow/core/kernels/data/multi_device_iterator_ops.cc
@@ -142,7 +142,7 @@ class MultiDeviceIterator : public ResourceBase {
     params.thread_pool = &unbounded_thread_pool_;
     params.cancellation_manager = ctx->cancellation_manager();
     IteratorContext iter_ctx(std::move(params));
-    multi_device_buffer_->GetNextFromShard(&iter_ctx, shard_num, incarnation_id,
+    multi_device_buffer_->GetNextFromShard(&iter_ctx, shard_num, 1/*incarnation_id*/,
                                            std::move(callback));
     return OkStatus();
   }


### PR DESCRIPTION
WAR: Force incarnation_id to 1. This effectively disables multiple instances of the multi_device_iterator.