### PR TITLE
[develop-upstream] Fix rocm.bazelrc and clean testing scripts

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -43,66 +43,21 @@ export TF_PYTHON_VERSION=$PYTHON_VERSION
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR
 
-if [ -f /usertools/rocm.bazelrc ]; then
-	 # Use the bazelrc files in /usertools if available
-  	if [ ! -d /tf ];then
-	   # The bazelrc files in /usertools expect /tf to exist
-           mkdir /tf
-	fi
-	bazel \
-           --bazelrc=/usertools/rocm.bazelrc \
-           test \
-           --local_test_jobs=${N_TEST_JOBS} \
-           --jobs=30 \
-           --local_ram_resources=60000 \
-           --local_cpu_resources=15 \
-           --config=sigbuild_local_cache \
-           --config=rocm \
-           --config=nonpip_multi_gpu \
-           --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION
-else
-	# Legacy style: run configure then build
-        yes "" | $PYTHON_BIN_PATH configure.py
-
-        # Run bazel test command. Double test timeouts to avoid flakes.
-        bazel test \
-              --config=rocm \
-              -k \
-              --test_tag_filters=-no_gpu,-cuda-only \
-              --jobs=30 \
-              --local_ram_resources=60000 \
-              --local_cpu_resources=15 \
-              --local_test_jobs=${N_TEST_JOBS} \
-              --test_timeout 920,2400,7200,9600 \
-              --build_tests_only \
-              --test_output=errors \
-              --test_sharding_strategy=disabled \
-              --test_size_filters=small,medium,large \
-              --cache_test_results=no \
-              --test_env=TF_PER_DEVICE_MEMORY_LIMIT_MB=2048 \
-              --test_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
-              -- \
-        //tensorflow/core/nccl:nccl_manager_test_2gpu \
-        //tensorflow/python/distribute/integration_test:mwms_peer_failure_test_2gpu \
-        //tensorflow/python/distribute:checkpoint_utils_test_2gpu \
-        //tensorflow/python/distribute:checkpointing_test_2gpu \
-        //tensorflow/python/distribute:collective_all_reduce_strategy_test_xla_2gpu \
-        //tensorflow/python/distribute:custom_training_loop_gradient_test_2gpu \
-        //tensorflow/python/distribute:custom_training_loop_input_test_2gpu \
-        //tensorflow/python/distribute:distribute_utils_test_2gpu \
-        //tensorflow/python/distribute:input_lib_test_2gpu \
-        //tensorflow/python/distribute:input_lib_type_spec_test_2gpu \
-        //tensorflow/python/distribute:metrics_v1_test_2gpu \
-        //tensorflow/python/distribute:mirrored_variable_test_2gpu \
-        //tensorflow/python/distribute:parameter_server_strategy_test_2gpu \
-        //tensorflow/python/distribute:ps_values_test_2gpu \
-        //tensorflow/python/distribute:random_generator_test_2gpu \
-        //tensorflow/python/distribute:test_util_test_2gpu \
-        //tensorflow/python/distribute:tf_function_test_2gpu \
-        //tensorflow/python/distribute:vars_test_2gpu \
-        //tensorflow/python/distribute:warm_starting_util_test_2gpu \
-        //tensorflow/python/training:saver_test_2gpu
+if [ ! -d /tf ];then
+    # The bazelrc files in /usertools expect /tf to exist
+        mkdir /tf
 fi
+
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
+        --local_test_jobs=${N_TEST_JOBS} \
+        --jobs=30 \
+        --local_ram_resources=60000 \
+        --local_cpu_resources=15 \
+        --verbose_failures \
+        --config=rocm \
+        --config=nonpip_multi_gpu \
+        --config=sigbuild_local_cache \
+        --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION
 
 
 #  Started failing with 210906 sync

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -59,11 +59,17 @@ if [ -z "$TARGET_ARCHS" ]; then
     exit 1
 fi
 
+if [ ! -d /tf ];then
+    # The bazelrc files in /usertools expect /tf to exist
+        mkdir /tf
+fi
+
 # Run bazel test command. Double test timeouts to avoid flakes.
-bazel test \
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
     --config=rocm \
+    --config=sigbuild_local_cache \
+    --config=pycpp \
     -k \
-    --test_tag_filters=gpu,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-cuda-only,-benchmark-test,-rocm_multi_gpu,-tpu,-v1only \
     --jobs=${N_BUILD_JOBS} \
     --local_test_jobs=${N_TEST_JOBS} \
     --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
@@ -73,11 +79,6 @@ bazel test \
     --repo_env="TF_ROCM_AMDGPU_TARGETS=$TARGET_ARCHS" \
     --build_tests_only \
     --test_output=errors \
+    --verbose_failures \
     --test_sharding_strategy=disabled \
