### PR TITLE
PR #27876: [ROCm] Fix reduction emitter for adapting to warp size 64

### DIFF
--- a/third_party/xla/xla/service/gpu/fusions/reduction_mlir.cc
+++ b/third_party/xla/xla/service/gpu/fusions/reduction_mlir.cc
@@ -676,7 +676,8 @@ llvm::SmallVector<mlir::Value> MlirColumnReductionFusion::EmitReduction(
   HloValueMap inits = GetInits(group_id, state);
   auto per_thread =
       state.EmitPerThreadElements(group_id, inits, state.FusionOutputs());
-  return state.ReduceViaSharedMemory(group_id, per_thread, inits);
+  return state.ReduceViaSharedMemory(group_id, per_thread, inits, std::nullopt,
+                                     kTileSize / 2);
 }
 
 MlirSmallColumnReductionFusion::MlirSmallColumnReductionFusion(


### PR DESCRIPTION
Imported from GitHub PR https://github.com/openxla/xla/pull/27876

Max distance for shuffling during warp reduction should be set to 16 since we still preserve 32x32 tiling in column reduction.

Fixed failing tests:
[  FAILED  ] ReduceTest.VectorizedReduce_Max
[  FAILED  ] ReduceTest.ReduceR2_1000x1500_To_R1
[  FAILED  ] ReduceTest.VectorizedReduce_Add
[  FAILED  ] ReduceTest.ReduceR2_1024x1024_To_R1
[  FAILED  ] ReduceTest.VectorizedReduce_Multiply
[  FAILED  ] ReduceTest.VectorizedReduce_Min
[  FAILED  ] ReduceR3ToR2Test_Instantiation/ReduceR3ToR2Test.ReduceR3ToR2/17 Copybara import of the project:

--
d40b5e6c5b01ebcce3e4da4071b346f58c4a3ebc by Jian Li <Jian.Li@amd.com>:

[ROCm] Fix reduction emitter for adapting to warp size 64

Max distance for shuffling during warp reduction should be set to 16 since we still preserve 32x32 tiling in column reduction.

Fixed failing tests:
[  FAILED  ] ReduceTest.VectorizedReduce_Max
[  FAILED  ] ReduceTest.ReduceR2_1000x1500_To_R1
[  FAILED  ] ReduceTest.VectorizedReduce_Add
[  FAILED  ] ReduceTest.ReduceR2_1024x1024_To_R1
[  FAILED  ] ReduceTest.VectorizedReduce_Multiply
[  FAILED  ] ReduceTest.VectorizedReduce_Min
[  FAILED  ] ReduceR3ToR2Test_Instantiation/ReduceR3ToR2Test.ReduceR3ToR2/17

Merging this change closes #27876

PiperOrigin-RevId: 775119933