### PR TITLE
[r2.14-rocm-enhanced] Revert: ROCM6: Install hiprand-dev separately

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
@@ -66,4 +66,3 @@ hipcub-devel
 rccl-devel 
 hipsparse-devel 
 hipsolver-devel
-hiprand-devel

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
@@ -16,7 +16,6 @@ hipcub-dev
 rccl-dev
 hipsparse-dev
 hipsolver-dev
-hiprand-dev
 
 # Other build-related tools
 apt-transport-https


### PR DESCRIPTION
This causes build fails of tensorflow-build on 5.7.
We should be covered on 6.0 with the rocm-libs and rocm-ml-sdk meta packages.