### PR TITLE
[r2.17-rocm-enhanced] Disable kAllNHWC

### DIFF
--- a/third_party/xla/xla/service/gpu/gpu_layout_assignment.cc
+++ b/third_party/xla/xla/service/gpu/gpu_layout_assignment.cc
@@ -129,10 +129,6 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
     return kAllNHWC;
   }
 
-  const auto* rocm_compute_capability =
-      std::get_if<se::RocmComputeCapability>(&gpu_version);
-  if (rocm_compute_capability && input_ty == F16) return kAllNHWC;
-
   // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is
   // easy: Use NCHW.
   const bool isFloat16 = (input_ty == F16) || (input_ty == BF16);


### PR DESCRIPTION
This is a workaround for an undiagnosed MIOpen issue related to fused CBA and NHWC internal format.