### PR TITLE
CPU unit test fixes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -940,7 +940,7 @@ def retrieve_clang_version(clang_executable):
 # offset of in the current version of ubp. See
 # https://github.com/protocolbuffers/upb/blob/9effcbcb27f0a665f9f345030188c0b291e32482/upb/upb.c#L183.
 def disable_clang_offsetof_extension(clang_version):
-  if int(clang_version.split('.')[0]) in (16, 17):
+  if int(clang_version.split('.')[0]) in (16, 17, 18):
     write_to_bazelrc('build --copt=-Wno-gnu-offsetof-extensions')
 
 

--- a/configure.py
+++ b/configure.py
@@ -463,6 +463,8 @@ def set_cc_opt_flags(environ_cp):
     default_cc_opt_flags = '-mcpu=native'
   elif is_windows():
     default_cc_opt_flags = '/arch:AVX'
+  elif is_linux():
+    default_cc_opt_flags = '-mavx'
   else:
     # On all other platforms, no longer use `-march=native` as this can result
     # in instructions that are too modern being generated. Users that want

--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -55,7 +55,6 @@ else
               --config=opt \
               --build_tests_only \
               --test_output=errors \
-              --test_sharding_strategy=disabled \
               --test_size_filters=small,medium \
               --test_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
               -- \

--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -52,6 +52,7 @@ else
               --jobs=${N_BUILD_JOBS} \
               --local_test_jobs=${N_BUILD_JOBS} \
               --test_timeout 920,2400,7200,9600 \
+              --config=opt \
               --build_tests_only \
               --test_output=errors \
               --test_sharding_strategy=disabled \
@@ -63,5 +64,5 @@ else
               -//tensorflow/compiler/tf2tensorrt/... \
               -//tensorflow/core/tpu/... \
               -//tensorflow/lite/... \
-              -//tensorflow/tools/toolchains/...
+              -//tensorflow/tools/toolchains/...    
 fi


### PR DESCRIPTION
Running CPU tests without `/usertools/cpu.bazelrc` present fails due to:
- Not disabling clang extension that rejects type definitions within offsetof (a large number of tests failed to build because of this when using clang-18)
- Not using AVX instruction set (onednn_fused_matmul_ops_test failed because of this)