### PR TITLE
Fix distributed_save_test by switching to only use api v1

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/service/distributed_save_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/distributed_save_test.py
@@ -189,7 +189,7 @@ class DistributedSaveTest(
 
   @combinations.generate(
       combinations.times(
-          test_base.default_test_combinations(),
+          test_base.v1_only_combinations(),
           combinations.combine(
               num_workers=[1, 3],
               repeated_load=[1, 5],


### PR DESCRIPTION
it seems that the test is crashing if v2 api is used. So  switching to only use v1 api for that test.