### PR TITLE
[r2.14-rocm-enhanced][ROCM] adding env variable to control rocm_dnn workspace limit

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
@@ -46,6 +46,7 @@ limitations under the License.
 #include "tensorflow/tsl/platform/logger.h"
 #include "tensorflow/tsl/platform/numbers.h"
 #include "tensorflow/tsl/util/proto/proto_utils.h"
+#include "tensorflow/tsl/util/env_var.h"
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
 #include "third_party/gpus/cudnn/cudnn.h"
@@ -68,9 +69,16 @@ class ScratchAllocator : public se::ScratchAllocator {
       : device_ordinal_(device_ordinal), memory_allocator_(memory_allocator) {}
 
   int64_t GetMemoryLimitInBytes() override {
-    return 1LL << 32;  // 4GB.  TODO(jlebar): Tune this?
+    return ScratchAllocator::GetDefaultMemoryLimitInBytes();
   }
   int64_t TotalAllocatedBytes() { return total_allocated_bytes_; }
+  static int64_t GetDefaultMemoryLimitInBytes() {
+      int64_t value;
+      TF_CHECK_OK(
+          tsl::ReadInt64FromEnvVar("TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 12, &value));
+      return value * (1LL << 20);
+  }
+
 
   StatusOr<se::DeviceMemory<uint8_t>> AllocateBytes(int64_t byte_size) override;
 


### PR DESCRIPTION
This fixes the issue: https://github.com/ROCm/frameworks-internal/issues/6958