### PR TITLE
Fix distributed_save_test

### DIFF
--- a/tensorflow/core/data/compression_utils.cc
+++ b/tensorflow/core/data/compression_utils.cc
@@ -233,6 +233,20 @@ Status UncompressElement(const CompressedElement& compressed,
 
 REGISTER_UNARY_VARIANT_DECODE_FUNCTION(CompressedElement,
                                        "tensorflow.data.CompressedElement");
+namespace {
+
+Status CopyCompressedElementOnDevice(
+    const CompressedElement& from, CompressedElement* to,
+    std::function<Status(const Tensor&, Tensor*)> copy_tensor_fn) {
+  *to = from;  // This assumes CompressedElement can be safely copied.
+  return OkStatus();
+}
+
+}  // namespace
+
+INTERNAL_REGISTER_UNARY_VARIANT_DEVICE_COPY_FUNCTION(
+    CompressedElement, VariantDeviceCopyDirection::DEVICE_TO_HOST,
+    CopyCompressedElementOnDevice);
 
 }  // namespace data
 }  // namespace tensorflow


### PR DESCRIPTION
Test was failing because the copy unary function was missing from the registry. 
Adding it fixes the test.