### PR TITLE
Remove usage of hipGetLastError from GpuLaunchKernel to avoid false

### DIFF
--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -134,9 +134,17 @@ Status GpuLaunchKernel(void (*function)(Ts...), dim3 grid_dim, dim3 block_dim,
       return errors::Internal(cudaGetErrorString(result));
     }
 #elif TENSORFLOW_USE_ROCM
-    hipLaunchKernelGGL(function, grid_dim, block_dim, shared_memory_size_bytes,
-                       stream, std::forward<Args>(arguments)...);
-    TF_RETURN_IF_CUDA_ERROR(hipGetLastError());
+    constexpr size_t count = sizeof...(Args);
+    auto tup_ = std::tuple<Args...>{arguments...};
+    auto tup = validateArgsCountType(function, tup_);
+    void* _Args[count];
+    pArgs<0>(tup, _Args);
+    auto k = reinterpret_cast<void*>(function);
+    auto result =
+        hipLaunchKernel(k, grid_dim, block_dim, _Args, shared_memory_size_bytes, stream);
+    if (result != hipSuccess) {
+      return errors::Internal(hipGetErrorString(result));
+    }
 #endif
   }
   return OkStatus();


### PR DESCRIPTION
failures.

## Motivation

Fix SWDEV-547277

## Technical Details

hipGetLastError changed behaviour - returns last error even if last call was successfu

## Test Plan

Fixes: //tensorflow/python/ops:init_ops_test_gpu

## Test Result

Test pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
