### PR TITLE
Workaround for TF #62466

### DIFF
--- a/tensorflow/core/common_runtime/base_collective_executor.cc
+++ b/tensorflow/core/common_runtime/base_collective_executor.cc
@@ -387,28 +387,29 @@ void BaseCollectiveExecutor::CompleteParamsAsync(
       done(GetStatus(s));
     }
   };
+
+  constexpr int64_t mio = 1'000'000;
   auto timeout_microseconds = static_cast<int64_t>(
-      cp->instance.impl_details.timeout_seconds * 1'000'000);
+      cp->instance.impl_details.timeout_seconds * mio);
   if (timeout_microseconds > 0) {
     // TODO(xldrx): Share the timeout watchdog thread among collectives.
-    int timeout = cp->instance.impl_details.timeout_seconds;
+    int64_t usecs = std::min(timeout_microseconds, mio);
     SchedNonBlockingClosureAfter(
-        1'000'000, [this, is_callback_called, done, timeout]() {
-          for(int count = 0; count < timeout; count++) {
-              if(bool called = is_callback_called->exchange(false); called) {
-                return;
-              }
-              usleep(1000000);
+        usecs, [this, is_callback_called, done, timeout_microseconds, usecs]() {
+          for(auto cnt = timeout_microseconds - usecs; cnt > 0; cnt -= mio) {
+            if(bool called = is_callback_called->exchange(false); called) {
+              return;
+            }
+            usleep(mio);
           }
           // The last chance: if callback is not called, reset it and abort
-          if(bool called = is_callback_called->exchange(true); called) {
-            return; 
-          }
-          Status status(
+          if(bool called = is_callback_called->exchange(true); !called) {
+            Status status(
               absl::StatusCode::kDeadlineExceeded,
               "Collective has timed out waiting for other workers.");
-          StartAbort(status);
-          done(status);
+            StartAbort(status);
+            done(status);
+          }
         });
   }
   cem_->GetParamResolver()->CompleteParamsAsync(device, cp, cancel_mgr,

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -25,7 +25,6 @@ STATUS=$?
 if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
    TF_GPU_COUNT=$(rocm-smi -i|grep 'ID' |grep 'GPU' |wc -l)
 fi
-TF_GPU_COUNT=1
 TF_TESTS_PER_GPU=1
 N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
 
@@ -71,7 +70,7 @@ if [ -f /usertools/rocm.bazelrc ]; then
              --test_env=TF_GPU_COUNT=$TF_GPU_COUNT
 else
 	# Legacy style: run configure then build
-	#yes "" | $PYTHON_BIN_PATH configure.py
+	yes "" | $PYTHON_BIN_PATH configure.py
 
 	# Run bazel test command. Double test timeouts to avoid flakes.
 	bazel test \

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -25,6 +25,7 @@ STATUS=$?
 if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
    TF_GPU_COUNT=$(rocm-smi -i|grep 'ID' |grep 'GPU' |wc -l)
 fi
+TF_GPU_COUNT=1
 TF_TESTS_PER_GPU=1
 N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
 
@@ -70,7 +71,7 @@ if [ -f /usertools/rocm.bazelrc ]; then
              --test_env=TF_GPU_COUNT=$TF_GPU_COUNT
 else
 	# Legacy style: run configure then build
-	yes "" | $PYTHON_BIN_PATH configure.py
+	#yes "" | $PYTHON_BIN_PATH configure.py
 
 	# Run bazel test command. Double test timeouts to avoid flakes.
 	bazel test \


### PR DESCRIPTION
See https://github.com/tensorflow/tensorflow/issues/62466.

This changes the callback from sleeping for 1000 seconds and checking if the condition is satisfied, to checking it once every second and exiting as soon as it is satisfied (probably on the very first call).