### PR TITLE
protected code by TF_HIPBLASLT macro to make sure code builds without hipblas-lt

### DIFF
--- a/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -19,6 +19,8 @@ limitations under the License.
 #include "xla/stream_executor/blas.h"
 #include "rocm/rocm_config.h"
 
+#if TF_HIPBLASLT
+
 namespace stream_executor {
 namespace rocm {
 
@@ -78,3 +80,5 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans) {
 
 }  // namespace rocm
 }  // namespace stream_executor
+
+#endif // #TF_HIPBLASLT

--- a/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/third_party/xla/xla/stream_executor/rocm/hip_blas_utils.h
@@ -22,6 +22,8 @@ limitations under the License.
 #include "xla/stream_executor/rocm/hipblaslt_wrapper.h"
 #include "tsl/platform/errors.h"
 #include "tsl/platform/status.h"
+#if TF_HIPBLASLT
+
 
 #include "rocm/rocm_config.h"
 #if TF_ROCM_VERSION < 60000
@@ -55,5 +57,7 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans);
 
 }  // namespace rocm
 }  // namespace stream_executor
+
+#endif // TF_HIPBLASLT
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_UTILS_H_

--- a/third_party/xla/xla/stream_executor/rocm/hipblaslt_wrapper.h
+++ b/third_party/xla/xla/stream_executor/rocm/hipblaslt_wrapper.h
@@ -20,6 +20,8 @@ limitations under the License.
 #define __HIP_DISABLE_CPP_FUNCTIONS__
 
 #include "rocm/rocm_config.h"
+#if TF_HIPBLASLT
+
 #if TF_ROCM_VERSION >= 50500
 #include "rocm/include/hipblaslt/hipblaslt.h"
 #else
@@ -94,5 +96,6 @@ FOREACH_HIPBLASLT_API(HIPBLASLT_API_WRAPPER)
 
 }  // namespace wrap
 }  // namespace stream_executor
+#endif // TF_HIPBLASLT
 
 #endif  // XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_


### PR DESCRIPTION
This is from https://github.com/openxla/xla/pull/5911/commits/b4ff019b278dfc93c93f17eaab2eccd772852cd3

We will patch this to r2.15-rocm-enhanced as well.  https://github.com/ROCm/tensorflow-upstream/pull/2500