-    --test_size_filters=small,medium,large \
-    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
-    -- \
-    //tensorflow/... \
-    -//tensorflow/core/tpu/... \
-    -//tensorflow/lite/... \
-    -//tensorflow/compiler/tf2tensorrt/... \
+    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute 

--- a/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
@@ -50,38 +50,18 @@ export TF_PYTHON_VERSION=$PYTHON_VERSION
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR
 
-if [ -f /usertools/rocm.bazelrc ]; then
-        # Use the bazelrc files in /usertools if available
-	if [ ! -d /tf ];then
-           # The bazelrc files in /usertools expect /tf to exist
-           mkdir /tf
-        fi
- 
-	bazel \
-    		--bazelrc=/usertools/rocm.bazelrc \
-        	test \
-    		--config=sigbuild_local_cache \
-    		--config=rocm \
-    		--config=xla_cpp_filters \
-    		--test_output=errors \
-    		--local_test_jobs=${N_TEST_JOBS} \
-    		--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
-    		--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
-    		--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
-    		-- @local_xla//xla/...
-else
+if [ ! -d /tf ];then
+		# The bazelrc files in /usertools expect /tf to exist
+		mkdir /tf
+	fi
 
-        yes "" | $PYTHON_BIN_PATH configure.py
-	bazel \
-        	test \
-		-k \
-		--test_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-cuda-only --keep_going \
-		--build_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-cuda-only \
-    		--config=rocm \
-    		--test_output=errors \
-    		--local_test_jobs=${N_TEST_JOBS} \
-    		--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
-    		--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
-    		--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
-    		-- @local_xla//xla/...
-fi
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
+	--config=sigbuild_local_cache \
+	--config=rocm \
+	--config=xla_cpp_filters \
+	--test_output=errors \
+	--local_test_jobs=${N_TEST_JOBS} \
+	--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+	--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+	--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
+	-- @local_xla//xla/...

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -86,12 +86,12 @@ build:build_event_export --build_event_json_file=/tf/pkg/bep.json
 build:rbe --config=rbe_linux_cuda
 
 # For continuous builds
-test:pycpp_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-cuda-only
-test:pycpp_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-cuda-only
+test:pycpp_filters --test_tag_filters=gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,-no_gpu,-requires-gpu:2,-multi-gpu,-no_gpu_presubmit,-tpu,-cuda-only,-oneapi-only
+test:pycpp_filters --build_tag_filters=gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,-no_gpu,-requires-gpu:2,-multi-gpu,-no_gpu_presubmit,-tpu,-cuda-only,-oneapi-only
 test:pycpp_filters --test_lang_filters=cc,py --test_size_filters=small,medium
-test:pycpp --config=pycpp_filters -- //tensorflow/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/dtensor/python/tests:multi_client_test_2gpus -//tensorflow/dtensor/python/tests:multi_client_test_nccl_2gpus -//tensorflow/dtensor/python/tests:multi_client_test_nccl_local_2gpus -//tensorflow/python/distribute/experimental:multi_worker_mirrored_strategy_test_2gpus
+test:pycpp --config=pycpp_filters -- //tensorflow/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
 
 # For XLA (rocm)
-test:xla_cpp_filters --test_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only --keep_going
-test:xla_cpp_filters --build_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only
+test:xla_cpp_filters --test_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-requires-gpu-intel,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-multi_gpu,-oneapi-only,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only --keep_going
+test:xla_cpp_filters --build_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-requires-gpu-intel,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-multi_gpu,-oneapi-only,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only
 test:xla_cpp --config=xla_cpp_filters -- //xla/... //build_tools/...


### PR DESCRIPTION
## Motivation

This PR is part of the effort to unify testing between CI and QA, and fix all existing problems with test filters. All details can be found in this ticket https://github.com/ROCm/frameworks-internal/issues/13456

Note: This will need to be backported to `r2.20`, `r2.19`, and `r2.18` (and any QA branches if necessary).

## Technical Details

This PR:
- Adds missing test filters to `rocm.bazelrc` (link of `gpu.bazelrc`). These include: Intel-specific tests, multi-GPU tests and TPU tests
- Switches all test scripts to using `rocm.bazelrc` from the TF repo (which is always available). There is no need to check for and use `/usertools/rocm.bazelrc`, which is just a copy of the original one from the repo.
- Aligns Bazel commands with those used in the TF CI (in https://github.com/ROCm/rocAutomation/blob/jenkins-pipelines/vars/tfUtils.groovy). The next step is to use these scripts in CI directly (similarly to what we do for XLA CI).
- I will also push a PR to XLA that will similarly rework XLA test scripts. 

## Test Plan

Ran TF sGPU tests locally to confirm mGPU ones are filtered out successfully. Ran other test scripts to confirm `rocm.bazelrc` is used successfully.

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
