### PR TITLE
Using MFMA enabled calls for batched GEMM

### DIFF
--- a/third_party/xla/xla/stream_executor/rocm/rocm_blas.h
+++ b/third_party/xla/xla/stream_executor/rocm/rocm_blas.h
@@ -208,6 +208,9 @@ class ROCMBlas : public blas::BlasSupport {
 
   ROCMBlas(const ROCMBlas &) = delete;
   void operator=(const ROCMBlas &) = delete;
+
+  bool has_mfma_ = false;
+  bool use_hgemm_alt_impl_ = false;
 };
 
 }  // namespace gpu


### PR DESCRIPTION
Strided batched GEMM rocblas interface for float16 was never switched from rocblas_hgemm_strided_batched to rocblas_gemm_strided_batched_ex, and, as a result, still uses slow non-MFMA-enabled calls. This enables MFMA calls when supported by hardware. 

It also eliminates repeated calls to hipGetDeviceProperties by checking once if the device supports MFMA and then remembering the result, and corrects  rocblas_gemm_flags_fp16_alt_impl  logic to only affect MI200.