### PR TITLE
[r2.14-rocm-enhanced] ROCM6: Install hiprand-dev separately

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -78,7 +78,7 @@ RUN MIOPENKERNELS=$( \
     ) && \
     apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rccl hipblaslt-dev ${MIOPENKERNELS} && \
+    rocm-dev rocm-libs rccl hipblaslt-dev ${MIOPENKERNELS} && hiprand-dev \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -78,7 +78,7 @@ RUN MIOPENKERNELS=$( \
     ) && \
     apt-get update --allow-insecure-repositories && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
-    rocm-dev rocm-libs rccl hipblaslt-dev ${MIOPENKERNELS} && hiprand-dev \
+    rocm-dev rocm-libs ${MIOPENKERNELS} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/clone_test_repo.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/clone_test_repo.sh
@@ -18,8 +18,9 @@ clone_benchmark() {
     # For TF version higher than 2.12, use the new AMD benchmarks repo
     if (( ${tf_ver//./} > 212 ));then
         benchmarks_repo='https://github.com/ROCmSoftwarePlatform/benchmarks'
+        benchmark_branch='-b tf2.13-compatible'
     fi
-    git clone ${benchmarks_repo}
+    git clone ${benchmark_branch} ${benchmarks_repo}
 }
 
 git clone https://github.com/tensorflow/models.git

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
@@ -65,3 +65,4 @@ hipcub-devel
 rccl-devel 
 hipsparse-devel 
 hipsolver-devel
+hiprand-devel

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
@@ -51,6 +51,7 @@ kernel-devel-uname-r
 # rocm packagaes
 libdrm-amdgpu
 rocm-dev
+rocm-ml-sdk
 miopen-hip 
 miopen-hip-devel 
 rocblas 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
@@ -15,6 +15,7 @@ hipcub-dev
 rccl-dev
 hipsparse-dev
 hipsolver-dev
+hiprand-dev
 
 # Other build-related tools
 apt-transport-https

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
@@ -1,6 +1,7 @@
 # All required ROCM packages
 rocm-libs
 rocm-dev
+rocm-ml-sdk
 miopen-hip 
 miopen-hip-dev
 rocblas


### PR DESCRIPTION
1. Added hiprand install
2.  Removed extra package name when we are using rocm-libs
3. Updated benchmark correct branch clone