### PR TITLE
[r2.19-rocm-enhanced] Pin some deps for 2.19

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -30,8 +30,8 @@ gast == 0.4.0
 # For release jobs, we will pin these on the release branch
 # Note that the CACHEBUSTER variable, set in the CI builds, will force these to
 # be the latest version.
-keras-nightly >= 3.2.0.dev
-tb-nightly ~= 2.17.0.a
+keras >= 3.5.0
+tensorboard ~= 2.19.0
 # Test dependencies
 grpcio ~= 1.59.0 # Earliest version for Python 3.12
 portpicker ~= 1.6.0

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.build-python_ubuntu.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.build-python_ubuntu.sh
@@ -83,4 +83,4 @@ python3 --version
 echo "Install Requirements"
 # Disable the cache dir to save image space, and install packages
 python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U
-python3 -m pip install --no-cache-dir --no-deps tf-keras-nightly
+python3 -m pip install --no-cache-dir --no-deps tf-keras~=2.19.0

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.python.sh
@@ -91,10 +91,10 @@ python3 -m pip install -U setuptools
 
 if [[ $3 ]]; then
     echo "Runtime mode"
-    python3 -m pip install --no-cache-dir --no-deps tf-keras-nightly
+    python3 -m pip install --no-cache-dir --no-deps tf-keras~=2.19.0
 else
     echo "Install Requirements"
     # Disable the cache dir to save image space, and install packages
     python3 -m pip install --no-cache-dir -r $REQUIREMENTS -U
-    python3 -m pip install --no-cache-dir --no-deps tf-keras-nightly
+    python3 -m pip install --no-cache-dir --no-deps tf-keras~=2.19.0
 fi


### PR DESCRIPTION
## Motivation

Ensure 2.19 release versions of keras, tf-keras and tensorboard are in the container vs the nightly versions.

## Technical Details

pin to 2.19 versions

https://ontrack-internal.amd.com/browse/SWDEV-552900