### PR TITLE
Pin some deps for 2.20

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -30,8 +30,8 @@ gast == 0.4.0
 # For release jobs, we will pin these on the release branch
 # Note that the CACHEBUSTER variable, set in the CI builds, will force these to
 # be the latest version.
-keras-nightly >= 3.2.0.dev
-tb-nightly ~= 2.17.0.a
+keras >= 3.5.0
+tensorboard ~= 2.20.0
 # Test dependencies
 grpcio ~= 1.59.0 # Earliest version for Python 3.12
 portpicker ~= 1.6.0


### PR DESCRIPTION
## Motivation

Ensure 2.20 release versions of keras, tf-keras and tensorboard are in the container vs the nightly versions.
Note - It looks like tf-keras 2.20 was [yanked ](https://pypi.org/project/tf-keras/2.20.0/) and never replaced so keep nightly there.

## Technical Details

pin to 2.20 versions

https://ontrack-internal.amd.com/browse/SWDEV-552900