### PR TITLE
Fixes for #9664

### DIFF
--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -725,7 +725,7 @@ inline bool isGfx10orGfx11(OpKernelContext* ctx) {
   result = hipGetDeviceProperties(&props, dev);
   if (result == hipSuccess) {
     std::string gcnArchName = props.gcnArchName;
-    return (gcnArchName.substr(0,5)=="gfx10" || gcnArchName.substr(0,5)=="gfx11");
+    return gcnArchName.substr(0,4)=="gfx1";
   }
   return false;
 }

--- a/tensorflow/core/util/gpu_launch_config.h
+++ b/tensorflow/core/util/gpu_launch_config.h
@@ -203,6 +203,8 @@ GpuLaunchConfig GetGpuLaunchConfigFixedBlockSize(
 #elif TENSORFLOW_USE_ROCM
   hipError_t err = hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &block_count, func, fixed_block_size, dynamic_shared_memory_size);
+  if (block_count < 1)
+    block_count = 1;
   CHECK_EQ(err, hipSuccess);
 #endif
   block_count = std::min(block_count * d.getNumGpuMultiProcessors(),


### PR DESCRIPTION
* Correctly treat gfx1200 as a member of gfx1* family and set warpsize to 32 in reduction.
* Handle the case of  hipOccupancyMaxActiveBlocksPerMultiprocessor returning in illegal value for an otherwise good kernel. If the kernel really can't be launched with the requested number of threads, the launch will fail and it does not matter what GetGpuLaunchConfigFixedBlockSize does, but if it can be launched and HIP API returns block_count=0 by mistake, this change allows the execution to proceed as intended.