### PR TITLE
[XLA:GPU] Fix vector bias add fusion into cuBLAS call

### DIFF
--- a/third_party/xla/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
+++ b/third_party/xla/xla/service/gpu/transforms/cublas_gemm_rewriter_test.cc
@@ -3334,6 +3334,27 @@ ENTRY test {
 )");
 }
 
+TEST_F(CublasLtGemmRewriteTest, CublasLtFullyContractingRhsWithBias) {
+  const char* hlo_text = R"(
+HloModule test
+ENTRY test {
+  param_0 = bf16[10240,1024]{1,0} parameter(0)
+  param_1 = bf16[1024,1]{1,0} parameter(1)
+  dot = bf16[10240,1]{1,0} dot(param_0, param_1), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+  transpose = bf16[10240,1]{1,0} transpose(dot), dimensions={0,1}
+  param_2 = bf16[1]{0} parameter(2)
+  reshape = bf16[1]{0} reshape(param_2)
+  broadcast = bf16[10240,1]{1,0} broadcast(reshape), dimensions={1}
+  ROOT out = bf16[10240,1]{1,0} add(transpose, broadcast)
+}
+)";
+  MatchOptimizedHlo(hlo_text, R"(
+; CHECK: [[P_2:%[^ ]+]] = bf16[1]{0} parameter(2)
+; CHECK: [[BIAS:%[^ ]+]] = bf16[10240]{0} {{.+}}([[P_2]])
+; CHECK: custom-call({{.+}}, {{.+}}, [[BIAS]]), custom_call_target="__cublas$lt$matmul"
+)");
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/third_party/xla/xla/service/gpu/transforms/gemm_rewriter.cc
+++ b/third_party/xla/xla/service/gpu/transforms/gemm_rewriter.cc
@@ -1770,6 +1770,14 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
         return false;
       }
     }
+    // If rhs operand has no non-contracting dims, guarantee bias vector length
+    // will still match matrix D rows with CUBLASLT_EPILOGUE_BIAS epilogue
+    // (https://docs.nvidia.com/cuda/cublas/index.html#cublasltepilogue-t).
+    if (num_col_dims == 0) {
+      std::unique_ptr<HloInstruction> bias_broadcasted =
+          broadcast->CloneWithNewOperands(broadcast->shape(), {bias});
+      bias = broadcast->parent()->AddInstruction(std::move(bias_broadcasted));
+    }
 
     // In the case of high rank input for FP8, it is necessary to consider
     // potential padding for the bias.


### PR DESCRIPTION
If RHS operand of GEMM has no non-contracting dims, broadcast bias vector to guarantee its length will still match matrix D rows with CUBLASLT_EPILOGUE_BIAS epilogue required by
(https://docs.nvidia.com/cuda/cublas/index.html#cublasltepilogue-t).