### PR TITLE
[ROCM] Use 'type' instead of 'memoryType' from hipPointerAttribute_t …

### DIFF
--- a/tensorflow/core/common_runtime/direct_session_test.cc
+++ b/tensorflow/core/common_runtime/direct_session_test.cc
@@ -2361,7 +2361,7 @@ bool IsCUDATensor(const Tensor& t) {
   hipError_t err = hipPointerGetAttributes(&attributes, t.tensor_data().data());
   if (err == hipErrorInvalidValue) return false;
   CHECK_EQ(hipSuccess, err) << hipGetErrorString(err);
-  return (attributes.memoryType == hipMemoryTypeDevice);
+  return (attributes.type == hipMemoryTypeDevice);
 #else
   return false;
 #endif

--- a/tensorflow/core/common_runtime/process_function_library_runtime_test.cc
+++ b/tensorflow/core/common_runtime/process_function_library_runtime_test.cc
@@ -605,7 +605,7 @@ bool IsCUDATensor(const Tensor& t) {
   hipError_t err = hipPointerGetAttributes(&attributes, t.tensor_data().data());
   if (err == hipErrorInvalidValue) return false;
   CHECK_EQ(hipSuccess, err) << hipGetErrorString(err);
-  return (attributes.memoryType == hipMemoryTypeDevice);
+  return (attributes.type == hipMemoryTypeDevice);
 #else
   CHECK(false)
       << "IsCUDATensor should not be called when CUDA is not available";


### PR DESCRIPTION
…structure

Needed for ROCM 6.0