### PR TITLE
[DRAFT] add support of MI30X for tf1.15 + py310 [pending, requirements changed]

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -19,9 +19,10 @@
 # changes made in the current build are not working!
 TF_PKG_LOC=/tmp/tensorflow_pkg
 rm -f $TF_PKG_LOC/tensorflow*.whl
-
+set -e
+set -x
 # First positional argument (if any) specifies the ROCM_INSTALL_DIR
-ROCM_INSTALL_DIR=/opt/rocm-6.1.1
+ROCM_INSTALL_DIR=/opt/rocm
 if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi

--- a/tensorflow/python/lib/core/bfloat16.cc
+++ b/tensorflow/python/lib/core/bfloat16.cc
@@ -490,7 +490,7 @@ bool RegisterBfloat16Cast(int numpy_type, bool cast_is_safe) {
 }
 
 template <typename InType, typename OutType, typename Functor>
-void BinaryUFunc(char** args, npy_intp* dimensions, npy_intp* steps,
+void BinaryUFunc(char** args, const npy_intp* dimensions, const npy_intp* steps,
                  void* data) {
   const char* i0 = args[0];
   const char* i1 = args[1];
@@ -505,9 +505,16 @@ void BinaryUFunc(char** args, npy_intp* dimensions, npy_intp* steps,
   }
 }
 
+// this function works for python 3.9 and 1.60.0 <= numpy < 1.85.0
 template <typename Functor>
 void CompareUFunc(char** args, npy_intp* dimensions, npy_intp* steps,
                   void* data) {
+  BinaryUFunc<bfloat16, npy_bool, Functor>(args, dimensions, steps, data);
+}
+
+template <typename Functor>
+void CompareUFunc(char** args, const npy_intp* dimensions, 
+                  const npy_intp* steps, void* data) {
   BinaryUFunc<bfloat16, npy_bool, Functor>(args, dimensions, steps, data);
 }
 

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -31,7 +31,7 @@ _TF_ROCM_CONFIG_REPO = "TF_ROCM_CONFIG_REPO"
 
 _DEFAULT_ROCM_VERSION = ""
 _DEFAULT_MIOPEN_VERSION = ""
-_DEFAULT_ROCM_TOOLKIT_PATH = "/opt/rocm"
+_DEFAULT_ROCM_TOOLKIT_PATH = "/opt/rocm/bin"
 _DEFAULT_ROCM_AMDGPU_TARGETS = ["gfx942"]
 
 def _get_win_rocm_defines(repository_ctx):

--- a/third_party/protobuf/protobuf.patch
+++ b/third_party/protobuf/protobuf.patch
@@ -20,3 +20,20 @@ index 2fb26050..c2744d5b 100644
      includes = ["src/"],
      visibility = ["//visibility:public"],
  )
+diff --git a/python/google/protobuf/pyext/message.cc b/python/google/protobuf/pyext/message.cc
+index 3530a9b37..6388d401a 100644
+--- a/python/google/protobuf/pyext/message.cc
++++ b/python/google/protobuf/pyext/message.cc
+@@ -2992,7 +2992,11 @@ bool InitProto2MessageModule(PyObject *m) {
+             &RepeatedCompositeContainer_Type));
+ 
+     // Register them as collections.Sequence
++    #if PY_MAJOR_VERSION >= 3
++    ScopedPyObjectPtr collections(PyImport_ImportModule("collections.abc"));
++    #else
+     ScopedPyObjectPtr collections(PyImport_ImportModule("collections"));
++    #endif
+     if (collections == NULL) {
+       return false;
+     }
+--

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -52,6 +52,9 @@ def _execute(
       the result of repository_ctx.execute(cmdline)
     """
     result = repository_ctx.execute(cmdline)
+    print("result.stderr:\n", result.stderr)
+    print("result.stdout:\n", result.stdout)
+    return result
     if result.stderr or not (empty_stdout_fine or result.stdout):
         _fail("\n".join([
             error_msg.strip() if error_msg else "Repository command failed",
@@ -155,6 +158,8 @@ def _symlink_genrule_for_dir(
 def _get_python_bin(repository_ctx):
     """Gets the python bin path."""
     python_bin = repository_ctx.os.environ.get(_PYTHON_BIN_PATH)
+    print("_PYTHON_BIN_PATH : {}".format(_PYTHON_BIN_PATH))
+    print("python_bin : {}".format(python_bin))
     if python_bin != None:
         return python_bin
     python_bin_path = repository_ctx.which("python")


### PR DESCRIPTION
## Description

TF 1.15 is very old which does to consider the changes of Numpy ABI and updates after python 3.10.

So we need to fix those problems to make sure TF 1.15 is well supported for existing customers.

The difficulty of changes of Numpy since 1.19 requires us to have tensorflow build numpy 1.19 by applying changes in numpy side.

However python 3.10 does not work with numpy < 1.24, due to numpy ABI changes which requires more changes from numpy side (unlike to apply patches upon python + Cython)


## Soluiton

Two relase for Tf1.15:

- Tf1.15+py3.8/py3.9 : this release is used for tensorflow 1.15 with python <= 3.9, numpy < 1.19.0

- Tf1.15+py3.10/py3.12: this release is used for latest optimizatoin could be applied upon tf1.15 with python >= 3.10, numpy >= 1.24

Both versions have fixed protobuf 3.8.0 but we need make sure protobuf works well with python3.x.

Previously we only have ROC6.1 image for python 3.10 and tensorflow 2.x, for the successive release we should have 

- ROC6.1_tf1.15_py38/py39
- ROC6.1_tf2.6_py310/py312 