### PR TITLE
Replace "Navi" with corresponding public product names

### DIFF
--- a/third_party/xla/xla/stream_executor/device_description.h
+++ b/third_party/xla/xla/stream_executor/device_description.h
@@ -200,8 +200,8 @@ class RocmComputeCapability {
         "gfx940",  // MI300
         "gfx941",  // MI300
         "gfx942",  // MI300
-        "gfx1030", // Navi21
-        "gfx1100"  // Navi31
+        "gfx1030", // RX68xx / RX69xx
+        "gfx1100"  // RX7900
   };
 };
 


### PR DESCRIPTION
The term 'Navi' is an internal product name used exclusively within AMD and should not appear in public projects. This PR replaces those 'Navi' names with the corresponding public product names.