### PR TITLE
no hipblas-lt build protection

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_utils.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_utils.cc
@@ -19,6 +19,8 @@ limitations under the License.
 #include "tensorflow/compiler/xla/stream_executor/blas.h"
 #include "rocm/rocm_config.h"
 
+#if TF_HIPBLASLT
+
 namespace stream_executor {
 namespace rocm {
 
@@ -78,3 +80,4 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans) {
 
 }  // namespace rocm
 }  // namespace stream_executor
+#endif // #TF_HIPBLASLT

--- a/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_utils.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_utils.h
@@ -23,6 +23,8 @@ limitations under the License.
 #include "tensorflow/tsl/platform/errors.h"
 #include "tensorflow/tsl/platform/status.h"
 
+#if TF_HIPBLASLT
+
 #include "rocm/rocm_config.h"
 #if TF_ROCM_VERSION < 60000
 #define hipDataType hipblasDatatype_t
@@ -54,5 +56,7 @@ hipblasOperation_t AsHipblasOperation(blas::Transpose trans);
 
 }  // namespace rocm
 }  // namespace stream_executor
+
+#endif // TF_HIPBLASLT
 
 #endif  // TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_UTILS_H_

--- a/tensorflow/compiler/xla/stream_executor/rocm/hipblaslt_wrapper.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hipblaslt_wrapper.h
@@ -20,6 +20,8 @@ limitations under the License.
 #define __HIP_DISABLE_CPP_FUNCTIONS__
 
 #include "rocm/rocm_config.h"
+#if TF_HIPBLASLT
+
 #if TF_ROCM_VERSION >= 50500
 #include "rocm/include/hipblaslt/hipblaslt.h"
 #else
@@ -94,5 +96,6 @@ FOREACH_HIPBLASLT_API(HIPBLASLT_API_WRAPPER)
 
 }  // namespace wrap
 }  // namespace stream_executor
+#endif // TF_HIPBLASLT
 
 #endif  // TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_


### PR DESCRIPTION
based on https://github.com/ROCm/tensorflow-upstream/pull/2499