### PR TITLE
Revert "Revert: fixes for hipblas-lt 6.0 enums and datatypes"

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -30,7 +30,7 @@ shift "$((OPTIND-1))"
 nightly=true
 
 # First positional argument (if any) specifies the ROCM_INSTALL_DIR
-ROCM_INSTALL_DIR=/opt/rocm-6.1.0-13312
+ROCM_INSTALL_DIR=/opt/rocm-6.0.0
 if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi

--- a/third_party/xla/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/third_party/xla/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -432,31 +432,31 @@ tsl::Status BlasLt::MatmulPlan::DoMatmul(
 
 namespace {
 
-template <hipblasltDatatype_t>
+template <hipDataType>
 struct HipToNativeT;
 
 template <>
-struct HipToNativeT<HIPBLASLT_R_16B> {
+struct HipToNativeT<HIP_R_16BF> {
   using type = Eigen::bfloat16;
 };
 template <>
-struct HipToNativeT<HIPBLASLT_R_16F> {
+struct HipToNativeT<HIP_R_16F> {
   using type = Eigen::half;
 };
 template <>
-struct HipToNativeT<HIPBLASLT_R_32F> {
+struct HipToNativeT<HIP_R_32F> {
   using type = float;
 };
 template <>
-struct HipToNativeT<HIPBLASLT_R_64F> {
+struct HipToNativeT<HIP_R_64F> {
   using type = double;
 };
 template <>
-struct HipToNativeT<HIPBLASLT_C_32F> {
+struct HipToNativeT<HIP_C_32F> {
   using type = complex64;
 };
 template <>
-struct HipToNativeT<HIPBLASLT_C_64F> {
+struct HipToNativeT<HIP_C_64F> {
   using type = complex128;
 };
 
@@ -487,22 +487,15 @@ tsl::Status BlasLt::MatmulPlan::ExecuteOnStream(
   }
 
   // Other data types:
-  TYPED_MATMUL(float, HIPBLASLT_R_16B, HIPBLASLT_R_16B, HIPBLASLT_R_16B,
-               HIPBLASLT_R_16B)
-  TYPED_MATMUL(float, HIPBLASLT_R_16F, HIPBLASLT_R_16F, HIPBLASLT_R_16F,
-               HIPBLASLT_R_16F)
-  TYPED_MATMUL(float, HIPBLASLT_R_16B, HIPBLASLT_R_16B, HIPBLASLT_R_32F,
-               HIPBLASLT_R_32F)
-  TYPED_MATMUL(float, HIPBLASLT_R_16F, HIPBLASLT_R_16F, HIPBLASLT_R_32F,
-               HIPBLASLT_R_32F)
-  TYPED_MATMUL(float, HIPBLASLT_R_32F, HIPBLASLT_R_32F, HIPBLASLT_R_32F,
-               HIPBLASLT_R_32F)
-  TYPED_MATMUL(double, HIPBLASLT_R_64F, HIPBLASLT_R_64F, HIPBLASLT_R_64F,
-               HIPBLASLT_R_64F)
-  TYPED_MATMUL(complex64, HIPBLASLT_C_32F, HIPBLASLT_C_32F, HIPBLASLT_C_32F,
-               HIPBLASLT_C_32F)
-  TYPED_MATMUL(complex128, HIPBLASLT_C_64F, HIPBLASLT_C_64F, HIPBLASLT_C_64F,
-               HIPBLASLT_C_64F)
+  TYPED_MATMUL(float, HIP_R_16BF, HIP_R_16BF, HIP_R_16BF, HIP_R_16BF)
+  TYPED_MATMUL(float, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F)
+  TYPED_MATMUL(float, HIP_R_16BF, HIP_R_16BF, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_16F, HIP_R_16F, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(float, HIP_R_32F, HIP_R_32F, HIP_R_32F, HIP_R_32F)
+  TYPED_MATMUL(double, HIP_R_64F, HIP_R_64F, HIP_R_64F, HIP_R_64F)
+  TYPED_MATMUL(complex64, HIP_C_32F, HIP_C_32F, HIP_C_32F, HIP_C_32F)
+  TYPED_MATMUL(complex128, HIP_C_64F, HIP_C_64F, HIP_C_64F, HIP_C_64F)
+
 #undef TYPED_MATMUL
 
   return xla::InternalError("Unexpected dtype");

--- a/third_party/xla/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/third_party/xla/xla/stream_executor/rocm/hip_blas_lt.h
@@ -43,16 +43,16 @@ class BlasLt : public gpu::BlasLt {
   struct MatrixLayout {
     static tsl::StatusOr<MatrixLayout> Create(const gpu::MatrixLayout& m);
 
-    hipblasltDatatype_t type() const { return datatype_; }
+    hipDataType type() const { return datatype_; }
     hipblasLtMatrixLayout_t get() const { return handle_.get(); }
 
    private:
-    MatrixLayout(hipblasLtMatrixLayout_t handle, hipblasltDatatype_t datatype)
+    MatrixLayout(hipblasLtMatrixLayout_t handle, hipDataType datatype)
         : handle_(handle, wrap::hipblasLtMatrixLayoutDestroy),
           datatype_(datatype) {}
 
     Owned<hipblasLtMatrixLayout_t> handle_;
-    hipblasltDatatype_t datatype_;
+    hipDataType datatype_;
   };
 
   class MatmulDesc {
@@ -64,24 +64,23 @@ class BlasLt : public gpu::BlasLt {
         Epilogue epilogue = Epilogue::kDefault,
         PointerMode pointer_mode = PointerMode::kHost);
 
-    hipblasLtComputeType_t compute_type() const { return compute_type_; }
-    hipblasltDatatype_t scale_type() const { return datatype_; }
+    hipblasComputeType_t compute_type() const { return compute_type_; }
+    hipDataType scale_type() const { return datatype_; }
     hipblasPointerMode_t pointer_mode() const {
       return HIPBLAS_POINTER_MODE_HOST;
     }
     hipblasLtMatmulDesc_t get() const { return handle_.get(); }
 
    private:
-     MatmulDesc(hipblasLtMatmulDesc_t handle,
-               hipblasLtComputeType_t compute_type,
-               hipblasltDatatype_t datatype)
+    MatmulDesc(hipblasLtMatmulDesc_t handle, hipblasComputeType_t compute_type,
+               hipDataType datatype)
         : handle_(handle, wrap::hipblasLtMatmulDescDestroy),
           compute_type_(compute_type),
           datatype_(datatype) {}
 
     Owned<hipblasLtMatmulDesc_t> handle_;
-    hipblasLtComputeType_t compute_type_;
-    hipblasltDatatype_t datatype_;
+    hipblasComputeType_t compute_type_;
+    hipDataType datatype_;
   };
 
   struct MatmulPlan : public gpu::BlasLt::MatmulPlan {

--- a/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -33,36 +33,36 @@ tsl::Status ToStatus(hipblasStatus_t status, const char* prefix) {
   return tsl::OkStatus();
 }
 
-hipblasltDatatype_t AsHipblasDataType(blas::DataType type) {
+hipDataType AsHipblasDataType(blas::DataType type) {
   switch (type) {
     case blas::DataType::kF8E5M2:
     case blas::DataType::kF8E4M3FN:
       LOG(FATAL) << "hipblaslt does not support F8 yet";
     case blas::DataType::kHalf:
-      return HIPBLASLT_R_16F;
+      return HIP_R_16F;
     case blas::DataType::kBF16:
-      return HIPBLASLT_R_16B;
+      return HIP_R_16BF;
     case blas::DataType::kFloat:
-      return HIPBLASLT_R_32F; 
+      return HIP_R_32F;
     case blas::DataType::kDouble:
-      return HIPBLASLT_R_64F;
+      return HIP_R_64F;
     case blas::DataType::kInt8:
-      return HIPBLASLT_R_8I;
+      return HIP_R_8I;
     case blas::DataType::kInt32:
-      return HIPBLASLT_R_32I;
+      return HIP_R_32I;
     case blas::DataType::kComplexFloat:
-      return HIPBLASLT_C_32F;
+      return HIP_C_32F;
     case blas::DataType::kComplexDouble:
-      return HIPBLASLT_C_64F;
+      return HIP_C_64F;
     default:
       LOG(FATAL) << "unknown data type";
   }
 }
 
-hipblasLtComputeType_t AsHipblasComputeType(blas::ComputationType type) {
+hipblasComputeType_t AsHipblasComputeType(blas::ComputationType type) {
   if (type == blas::ComputationType::kF32 ||
       type == blas::ComputationType::kTF32AsF32)
-    return HIPBLASLT_COMPUTE_F32;
+    return HIPBLAS_COMPUTE_32F;
   else
     LOG(FATAL) << "unsupported hipblaslt computation type";
 }

--- a/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.h
@@ -51,8 +51,8 @@ namespace rocm {
   TF_RETURN_IF_ERROR(::stream_executor::rocm::ToStatus(expr, #expr))
 
 tsl::Status ToStatus(hipblasStatus_t status, const char* prefix);
-hipblasltDatatype_t AsHipblasDataType(blas::DataType type);
-hipblasLtComputeType_t AsHipblasComputeType(blas::ComputationType type);
+hipDataType AsHipblasDataType(blas::DataType type);
+hipblasComputeType_t AsHipblasComputeType(blas::ComputationType type);
 hipblasOperation_t AsHipblasOperation(blas::Transpose trans);
 
 }  // namespace rocm


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/tensorflow-upstream#2355

To fix, https://ontrack-internal.amd.com/browse/SWDEV-441823