### PR TITLE
Use `/opt/rocm/` for ROCM_INSTALL_DIR environment variable

### DIFF
--- a/build_rocm_python3
+++ b/build_rocm_python3
@@ -26,7 +26,7 @@ done
 shift "$((OPTIND-1))"
 
 # First positional argument (if any) specifies the ROCM_INSTALL_DIR
-ROCM_INSTALL_DIR=/opt/rocm-6.2.0
+ROCM_INSTALL_DIR=/opt/rocm/
 if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 fi

--- a/rocm_docs/tensorflow-build-from-source.md
+++ b/rocm_docs/tensorflow-build-from-source.md
@@ -13,7 +13,7 @@ For details of the ROCm instructions, please refer to the [ROCm QuickStart Insta
 
 To build with ROCm3.10, set the following environment variables, and add those environment variables at the end of ~/.bashrc 
 ```
-export ROCM_PATH=/opt/rocm-6.1.1
+export ROCM_PATH=/opt/rocm/
 export HCC_HOME=$ROCM_PATH/hcc
 export HIP_PATH=$ROCM_PATH/hip
 export PATH=$HCC_HOME/bin:$HIP_PATH/bin:$PATH

--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -6,7 +6,7 @@ MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 ARG ROCM_DEB_REPO=https://repo.radeon.com/rocm/apt/6.1.1/
 ARG ROCM_BUILD_NAME=ubuntu
 ARG ROCM_BUILD_NUM=main
-ARG ROCM_PATH=/opt/rocm-6.1.2
+ARG ROCM_PATH=/opt/rocm/
 ARG GPU_DEVICE_TARGETS="gfx900 gfx906 gfx908 gfx90a gfx940 gfx941 gfx942 gfx1030 gfx1100 gfx1200 gfx1201"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -29,7 +29,7 @@ if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 else
     if [[ -z "${ROCM_PATH}" ]]; then
-        ROCM_INSTALL_DIR=/opt/rocm-6.1.1
+        ROCM_INSTALL_DIR=/opt/rocm/
     else
         ROCM_INSTALL_DIR=$ROCM_PATH
     fi

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -37,7 +37,7 @@ if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 else
     if [[ -z "${ROCM_PATH}" ]]; then
-        ROCM_INSTALL_DIR=/opt/rocm-6.1.1
+        ROCM_INSTALL_DIR=/opt/rocm/
     else
         ROCM_INSTALL_DIR=$ROCM_PATH
     fi

--- a/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
@@ -38,7 +38,7 @@ if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 else
     if [[ -z "${ROCM_PATH}" ]]; then
-        ROCM_INSTALL_DIR=/opt/rocm-6.1.1
+        ROCM_INSTALL_DIR=/opt/rocm/
     else
         ROCM_INSTALL_DIR=$ROCM_PATH
     fi

--- a/third_party/xla/build_tools/rocm/run_xla.sh
+++ b/third_party/xla/build_tools/rocm/run_xla.sh
@@ -38,7 +38,7 @@ if [[ -n $1 ]]; then
     ROCM_INSTALL_DIR=$1
 else
     if [[ -z "${ROCM_PATH}" ]]; then
-        ROCM_INSTALL_DIR=/opt/rocm-6.0.2
+        ROCM_INSTALL_DIR=/opt/rocm/
     else
         ROCM_INSTALL_DIR=$ROCM_PATH
     fi


### PR DESCRIPTION
Using generic softlink `/opt/rocm` path enables seamless testing across various ROCm versions without having to explicitly pass the argument to the scripts.