### PR TITLE
 [r2.16] Update llvm path after compiler change

### DIFF
--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -207,7 +207,11 @@ def _rocm_include_path(repository_ctx, rocm_config, bash_bin):
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/17/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/18/include")
     inc_dirs.append(rocm_toolkit_path + "/llvm/lib/clang/19/include")
-
+    if int(rocm_config.rocm_version_number) >= 60300:
+        inc_dirs.append(rocm_toolkit_path + "/lib/llvm/lib/clang/17/include")
+        inc_dirs.append(rocm_toolkit_path + "/lib/llvm/lib/clang/18/include")
+        inc_dirs.append(rocm_toolkit_path + "/lib/llvm/lib/clang/19/include")
+    
     # Support hcc based off clang 10.0.0 (for ROCm 3.3)
     inc_dirs.append(rocm_toolkit_path + "/hcc/compiler/lib/clang/10.0.0/include/")
     inc_dirs.append(rocm_toolkit_path + "/hcc/lib/clang/10.0.0/include")


### PR DESCRIPTION
Added the logic to add new path from ROCm >=6.3.0

To fix, https://ontrack-internal.amd.com/browse/SWDEV-470815