### PR TITLE
Fix runtime pkgs

### DIFF
--- a/tensorflow/core/grappler/optimizers/meta_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer_test.cc
@@ -781,7 +781,7 @@ TEST_F(MetaOptimizerTest, OptimizerDoesNotTimeOut) {
       *config.mutable_graph_options()->mutable_rewrite_options();
   rewriter_config.add_optimizers("SleepingOptimizer");
   rewriter_config.set_min_graph_nodes(-1);
-  rewriter_config.set_meta_optimizer_timeout_ms(2500);
+  rewriter_config.set_meta_optimizer_timeout_ms(7500);
   rewriter_config.set_meta_optimizer_iterations(RewriterConfig::TWO);
   GraphDef output;
   const int original_node_size = item.graph.node_size();

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
@@ -43,7 +43,7 @@ RUN echo $CACHEBUSTER
 ARG PYTHON_VERSION
 COPY setup.python.sh /setup.python.sh
 COPY devel.requirements.txt /devel.requirements.txt
-RUN /setup.python.sh $PYTHON_VERSION devel.requirements.txt true
+RUN /setup.python.sh $PYTHON_VERSION devel.requirements.txt
 
 ARG TF_WHEEL_URL
 RUN if [ -n "${TF_WHEEL_URL}" ]; then pip install "${TF_WHEEL_URL}"; fi

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
@@ -63,21 +63,6 @@ $VERSION-distutils
 EOF
 /setup.packages.sh pythons.txt
 
-if [[ $3 ]]; then
-    echo "Runtime mode"
-else
-    echo "Dev mode"
-    # Re-link pyconfig.h from x86_64-linux-gnu into the devtoolset directory
-    # for any Python version present
-    pushd /usr/include/x86_64-linux-gnu
-    for f in $(ls | grep python); do
-      # set up symlink for devtoolset-9
-      rm -f /dt9/usr/include/x86_64-linux-gnu/$f
-      ln -s /usr/include/x86_64-linux-gnu/$f /dt9/usr/include/x86_64-linux-gnu/$f
-    done
-    popd
-fi
-
 # Setup links for TensorFlow to compile.
 # Referenced in devel.usertools/*.bazelrc
 ln -sf /usr/bin/$VERSION /usr/bin/python3
@@ -102,7 +87,6 @@ python3 -m pip install -U setuptools
 
 if [[ $3 ]]; then
     echo "Runtime mode"
-    python3 -m pip install --no-cache-dir portpicker numpy==1.26.0 scipy -U
 else
     echo "Install Requirements"
     # Disable the cache dir to save image space, and install packages

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
@@ -100,5 +100,11 @@ python3 get-pip.py
 python3 -m pip install --no-cache-dir --upgrade pip
 python3 -m pip install -U setuptools
 
-# Disable the cache dir to save image space, and install packages
-python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U
+if [[ $3 ]]; then
+    echo "Runtime mode"
+    python3 -m pip install --no-cache-dir portpicker numpy==1.26.0 scipy -U
+else
+    echo "Install Requirements"
+    # Disable the cache dir to save image space, and install packages
+    python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U
+fi


### PR DESCRIPTION
This fixes the way we put (or not) the dev requirements list into the container.
We want the dev requirements in the dev image, but not the rt (runtime) image as it includes numpy/scipy at purposely older levels for build reason, which isn't appropriate for the rt image.

*also includes a timeout fix for a cpu test that was timing out.