### PR TITLE
[develop-upstream-QA-rocm61] terminate called after throwing an instance of 'std::system_error' workaround 

### DIFF
--- a/tensorflow/core/common_runtime/base_collective_executor.cc
+++ b/tensorflow/core/common_runtime/base_collective_executor.cc
@@ -387,17 +387,26 @@ void BaseCollectiveExecutor::CompleteParamsAsync(
       done(GetStatus(s));
     }
   };
+
+  constexpr int64_t mio = 1'000'000;
   auto timeout_microseconds = static_cast<int64_t>(
-      cp->instance.impl_details.timeout_seconds * 1'000'000);
+      cp->instance.impl_details.timeout_seconds * mio);
   if (timeout_microseconds > 0) {
     // TODO(xldrx): Share the timeout watchdog thread among collectives.
+    int64_t usecs = std::min(timeout_microseconds, mio);
     SchedNonBlockingClosureAfter(
-        timeout_microseconds, [this, is_callback_called, done]() {
-          bool called = is_callback_called->exchange(true);
-          if (!called) {
+        usecs, [this, is_callback_called, done, timeout_microseconds, usecs]() {
+          for(auto cnt = timeout_microseconds - usecs; cnt > 0; cnt -= mio) {
+            if(bool called = is_callback_called->load(); called) {
+              return;
+            }
+            usleep(mio);
+          }
+          // The last chance: if callback is not called, reset it and abort
+          if(bool called = is_callback_called->exchange(true); !called) {
             Status status(
-                absl::StatusCode::kDeadlineExceeded,
-                "Collective has timed out waiting for other workers.");
+              absl::StatusCode::kDeadlineExceeded,
+              "Collective has timed out waiting for other workers.");
             StartAbort(status);
             done(status);
           }


### PR DESCRIPTION
This PR fixed sleeping threads problem: https://github.com/tensorflow/tensorflow/issues/62466 
already merged to upstream: https://github.com/ROCm/tensorflow-upstream/pull/2370

The respective Jira issue is: https://ontrack-internal.amd.com/browse/SWDEV-448642