### PR TITLE
Fix py test failure due to thread creation issue

### DIFF
--- a/tensorflow/dtensor/python/tests/BUILD
+++ b/tensorflow/dtensor/python/tests/BUILD
@@ -869,7 +869,6 @@ dtensor_test(
         "gpu": 30,
         TPU_V3_DONUT_BACKEND: 20,
     },
-    env = { "TF_NUM_INTEROP_THREADS": "20" },
     deps = [
         ":test_util",
         "//tensorflow/dtensor/python:api",

--- a/tensorflow/dtensor/python/tests/test_util.py
+++ b/tensorflow/dtensor/python/tests/test_util.py
@@ -173,6 +173,7 @@ class DTensorBaseTest(tf_test.TestCase, parameterized.TestCase):
     # Make sure all async ops finish.
     try:
       context.async_wait()
+      context._context.ensure_uninitialized()
     finally:
       # TODO(hthu): Remove the reset once we fixed the CopyToMesh with
       # DefaultMesh placement issue.

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -764,6 +764,7 @@ class Context:
       if self._is_global_context:
         pywrap_tfe.TFE_Py_SetCEagerContext(None)
 
+      pywrap_tfe.TFE_DeleteContext(self._context_handle)
       self._context_handle = None
 
   def mark_as_global_context(self):

--- a/tensorflow/python/tfe_wrapper.cc
+++ b/tensorflow/python/tfe_wrapper.cc
@@ -810,6 +810,7 @@ PYBIND11_MODULE(_pywrap_tfe, m) {
       py::return_value_policy::reference);
   m.def("TFE_DeleteContext", [](py::handle& o) {
     TFE_DeleteContext(tensorflow::InputTFE_Context(o));
+    PyCapsule_SetDestructor(o.ptr(), nullptr);
   });
   m.def(
       "TFE_ContextListDevices",


### PR DESCRIPTION
Fixing issue with the consequent tests execution and the thread creation limit hit.


The issue was that we create threadpools with 200 threads each. These threadpools are only released by the gc of python. It come out that at some point we just hit the limit of the threads we can create. 
This fix does release the context (threadpool) in a test teardown call making sure we do not have this issue anymore.