### PR TITLE
[ROCm] Added include of hipblas.h in hipblaslt_wrapper.h

### DIFF
--- a/third_party/xla/xla/stream_executor/rocm/hipblaslt_wrapper.h
+++ b/third_party/xla/xla/stream_executor/rocm/hipblaslt_wrapper.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "rocm/rocm_config.h"
 
 #if TF_HIPBLASLT
+#include "rocm/include/hipblas/hipblas.h"
 #if TF_ROCM_VERSION >= 50500
 #include "rocm/include/hipblaslt/hipblaslt.h"
 #else


### PR DESCRIPTION
Fixed issue from SWDEV-482396 for r2.16-rocm-enhanced branch.