### PR TITLE
skipping winograd in single gpu test

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -62,6 +62,7 @@ bazel test \
       --local_test_jobs=${N_TEST_JOBS} \
       --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
       --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+      --test_env=MIOPEN_DEBUG_CONV_WINOGRAD=0 \
       --test_timeout 600,900,2400,7200 \
       --build_tests_only \
       --test_output=errors \


### PR DESCRIPTION
Workaround: https://ontrack-internal.amd.com/browse/SWDEV-480036