### PR TITLE
[r2.15-rocm-enhanced][ROCM] adding env variable to control rocm_dnn workspace limit

### DIFF
--- a/third_party/xla/xla/service/gpu/conv_algorithm_picker.cc
+++ b/third_party/xla/xla/service/gpu/conv_algorithm_picker.cc
@@ -49,6 +49,7 @@ limitations under the License.
 #include "tsl/platform/logger.h"
 #include "tsl/platform/numbers.h"
 #include "tsl/util/proto/proto_utils.h"
+#include "tsl/util/env_var.h"
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
 #include "third_party/gpus/cudnn/cudnn.h"
@@ -71,11 +72,20 @@ class ScratchAllocator : public se::ScratchAllocator {
       : device_ordinal_(device_ordinal), memory_allocator_(memory_allocator) {}
 
   int64_t GetMemoryLimitInBytes() override {
-    return 1LL << 32;  // 4GB.  TODO(jlebar): Tune this?
+    return ScratchAllocator::GetDefaultMemoryLimitInBytes();
   }
+
   int64_t TotalAllocatedBytes() { return total_allocated_bytes_; }
 
-  StatusOr<se::DeviceMemory<uint8_t>> AllocateBytes(int64_t byte_size) override;
+  static int64_t GetDefaultMemoryLimitInBytes() {
+      int64_t value;
+      TF_CHECK_OK(tsl::ReadInt64FromEnvVar("TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 
+                1LL << 12, &value));
+      return value * (1LL << 20);
+  }
+
+  absl::StatusOr<se::DeviceMemory<uint8_t>> AllocateBytes(
+      int64_t byte_size) override;
 
   template <typename T>
   StatusOr<se::DeviceMemory<T>> Allocate(int64_t num_elements) {


### PR DESCRIPTION
This fixes the issue: https://github.com/ROCm/frameworks-internal/issues/6958