### PR TITLE
Update deb 10 dockerfile

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.deb10
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.deb10
@@ -3,7 +3,7 @@ ARG DISTRO_IMG
 #FROM ${DISTRO_IMG:-'compute-artifactory.amd.com:5000/rocm-base-images/debian-10:2025022301-6.4-47'} as runtime
 #FROM ${DISTRO_IMG:-'compute-artifactory.amd.com:5000/rocm-base-images/debian-10:2025032101-6.5-15845'} as runtime
 #FROM ${DISTRO_IMG:-'compute-artifactory.amd.com:5000/rocm-base-images/debian-10:2025022301-6.4.1-60'} as runtime
-FROM ${DISTRO_IMG:-'debian:buster-20240612'} as runtime
+FROM ${DISTRO_IMG:-'registry-sc-harbor.amd.com/rocm-base-images/debian-10:2025081801'} as runtime
 ################################################################################
 
 ARG GPU_DEVICE_TARGETS

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.packages.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.packages.sh
@@ -26,7 +26,7 @@ else
 # Prevent apt install tzinfo from asking our location (assumes UTC)
 export DEBIAN_FRONTEND=noninteractive
 
-#apt-get update
+apt-get update
 # Remove commented lines and blank lines
 apt-get install -y --no-install-recommends $(sed -e '/^\s*#.*$/d' -e '/^\s*$/d' "$1" | sort -u)
 rm -rf /var/lib/apt/lists/*

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.packages.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.packages.sh
@@ -26,7 +26,7 @@ else
 # Prevent apt install tzinfo from asking our location (assumes UTC)
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+#apt-get update
 # Remove commented lines and blank lines
 apt-get install -y --no-install-recommends $(sed -e '/^\s*#.*$/d' -e '/^\s*$/d' "$1" | sort -u)
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Motivation

Debian 10 is EOL 

## Technical Details

apt update fail so we are removing the deprecated repo
## Test Plan

run a test with updated docker

## Test Result

Success - http://rocm-ci.amd.com/job/tf_whl_docker/1614/

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
