### PR TITLE
disable onednn in QA-rocm60

### DIFF
--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -71,15 +71,6 @@ inline bool DefaultOneDnnPolicy() {
 #elif defined(PLATFORM_GOOGLE)
   return true;
 #elif defined(__linux__)
-  return port::TestCPUFeature(port::CPUFeature::AVX512_VNNI) ||
-         port::TestCPUFeature(port::CPUFeature::AVX512_BF16) ||
-         port::TestCPUFeature(port::CPUFeature::AVX_VNNI) ||
-         port::TestCPUFeature(port::CPUFeature::AMX_TILE) ||
-         port::TestCPUFeature(port::CPUFeature::AMX_INT8) ||
-         port::TestCPUFeature(port::CPUFeature::AMX_BF16) ||
-         port::TestAarch64CPU(
-             port::Aarch64CPU::ARM_NEOVERSE_V1);  // ARM NEOVERSE V1
-#else
   return false;
 #endif  // !defined(INTEL_MKL)
 }


### PR DESCRIPTION
same one https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/2270