### PR TITLE
R1.15 denorm

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -21,7 +21,7 @@ TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
 
 # First positional argument (if any) specifies the ROCM_INSTALL_DIR
-ROCM_INSTALL_DIR=/opt/rocm-5.1.1
+ROCM_INSTALL_DIR=/opt/rocm-5.1.0
 if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4290,6 +4290,7 @@ tf_kernel_library(
         ":bounds_check",
         ":conv_ops",
         ":ops_util",
+	"reduction_ops",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",


### PR DESCRIPTION
back port two kernels:  DepthwiseConv2dBackpropFilterGPUKernelNHWC and DepthwiseConv2dBackpropFilterGPUKernelNCHW from tf2.x to improve performance. 