### PR TITLE
[ROCM] Raise device memory cap for parallel GPU execution to 5GB

### DIFF
--- a/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
+++ b/tensorflow/tools/ci_build/gpu_build/parallel_gpu_execute.sh
@@ -29,7 +29,7 @@ function is_absolute {
   [[ "$1" = /* ]] || [[ "$1" =~ ^[a-zA-Z]:[/\\].* ]]
 }
 
-export TF_PER_DEVICE_MEMORY_LIMIT_MB=${TF_PER_DEVICE_MEMORY_LIMIT_MB:-4096}
+export TF_PER_DEVICE_MEMORY_LIMIT_MB=${TF_PER_DEVICE_MEMORY_LIMIT_MB:-5120}
 
 # *******************************************************************
 #         This section of the script is needed to

--- a/third_party/xla/xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc
+++ b/third_party/xla/xla/backends/gpu/codegen/triton/fusion_emitter_device_test.cc
@@ -1445,8 +1445,6 @@ CHECK:     tt.store
 // Reproducer from b/384110192.
 TEST_F(TritonEmitterTest,
        FusionWithOutputContainingMoreThanInt32MaxElementsExecutesCorrectly) {
-  GTEST_SKIP() << "TODO(rocm): Weekly-sync 25-01-21: Skip Int32 max elements "
-                  "issue with triton.";
   // The point here is to check the output of the Triton fusion. The `slice` op
   // at the end is inserted to allow the comparison of output to run in a
   // reasonable amount of time, and has been proven to still correctly capture


### PR DESCRIPTION
Recently added unit test below is requesting more than 4GB memory to run

TritonEmitterTest.FusionWithOutputContainingMoreThanInt32MaxElementsExecutesCorrectly

With current memory cap it complains OOM at run time

W stream_executor.h:364] Not enough memory to allocate 4294967552 on device 0 within provided limit.  limit=4294967296]