### PR TITLE
CPU unit test fixes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -458,6 +458,8 @@ def set_cc_opt_flags(environ_cp):
     default_cc_opt_flags = '-mcpu=native'
   elif is_windows():
     default_cc_opt_flags = '/arch:AVX'
+  elif is_linux():
+    default_cc_opt_flags = '-mavx'
   else:
     # On all other platforms, no longer use `-march=native` as this can result
     # in instructions that are too modern being generated. Users that want

--- a/configure.py
+++ b/configure.py
@@ -935,7 +935,7 @@ def retrieve_clang_version(clang_executable):
 # offset of in the current version of ubp. See
 # https://github.com/protocolbuffers/upb/blob/9effcbcb27f0a665f9f345030188c0b291e32482/upb/upb.c#L183.
 def disable_clang_offsetof_extension(clang_version):
-  if int(clang_version.split('.')[0]) in (16, 17):
+  if int(clang_version.split('.')[0]) in (16, 17, 18):
     write_to_bazelrc('build --copt=-Wno-gnu-offsetof-extensions')
 
 

--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -63,7 +63,6 @@ else
               --config=opt \
               --build_tests_only \
               --test_output=errors \
-              --test_sharding_strategy=disabled \
               --test_size_filters=small,medium \
               --test_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
               -- \

--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -60,6 +60,7 @@ else
               --local_cpu_resources=15 \
               --local_test_jobs=${N_BUILD_JOBS} \
               --test_timeout 920,2400,7200,9600 \
+              --config=opt \
               --build_tests_only \
               --test_output=errors \
               --test_sharding_strategy=disabled \


### PR DESCRIPTION
Running CPU tests without `/usertools/cpu.bazelrc` present fails due to:

- Not disabling clang extension that rejects type definitions within offsetof (a large number of tests failed to build because of this when using clang-18)
- Not using AVX instruction set (onednn_fused_matmul_ops_test failed because of this)


Reference: https://github.com/ROCm/frameworks-internal/issues/10918