### PR TITLE
Fix rng test gpu by limiting threads in threadpool to 20

### DIFF
--- a/tensorflow/dtensor/python/tests/BUILD
+++ b/tensorflow/dtensor/python/tests/BUILD
@@ -869,6 +869,7 @@ dtensor_test(
         "gpu": 30,
         TPU_V3_DONUT_BACKEND: 20,
     },
+    env = { "TF_NUM_INTEROP_THREADS": "20" },
     deps = [
         ":test_util",
         "//tensorflow/dtensor/python:api",


### PR DESCRIPTION
This PR fixes the issue:
https://ontrack-internal.amd.com/browse/SWDEV-532037