### PR TITLE
Benchmark branch "tf2.13-compatible"  clone for *QA-rocm60

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/clone_test_repo.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/clone_test_repo.sh
@@ -18,8 +18,9 @@ clone_benchmark() {
     # For TF version higher than 2.12, use the new AMD benchmarks repo
     if (( ${tf_ver//./} > 212 ));then
         benchmarks_repo='https://github.com/ROCmSoftwarePlatform/benchmarks'
+        benchmark_branch='-b tf2.13-compatible'
     fi
-    git clone ${benchmarks_repo}
+    git clone ${benchmark_branch} ${benchmarks_repo}
 }
 
 git clone https://github.com/tensorflow/models.git


### PR DESCRIPTION
Clone https://github.com/ROCmSoftwarePlatform/benchmarks/commits/tf2.13-compatible branch of benchmark if tf >2.12