### PR TITLE
[SWDEV-538480] fixed files not existed issue

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -153,5 +153,8 @@ echo $ROCM_PATH
 echo $GPU_DEVICE_TARGETS
 
 # Ensure the ROCm target list is set up
-printf '%s\n' ${GPU_DEVICE_TARGETS} | tee -a "$ROCM_PATH/bin/target.lst"
+mkdir -p "$ROCM_PATH/bin"
+mkdir -p "$ROCM_PATH/.info"
+
+printf '%s\n' ${GPU_DEVICE_TARGETS} | tee "$ROCM_PATH/bin/target.lst"
 touch "${ROCM_PATH}/.info/version"


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-538480

```
14:43:18  #18 26.56 tee: /opt/rocm-7.0.0/bin/target.lst: No such file or directory
14:43:18  #18 26.56 gfx942
14:43:18  #18 26.56 + touch /opt/rocm-7.0.0/.info/version
14:43:18  #18 26.56 touch: cannot touch '/opt/rocm-7.0.0/.info/version': No such file or directory
14:43:18  #18 ERROR: process "/bin/sh -c /setup.rocm.sh $ROCM_VERSION buster" did not complete successfully: exit code: 1
```