### PR TITLE
[r2.14-rocm-enhanced] Fix typo in device_description.h

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/device_description.h
+++ b/tensorflow/compiler/xla/stream_executor/device_description.h
@@ -181,7 +181,7 @@ class RocmComputeCapability {
         "gfx940",  // MI300
         "gfx941",  // MI300
         "gfx942",  // MI300
-        "gfx1030"  // Navi21
+        "gfx1030",  // Navi21
         "gfx1100"  // Navi31
     };
   }


### PR DESCRIPTION
https://github.com/ROCm/tensorflow-upstream/issues/2410
https://github.com/ROCm/tensorflow-upstream/issues/2404