### PR TITLE
[QA65] explict install gcc-toolset-13

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.manylinux_2_28
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.manylinux_2_28
@@ -10,7 +10,7 @@ RUN echo -e "[build_system]\nname=ROCm\nbaseurl=https://repo.almalinux.org/build
 
 # Setup c++ dev
 # TODO: Only install what is needed
-RUN dnf group install -y "Development Tools" && dnf install -y llvm-toolset
+RUN dnf group install -y "Development Tools" && dnf install -y llvm-toolset gcc-toolset-13
 
 # Install dependencies
 COPY setup.packages.rocm.el8.sh setup.packages.rocm.el8.sh

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.build-python_manylinux_2_28.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.build-python_manylinux_2_28.sh
@@ -29,8 +29,8 @@ if [ "$PYTHON_VERSION" = "3.9" ]; then
     ln -sf /usr/local/bin/python3.9 /usr/bin/python3 && ln -sf /usr/local/bin/pip3.9 /usr/bin/pip3
     ln -sf /usr/local/lib/python3.9 /usr/lib/tf_python
 
-    scl enable gcc-toolset-14 'bash'
-    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-14/root/usr/bin/ld /usr/bin/ld
+    scl enable gcc-toolset-13 'bash'
+    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-13/root/usr/bin/ld /usr/bin/ld
 
     NUMPY_VERSION=1.20.3
 elif [ "$PYTHON_VERSION" = "3.10" ]; then
@@ -43,8 +43,8 @@ elif [ "$PYTHON_VERSION" = "3.10" ]; then
     ln -sf /usr/local/bin/python3.10 /usr/bin/python3 && ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
     ln -sf /usr/local/lib/python3.10 /usr/lib/tf_python
 
-    scl enable gcc-toolset-14 'bash'
-    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-14/root/usr/bin/ld /usr/bin/ld
+    scl enable gcc-toolset-13 'bash'
+    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-13/root/usr/bin/ld /usr/bin/ld
 
     NUMPY_VERSION=1.21.4
 elif [ "$PYTHON_VERSION" = "3.11" ]; then
@@ -57,8 +57,8 @@ elif [ "$PYTHON_VERSION" = "3.11" ]; then
     ln -sf /usr/local/bin/python3.11 /usr/bin/python3 && ln -sf /usr/local/bin/pip3.11 /usr/bin/pip3
     ln -sf /usr/local/lib/python3.11 /usr/lib/tf_python
 
-    scl enable gcc-toolset-14 'bash'
-    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-14/root/usr/bin/ld /usr/bin/ld
+    scl enable gcc-toolset-13 'bash'
+    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-13/root/usr/bin/ld /usr/bin/ld
 
     NUMPY_VERSION=1.21.4
 elif [ "$PYTHON_VERSION" = "3.12" ]; then
@@ -71,8 +71,8 @@ elif [ "$PYTHON_VERSION" = "3.12" ]; then
     ln -sf /usr/local/bin/python3.12 /usr/bin/python3 && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3
     ln -sf /usr/local/lib/python3.12 /usr/lib/tf_python
 
-    scl enable gcc-toolset-14 'bash'
-    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-14/root/usr/bin/ld /usr/bin/ld
+    scl enable gcc-toolset-13 'bash'
+    rm -f /usr/bin/ld && ln -s /opt/rh/gcc-toolset-13/root/usr/bin/ld /usr/bin/ld
 
     NUMPY_VERSION=1.26.0
 else


### PR DESCRIPTION
Since "llvm-toolset" package is installing "gcc-toolset-14" default so keep explict install of "gcc-toolset-13"

Defect: https://ontrack-internal.amd.com/browse/SWDEV-533510

TF 2.18 has already explict install of "gcc-toolset-13" and working.