### PR TITLE
Dont install dev requirements in runtime mode

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
@@ -100,5 +100,10 @@ python3 get-pip.py
 python3 -m pip install --no-cache-dir --upgrade pip
 python3 -m pip install -U setuptools
 
-# Disable the cache dir to save image space, and install packages
-python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U
+if [[ $3 ]]; then
+    echo "Runtime mode"
+else
+    echo "Install Requirements"
+    # Disable the cache dir to save image space, and install packages
+    python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U
+fi


### PR DESCRIPTION
For the runtime container, installing the dev requirements list results in some dep mismatches.
It's ok for building, but for runtime let's just leave these off and let the user install what they want anyway.