### PR TITLE
Added missing numa linked library to rccl deps

### DIFF
--- a/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/gpus/rocm/BUILD.tpl
@@ -249,10 +249,14 @@ cc_library(
     includes = [
         "%{rocm_root}/include",
     ],
+    linkopts = ["-lnuma"],
     linkstatic = 1,
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],
-    deps = [":rocm_config"],
+    deps = [
+      ":rocm_config",
+      ":system_libs",
+    ],
 )
 
 bzl_library(


### PR DESCRIPTION
Backporing of this fix: https://github.com/openxla/xla/pull/22581