### PR TITLE
Add bf16 starting from gfx11, bugfix & optimize RocmComputeCapability

### DIFF
--- a/third_party/xla/xla/service/algorithm_util.cc
+++ b/third_party/xla/xla/service/algorithm_util.cc
@@ -173,7 +173,7 @@ bool IsSupportedByElementalIrEmitter(PrecisionConfig::Algorithm algorithm) {
 // input/output storage types.
 bool IsSupportedDotAlgorithmOnGpu(
     PrecisionConfig::Algorithm algorithm,
-    stream_executor::GpuComputeCapability gpu_compute_capability,
+    const stream_executor::GpuComputeCapability& gpu_compute_capability,
     PrimitiveType input_storage_type, PrimitiveType output_storage_type) {
   // Note: We may want to add some complex types here if people request that.
   const bool is_cuda_ge_ampere =
@@ -194,6 +194,12 @@ bool IsSupportedDotAlgorithmOnGpu(
       std::get<se::RocmComputeCapability>(gpu_compute_capability)
           .gfx9_mi100_or_later();
 
+  const bool is_rocm_bf16 =
+      std::holds_alternative<se::RocmComputeCapability>(
+          gpu_compute_capability) &&
+      std::get<se::RocmComputeCapability>(gpu_compute_capability)
+          .has_bf16_dtype_support();
+
   switch (algorithm) {
     case PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32:
     case PrecisionConfig::ALG_DOT_ANY_F8_ANY_F8_F32_FAST_ACCUM:
@@ -207,7 +213,7 @@ bool IsSupportedDotAlgorithmOnGpu(
       return input_storage_type == F16 &&
              (output_storage_type == F16 || output_storage_type == F32);
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32:
-      if (!is_cuda_ge_ampere && !is_rocm_mi100_and_above) return false;
+      if (!is_cuda_ge_ampere && !is_rocm_bf16) return false;
       switch (input_storage_type) {
         case BF16:
           return output_storage_type == BF16 || output_storage_type == F32;
@@ -218,7 +224,7 @@ bool IsSupportedDotAlgorithmOnGpu(
       }
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X3:
     case PrecisionConfig::ALG_DOT_BF16_BF16_F32_X6:
-      return (is_cuda_ge_ampere || is_rocm_mi100_and_above) &&
+      return (is_cuda_ge_ampere || is_rocm_bf16) &&
              input_storage_type == F32 && output_storage_type == F32;
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32_X3:
     case PrecisionConfig::ALG_DOT_TF32_TF32_F32:

--- a/third_party/xla/xla/service/algorithm_util.h
+++ b/third_party/xla/xla/service/algorithm_util.h
@@ -70,7 +70,7 @@ bool IsSupportedByElementalIrEmitter(PrecisionConfig::Algorithm algorithm);
 // input/output storage types.
 bool IsSupportedDotAlgorithmOnGpu(
     PrecisionConfig::Algorithm algorithm,
-    stream_executor::GpuComputeCapability gpu_compute_capability,
+    const stream_executor::GpuComputeCapability& gpu_compute_capability,
     PrimitiveType input_storage_type, PrimitiveType output_storage_type);
 
 }  // namespace algorithm_util

--- a/third_party/xla/xla/stream_executor/device_description.h
+++ b/third_party/xla/xla/stream_executor/device_description.h
@@ -20,8 +20,10 @@ limitations under the License.
 #ifndef XLA_STREAM_EXECUTOR_DEVICE_DESCRIPTION_H_
 #define XLA_STREAM_EXECUTOR_DEVICE_DESCRIPTION_H_
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -29,6 +31,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
@@ -54,91 +57,6 @@ class RocmComputeCapability {
 
   std::string gcn_arch_name() const { return gcn_arch_name_; }
 
-  std::string gfx_version() const {
-    std::vector<std::string> tokens = absl::StrSplit(gcn_arch_name_, ':');
-    return tokens[0];
-  }
-
-  bool is_supported_gfx_version() const {
-    return absl::c_count(kSupportedGfxVersions, gfx_version()) != 0;
-  }
-
-  std::string supported_gfx_versions_str() const {
-    return absl::StrJoin(kSupportedGfxVersions, ", ");
-  }
-
-  bool gfx9_mi100() const { return gfx_version() == "gfx908"; }
-
-  bool gfx9_mi200() const { return gfx_version() == "gfx90a"; }
-
-  bool gfx9_mi300() const { return gfx_version() == "gfx942"; }
-
-  bool gfx9_mi350() const { return gfx_version() == "gfx950"; }
-
-  bool gfx9_mi100_or_later() const {
-    static constexpr absl::string_view kList[] = {"gfx908", "gfx90a", "gfx942", "gfx950"};
-    return absl::c_count(kList, gfx_version()) != 0;
-  }
-
-  bool gfx9_mi200_or_later() const {
-    static constexpr absl::string_view kList[] = {"gfx90a", "gfx942", "gfx950"};
-    return absl::c_count(kList, gfx_version()) != 0;
-  }
-
-  bool gfx10_rx68xx() const { return gfx_version() == "gfx1030"; }
-
-  bool gfx10_rx69xx() const { return gfx_version() == "gfx1030"; }
-
-  bool gfx11_rx7900() const { return (gfx_version() == "gfx1100" ||
-                                      gfx_version() == "gfx1101" ||
-                                      gfx_version() == "gfx1102"); }
-
-  bool gfx12_rx8900() const { return ((gfx_version() == "gfx1200") || 
-                                      (gfx_version() == "gfx1201")); }
-
-  bool gfx1200() const { return gfx_version() == "gfx1200"; }
-
-  bool gfx1201() const { return gfx_version() == "gfx1201"; }
-
-  bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_bf16_dtype_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_fast_fp16_support() const {
-    return gfx9_mi100_or_later() || gfx10_rx68xx() || gfx10_rx69xx() ||
-           gfx11_rx7900();
-  }
-
-  bool has_mfma_instr_support() const { return gfx9_mi100_or_later(); }
-
-  bool has_amd_matrix_core() const {
-    return (gfx9_mi100_or_later() || gfx_version().find("gfx11") ||
-            gfx_version().find("gfx12"));
-  }
-
-  bool has_fp16_atomics_support() const {
-    // TODO(rocm): Check. This should be the same as has_fast_fp16_support().
-    return gfx9_mi200_or_later();
-  }
-
-  bool fence_before_barrier() const {
-    return gfx_version() != "gfx900" && gfx_version() != "gfx906";
-  }
-
-  bool has_hipblaslt() const {
-    return gfx9_mi200_or_later() || gfx1200() || gfx1201();
-  }
-
-  bool has_hipblaslt_mx_support() const { return gfx9_mi350(); }
-
-  bool has_fp8_support() const {
-    return has_ocp_fp8_support() || has_nanoo_fp8_support();
-  }
-
-  bool has_ocp_fp8_support() const { return gfx1200() || gfx1201() || gfx9_mi350(); }
-
-  bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
-
   std::string ToString() const { return gcn_arch_name(); }
 
   RocmComputeCapabilityProto ToProto() const {
@@ -151,20 +69,141 @@ class RocmComputeCapability {
     return gcn_arch_name_ == other.gcn_arch_name_;
   }
 
- private:
-  std::string gcn_arch_name_ = "gfx000";  // default to invalid arch.
+  std::string gfx_version() const {
+    //  std::strchr() is faster for the case than std::string::find()
+    const char *const p_colon = std::strchr(gcn_arch_name_.c_str(), ':');
+    if (nullptr == p_colon) {
+      return gcn_arch_name_;  // likely it's the default invalid value
+    }
+    return std::string(gcn_arch_name_.c_str(), p_colon);
+  }
 
+  // note, while there's no particular reason to make the lists public, it won't
+  // hurt since they are immutable, but keeping them close to methods simplifies
+  // maintanance.
   static constexpr absl::string_view kSupportedGfxVersions[]{
-      "gfx900",
-      "gfx906",
-      "gfx908",
-      "gfx90a",
-      "gfx942",
-      "gfx950",
-      "gfx1030",
-      "gfx1100", "gfx1101", "gfx1102",
-      "gfx1200", "gfx1201",
+      "gfx900",   // MI25
+      "gfx906",   // MI50 / MI60
+      "gfx908",   // MI100
+      "gfx90a",   // MI200
+      "gfx942",   // MI300
+      "gfx950",   // MI350
+      "gfx1030",  // RX68xx / RX69xx
+      "gfx1100",  // RX7900
+      "gfx1101",  // RX7700 / RX7800
+      "gfx1103", "gfx1150", "gfx1151", "gfx1200", "gfx1201",
   };
+
+  bool is_supported_gfx_version() const {
+    return IsThisGfxInAnyList(kSupportedGfxVersions);
+  }
+
+  std::string supported_gfx_versions_str() const {
+    return absl::StrJoin(kSupportedGfxVersions, ", ");
+  }
+
+  bool gfx9_mi100() const { return gfx_version() == "gfx908"; }
+
+  static constexpr absl::string_view kMI100Series[] = {"gfx908"};
+
+  bool gfx9_mi200() const { return gfx_version() == "gfx90a"; }
+
+  static constexpr absl::string_view kMI200Series[] = {"gfx90a"};
+
+  bool gfx9_mi300() const { return gfx_version() == "gfx942"; }
+
+  bool gfx9_mi350() const { return gfx_version() == "gfx950"; }
+
+  static constexpr absl::string_view kMI300Series[] = {"gfx942", "gfx950"};
+  bool gfx9_mi300_series() const { return IsThisGfxInAnyList(kMI300Series); }
+
+  bool gfx9_mi100_or_later() const {
+    return IsThisGfxInAnyList(kMI300Series, kMI200Series, kMI100Series);
+  }
+
+  bool gfx9_mi200_or_later() const {
+    return IsThisGfxInAnyList(kMI300Series, kMI200Series);
+  }
+
+  bool gfx10_rx68xx() const { return gfx_version() == "gfx1030"; }
+
+  bool gfx10_rx69xx() const { return gfx_version() == "gfx1030"; }
+
+  bool gfx11() const { return absl::StartsWith(gfx_version(), "gfx11"); }
+
+  static constexpr absl::string_view kGfx11Discrete[] = {"gfx1100", "gfx1101"};
+  bool gfx11_discrete() const { return IsThisGfxInAnyList(kGfx11Discrete); }
+
+  static constexpr absl::string_view kGfx11Apu[] = {"gfx1103", "gfx1150",
+                                                    "gfx1151"};
+  bool gfx11_apu() const { return IsThisGfxInAnyList(kGfx11Apu); }
+
+  bool gfx12() const { return absl::StartsWith(gfx_version(), "gfx12"); }
+
+  static constexpr absl::string_view kGfx12Discrete[] = {"gfx1200", "gfx1201"};
+  bool gfx12_discrete() const { return IsThisGfxInAnyList(kGfx12Discrete); }
+
+  bool has_nhwc_layout_support() const { return gfx9_mi100_or_later(); }
+
+  bool has_bf16_dtype_support() const {
+    return gfx9_mi100_or_later() || gfx12() || gfx11();
+  }
+
+  bool has_fast_fp16_support() const {
+    return gfx9_mi100_or_later() || gfx11() || gfx10_rx68xx() || gfx10_rx69xx();
+  }
+
+  bool has_mfma_instr_support() const { return gfx9_mi100_or_later(); }
+
+  bool has_amd_matrix_core() const {
+    return gfx9_mi100_or_later() || gfx12() || gfx11();
+  }
+
+  bool has_packed_fp16_atomics_support() const { return gfx9_mi100_or_later(); }
+
+  bool has_packed_bf16_atomics_support() const { return gfx9_mi300_series(); }
+
+  bool fence_before_barrier() const {
+    static constexpr absl::string_view kList[] = {"gfx900", "gfx906"};
+    return !IsThisGfxInAnyList(kList);
+  }
+
+  bool has_hipblaslt() const {
+    return IsThisGfxInAnyList(kMI300Series, kMI200Series, kGfx12Discrete,
+                              kGfx11Discrete, kGfx11Apu);
+  }
+
+  bool has_hipblaslt_mx_support() const { return gfx9_mi350(); }
+
+  bool has_fp8_support() const {
+    return has_ocp_fp8_support() || has_nanoo_fp8_support();
+  }
+
+  bool has_ocp_fp8_support() const { return gfx9_mi350() || gfx12_discrete(); }
+
+  bool has_nanoo_fp8_support() const { return gfx9_mi300(); }
+
+ private:
+  /// \brief Takes one or more arrays of string-like objects and tests if the
+  /// result of `gfx_version()` matches to any string in any of the arrays.
+  template <typename... ArrayOfStrings>
+  bool IsThisGfxInAnyList(ArrayOfStrings &&...arr) const {
+    static_assert(sizeof...(arr) >= 1);
+    const auto gfx = gfx_version();
+    return (implIsThisGfxInAnyList(std::begin(arr), std::end(arr), gfx) || ...);
+  }
+
+  /// \brief Template-less implementation of IsThisGfxInAnyList().
+  /// \warning Don't use directly!
+  bool implIsThisGfxInAnyList(const absl::string_view *beg,
+                              const absl::string_view *end,
+                              const std::string &gfx) const {
+    return std::any_of(beg, end, [&gfx = gfx](const absl::string_view &s) {
+      return gfx == s;
+    });
+  }
+
+  std::string gcn_arch_name_ = "gfx000";  // default to invalid arch.
 };
 
 using GpuComputeCapability =


### PR DESCRIPTION
The PR enables use of BF16 for dot algorithms on Navi3x and Navi4x, and bugfixes and optimizes class RocmComputeCapability.

Syncronizes the files with https://github.com/ROCm/xla/pull/303 into `rocm-jaxlib-v0.6.0` branch