### PR TITLE
[ERROR RDNA3] Update device_description.h

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/device_description.h
+++ b/tensorflow/compiler/xla/stream_executor/device_description.h
@@ -181,7 +181,7 @@ class RocmComputeCapability {
         "gfx940",  // MI300
         "gfx941",  // MI300
         "gfx942",  // MI300
-        "gfx1030"  // Navi21
+        "gfx1030",  // Navi21
         "gfx1100"  // Navi31
     };
   }

--- a/tensorflow/compiler/xla/stream_executor/device_description.h
+++ b/tensorflow/compiler/xla/stream_executor/device_description.h
@@ -181,7 +181,7 @@ class RocmComputeCapability {
         "gfx940",  // MI300
         "gfx941",  // MI300
         "gfx942",  // MI300
-        "gfx1030",  // Navi21
+        "gfx1030", // Navi21
         "gfx1100"  // Navi31
     };
   }


### PR DESCRIPTION
error compiling Ignoring visible gpu device (device: 0, name: Radeon RX 7900 XT, pci bus id: 0000:03:00.0) with AMDGPU version : gfx1100. The supported AMDGPU versions are gfx1030gfx1100, gfx900, gfx906, gfx908, gfx90a, gfx940, gfx941, gfx942.

There is a mistake "gfx1030gfx1100"

![image](https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/assets/22727137/dcf70ff0-5b9d-40a2-abee-8d6f72f6fb4c)
working