### PR TITLE
enable GemmRewriter 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -873,11 +873,11 @@ Status GpuCompiler::OptimizeHloPostLayoutAssignment(
         compute_capability.IsAtLeast(se::CudaComputeCapability::VOLTA)) {
       pipeline.AddPass<GemmRewriterTriton>(compute_capability);
     }
+#endif
     pipeline.AddPass<GemmRewriter>(compute_capability);
-
     // Rewrite GEMMs with broadcasted inputs as strided GEMMs.
     pipeline.AddPass<GemmBroadcastFoldingRewriter>();
-#endif
+    
     if (debug_options.xla_gpu_normalize_layouts()) {
       pipeline.AddPass<LayoutNormalization>(&NormalizeLayoutForGpuCustomCalls);
       pipeline.AddPass<HloPassFix<AlgebraicSimplifier>>(options);


### PR DESCRIPTION
This fix enables GemmRewriter for r2.13 and r2.12 version, and it can avoid the crash at AMP batch Matmul without hipblas-lt support