### PR TITLE
[r2.13-rocm-enhanced] Revert "Added support for gfx941 and gfx942. (#2181)"

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter.cc
@@ -730,10 +730,8 @@ void IrEmitter::BindFusionArguments(const HloInstruction* fusion,
 void IrEmitter::MaybeEmitFenceForAMDGPU(llvm::AtomicOrdering atomic_ordering,
                                         const char* sync_scope_id) {
   if (IsEmittingForAMDGPU() &&
-      (ir_emitter_context_->rocm_compute_capability().gcn_arch_name().substr(0, 6) == "gfx90a" || 
-       ir_emitter_context_->rocm_compute_capability().gcn_arch_name().substr(0, 6) == "gfx940" || 
-       ir_emitter_context_->rocm_compute_capability().gcn_arch_name().substr(0, 6) == "gfx941" || 
-       ir_emitter_context_->rocm_compute_capability().gcn_arch_name().substr(0, 6) == "gfx942")) {
+      ir_emitter_context_->rocm_compute_capability().gcn_arch_name().substr(
+          0, 6) == "gfx90a") {
     b_.CreateFence(atomic_ordering,
                    b_.getContext().getOrInsertSyncScopeID(sync_scope_id));
   }

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -884,7 +884,7 @@ std::string MapGCNArchNameTokenToFeatureStr(const std::string& token,
   if (token == "sramecc+") {
     return "+sramecc";
   } else if (token == "sramecc-") {
-    if(gfx == "gfx90a" || gfx == "gfx940" || gfx == "gfx941" || gfx == "gfx942")
+    if(gfx=="gfx90a")
       return "";
     return "-sramecc";
   } else if (token == "xnack+") {

--- a/tensorflow/compiler/xla/stream_executor/device_description.h
+++ b/tensorflow/compiler/xla/stream_executor/device_description.h
@@ -176,28 +176,23 @@ class RocmComputeCapability {
         "gfx906",  // MI50 / MI60
         "gfx908",  // MI100
         "gfx90a",  // MI200
-        "gfx940",  // MI300
-        "gfx941",  // MI300
-        "gfx942",  // MI300
         "gfx1030"  // Navi21
     };
   }
   std::set<std::string> gfx_versions_with_nhwc_layout_support() {
-    return {"gfx908", "gfx90a", "gfx940", "gfx941", "gfx942"};
+    return {"gfx908", "gfx90a"};
   }
   std::set<std::string> gfx_versions_with_fast_bf16_support() {
-    return {"gfx908", "gfx90a", "gfx940", "gfx941", "gfx942"};
+    return {"gfx908", "gfx90a"};
   }
   std::set<std::string> gfx_versions_with_fast_fp16_support() {
-    return {"gfx906", "gfx908", "gfx90a", "gfx940", "gfx941", "gfx942", "gfx1030"};
+    return {"gfx906", "gfx908", "gfx90a", "gfx1030"};
   }
   std::set<std::string> gfx_versions_with_mfma_instr_support() {
-    return {"gfx908", "gfx90a", "gfx940", "gfx941", "gfx942"};
+    return {"gfx908", "gfx90a"};
   }
   std::set<std::string> gfx_versions_with_fp16_atomics_support() {
-    // TODO(rocm): Check. This should be the same as
-    // gfx_versions_with_fast_fp16_support.
-    return {"gfx90a", "gfx940", "gfx941", "gfx942"};
+    return {"gfx90a"};
   }
 };
 

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_driver.cc
@@ -1265,9 +1265,7 @@ static tsl::StatusOr<T> GetSimpleAttribute(hipDevice_t device,
   if (gcnArchName.substr(0, 6) == "gfx908") {
     *reserve = RESERVED_GFX908;
   } else if (gcnArchName.substr(0, 6) == "gfx90a" ||
-             gcnArchName.substr(0, 6) == "gfx940" ||
-             gcnArchName.substr(0, 6) == "gfx941" ||
-             gcnArchName.substr(0, 6) == "gfx942" ) {
+             gcnArchName.substr(0, 6) == "gfx940") {
     *reserve = RESERVED_GFX9_X;
   }
   return true;

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -114,8 +114,8 @@ bool HasFastFP16Support(const DeviceProperties& props) {
   return GetDeviceGPUArch(props) >= kMinGPUArch;
 #elif TENSORFLOW_USE_ROCM
   absl::flat_hash_set<std::string> FP16SupportedDevices = {
-      {"gfx906"}, {"gfx908"}, {"gfx90a"}, {"gfx910"}, {"gfx940"}, {"gfx941"},
-      {"gfx942"}, {"gfx1010"}, {"gfx1012"}, {"gfx1030"}
+      {"gfx906"}, {"gfx908"}, {"gfx90a"}, {"gfx910"}, {"gfx1010"}, {"gfx1012"},
+      {"gfx1030"}
   };
   std::string gcnArchName = props.environment().at("architecture");
   std::vector<std::string> gpu_arch = absl::StrSplit(gcnArchName, ":");

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
@@ -69,10 +69,7 @@ inline GpuStats GetNumGPUs(const Cluster& cluster) {
 #if TENSORFLOW_USE_ROCM
     bool is_enabled = se::gpu::UseNhwcLayoutForRocm();
     if ((compute_capability_it->second == "gfx908" ||
-         compute_capability_it->second == "gfx90a" ||
-	 compute_capability_it->second == "gfx940" ||
-	 compute_capability_it->second == "gfx941" ||
-	 compute_capability_it->second == "gfx942") && is_enabled) {
+         compute_capability_it->second == "gfx90a") && is_enabled) {
        gpu_stats.num_voltas++;
     }
 #endif

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -743,7 +743,7 @@ __device__ inline double GpuAtomicAdd(double* ptr, double value) {
 }
 #endif
 
-#if __gfx908__ || __gfx90a__ || __gfx940__ || __gfx941__ || __gfx942__
+#if __gfx908__ || __gfx90a__ || __gfx940__
 
 #define ADDRSP1 __attribute__((address_space(1)))
 __device__ float
@@ -963,7 +963,7 @@ __device__ inline int64_t GpuAtomicMin(int64_t* ptr, int64_t value) {
 }
 #endif
 
-#if __gfx908__ || __gfx90a__ || __gfx940__ || __gfx941__ || __gfx942__
+#if __gfx908__ || __gfx90a__ || __gfx940__
 // Low level instructions don't return. For now, assume that return value
 // is always unused.
 __device__ float GpuAtomicAdd(float* dst, float val) {
@@ -978,7 +978,7 @@ __device__ inline T GpuAtomicAddShared(T* ptr, T value) {
   return GpuAtomicAdd(ptr, value);
 }
 
-#if __gfx908__ || __gfx90a__ || __gfx940__ || __gfx941__ || __gfx942__
+#if __gfx908__ || __gfx90a__ || __gfx940__
 __device__ float GpuAtomicAddShared(float* dst, float val) {
   atomicAdd(dst, val);
   return val;


### PR DESCRIPTION
This reverts commit 2d52de6d2c9428162cf810fd1dda7c36ab6bc126.

The LLVM commit in TF 2.13 is too old for gfx94x