### PR TITLE
Update requirements for 2.14

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -1717,8 +1717,6 @@ py_library(
         "//tensorflow/lite/python:lite",
         "//tensorflow/lite/python/authoring",
         "//tensorflow/python:no_contrib",
-        "@pypi_keras_nightly//:pkg",
-        "@pypi_tb_nightly//:pkg",
     ],
 )
 # copybara:comment_end

--- a/tensorflow/python/estimator/BUILD
+++ b/tensorflow/python/estimator/BUILD
@@ -19,7 +19,6 @@ py_library(
         ":dnn",
         ":dnn_linear_combined",
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":export",
         ":exporter",
         ":inputs",
@@ -38,7 +37,6 @@ py_library(
     srcs = ["exporter.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":gc",
         ":metric_keys",
         ":util",
@@ -51,7 +49,6 @@ py_library(
     srcs = ["gc.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
     ],
 )
@@ -61,7 +58,6 @@ py_library(
     srcs = ["model_fn.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":export_output",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
@@ -74,7 +70,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":exporter",
         ":run_config",
         "//tensorflow:tensorflow_py_no_contrib",
@@ -87,7 +82,6 @@ py_library(
     srcs = ["run_config.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
     ],
@@ -99,7 +93,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":head",
         ":model_fn",
         ":optimizers",
@@ -114,7 +107,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":head",
         ":model_fn",
         ":optimizers",
@@ -130,7 +122,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":head",
         ":metric_keys",
         ":model_fn",
@@ -150,7 +141,6 @@ py_library(
     deps = [
         ":dnn",
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":head",
         ":linear",
         ":model_fn",
@@ -167,7 +157,6 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
     ],
 )
@@ -179,7 +168,6 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":export_export",
         ":model_fn",
         ":run_config",
@@ -197,7 +185,6 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
     ],
@@ -208,7 +195,6 @@ py_library(
     srcs = ["export/export_output.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
     ],
@@ -221,7 +207,6 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":export_export",
         ":export_output",
         "//tensorflow:tensorflow_py_no_contrib",
@@ -235,7 +220,6 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":util",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
@@ -247,7 +231,6 @@ py_library(
     srcs = ["canned/head.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":export_output",
         ":metric_keys",
         ":model_fn",
@@ -262,7 +245,6 @@ py_library(
     srcs = ["inputs/inputs.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":numpy_io",
         ":pandas_io",
         "//tensorflow:tensorflow_py_no_contrib",
@@ -275,7 +257,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":head",
         ":optimizers",
         "//tensorflow:tensorflow_py_no_contrib",
@@ -290,7 +271,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":export_export",
         ":linear",
         ":metric_keys",
@@ -307,7 +287,6 @@ py_library(
     srcs = ["canned/metric_keys.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":model_fn",
     ],
 )
@@ -317,7 +296,6 @@ py_library(
     srcs = ["inputs/numpy_io.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":inputs_queues",
     ],
 )
@@ -327,7 +305,6 @@ py_library(
     srcs = ["canned/optimizers.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
     ],
@@ -338,7 +315,6 @@ py_library(
     srcs = ["inputs/pandas_io.py"],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         ":inputs_queues",
     ],
 )
@@ -347,9 +323,6 @@ py_library(
     name = "prediction_keys",
     srcs = ["canned/prediction_keys.py"],
     srcs_version = "PY3",
-    deps = [
-        ":expect_tensorflow_estimator_installed",
-    ],
 )
 
 py_library(
@@ -360,7 +333,6 @@ py_library(
     ],
     srcs_version = "PY3",
     deps = [
-        ":expect_tensorflow_estimator_installed",
         "//tensorflow:tensorflow_py_no_contrib",
         "@six_archive//:six",
     ],
@@ -372,15 +344,9 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":estimator",
-        ":expect_tensorflow_estimator_installed",
         ":export_export",
         ":model_fn",
         ":run_config",
         "//tensorflow:tensorflow_py_no_contrib",
     ],
-)
-
-alias(
-    name = "expect_tensorflow_estimator_installed",
-    actual = "@pypi_tf_estimator_nightly//:pkg",
 )

--- a/tensorflow/python/util/tf_export.py
+++ b/tensorflow/python/util/tf_export.py
@@ -344,15 +344,6 @@ class api_export(object):  # pylint: disable=invalid-name
     self.set_attr(undecorated_func, api_names_attr, self._names)
     self.set_attr(undecorated_func, api_names_attr_v1, self._names_v1)
 
-    # TODO(b/263286841): Remove functionality
-    if self._deprecation_inst is not None:
-      # Inline import to avoid dependency cycle between deprecation
-      # utility and tf_export
-      from tensorflow.python.util import deprecation  # pylint: disable=g-import-not-at-top
-      deprecation_wrapper = deprecation.deprecated(
-          None, self._deprecation_inst, warn_once=True)
-      func = deprecation_wrapper(func)
-    
     for name in self._names:
       _NAME_TO_SYMBOL_MAPPING[name] = func
     for name_v1 in self._names_v1:

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -5,12 +5,11 @@ absl-py ~= 1.0.0
 astunparse ~= 1.6.3
 flatbuffers ~= 23.5.26
 google_pasta ~= 0.2
-h5py ~= 3.8.0  # Earliest version for Python 3.11
+h5py >= 2.9.0
 ml_dtypes ~= 0.2
 # TODO(b/262592253): Support older versions of NumPy for Python 3.10 and lower
 # to support TFX. Remove when Apache Beam upgrades to newer NumPy.
-numpy ~= 1.22.0; python_version < '3.11'
-numpy ~= 1.23.2; python_version >= '3.11' # Earliest version for Python 3.11
+numpy ~= 1.23.5
 opt_einsum ~= 3.3.0
 protobuf ~= 3.20.3  # NOTE: Earliest version for Python 3.10
 six ~= 1.16.0
@@ -26,19 +25,18 @@ gast == 0.4.0
 # Note that here we want the latest version that matches TF major.minor version
 # Note that we must use nightly here as these are used in nightly jobs
 # For release jobs, we will pin these on the release branch
-keras-nightly ~= 2.14.0.dev
-tb-nightly ~= 2.14.0.a
-tf-estimator-nightly ~= 2.14.0.dev
+keras ~= 2.14.0rc0
+tensorboard ~= 2.14.0
+tensorflow-estimator ~= 2.14.0rc0
 
 # Test dependencies
-grpcio ~= 1.49.1 # Earliest version for Python 3.11
+grpcio >= 1.24.3, < 2.0
 portpicker ~= 1.5.2
-scipy ~= 1.7.2; python_version < '3.11'
-scipy ~= 1.9.2; python_version >= '3.11' # Earliest version for Python 3.11
+scipy == 1.10.1
+requests == 2.31.0
+jax==0.4.7
 
-# This is usually vendored in setuptools but ensure it gets installed in CI anyway
-# No bound here, we prefer the one in setuptools
-packaging
+packaging==23.1
 
 # For using Python 3.11 with Bazel 6 (b/286090018)
 lit ~= 16.0.5.post0

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -8,14 +8,11 @@ absl-py ~= 1.0.0
 astunparse ~= 1.6.3
 flatbuffers ~= 23.5.26
 google_pasta ~= 0.2
-h5py ~= 3.8.0 # Earliest version for Python 3.11
+h5py >= 2.9.0
 ml_dtypes ~= 0.2
-# TODO(b/262592253): Support older versions of NumPy for Python 3.10 and lower
-# to support TFX. Remove when Apache Beam upgrades to newer NumPy.
-numpy ~= 1.22.0; python_version < '3.11'
-numpy ~= 1.23.2; python_version >= '3.11' # Earliest version for Python 3.11
+numpy ~= 1.23.5
 opt_einsum ~= 3.3.0
-packaging ~= 21.3
+packaging==23.1
 protobuf ~= 3.20.3
 six ~= 1.16.0
 termcolor ~= 2.1.1
@@ -30,17 +27,16 @@ gast == 0.4.0
 # For release jobs, we will pin these on the release branch
 # Note that the CACHEBUSTER variable, set in the CI builds, will force these to
 # be the latest version.
-keras-nightly ~= 2.14.0.dev
-tb-nightly ~= 2.13.0.a
-tf-estimator-nightly ~= 2.14.0.dev
+keras ~= 2.14.0rc0
+tensorboard ~= 2.14.0
+tensorflow-estimator ~= 2.14.0rc0
 # Test dependencies
-grpcio ~= 1.49.1 # Earliest version for Python 3.11
-portpicker ~= 1.5.2
-scipy ~= 1.7.2; python_version < '3.11'
-scipy ~= 1.9.2; python_version >= '3.11' # Earliest version for Python 3.11
+grpcio >= 1.24.3, < 2.0
+portpicker == 1.5.2
+scipy == 1.10.1
 # Required for TFLite import from JAX tests
-jax ~= 0.3.25
-jaxlib ~= 0.3.25 # Earliest version for Python 3.11
+jax==0.4.7
+jaxlib ~= 0.4.7 # Earliest version for Python 3.11
 # Needs to be addressed. Unblocked 2.4 branchcut cl/338377048
 PyYAML ~= 6.0
 # For uploading
@@ -51,6 +47,7 @@ junitparser ~= 2.2.0
 lxml ~= 4.9.1
 pylint ~= 2.13.9
 urllib3<2
+requests == 2.31.0
 
 # For using Python 3.11 with Bazel 6 (b/286090018)
 lit ~= 16.0.5.post0


### PR DESCRIPTION
The new update_requirements scripts seem to not be working for us. Remove some of it and hardcode the dependencies to where is should be for 2.14