### PR TITLE
Change platform define HIP_PLATFORM_HCC to HIP_PLATFORM_AMD

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -721,7 +721,7 @@ def _create_local_rocm_repository(repository_ctx):
 
     rocm_defines["%{unfiltered_compile_flags}"] = to_list_of_strings([
         "-DTENSORFLOW_USE_ROCM=1",
-        "-D__HIP_PLATFORM_HCC__",
+        "-D__HIP_PLATFORM_AMD__",
         "-DEIGEN_USE_HIP",
     ])
 


### PR DESCRIPTION
HIP_PLATFORM_AMD is defined if the HIP platform targets AMD.
Note, HIP_PLATFORM_HCC was previously defined if the HIP platform targeted AMD. It
is now deprecated since 4.5:
https://raw.githubusercontent.com/RadeonOpenCompute/ROCm/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf

It's time to move to HIP_PLATFORM_AMD