### PR TITLE
[r2.15-rocm-enhanced] Merge PR#2453 ,touch /etc/sudoers.d/sudo-nopasswd

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm
@@ -57,4 +57,5 @@ ENV TF_NEED_ROCM=1
 ENV TF_ROCM_GCC=1
 ENV ROCM_TOOLKIT_PATH=${ROCM_PATH}
 
+RUN touch /etc/sudoers.d/sudo-nopasswd
 RUN echo 'ALL ALL=NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd


### PR DESCRIPTION
This change is helping to permanently get rid of below issue.

02:56:54  Step 29/38 : RUN echo 'ALL ALL=NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
02:56:54   ---> Running in f871d0cf3b96
02:56:54  [91mtee: /etc/sudoers.d/sudo-nopasswd: No such file or directory
02:56:54  [0mALL ALL=NOPASSWD:ALL
02:56:54  The command '/bin/sh -c echo 'ALL ALL=NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd' returned a non-zero code: 1