### PR TITLE
Update rocPrim usage for ROCm7

### DIFF
--- a/tensorflow/core/kernels/gpu_prim.h
+++ b/tensorflow/core/kernels/gpu_prim.h
@@ -82,8 +82,8 @@ namespace gpuprim = ::hipcub;
 
 // Required for sorting Eigen::half and bfloat16.
 namespace rocprim {
+#if (TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000)
 namespace detail {
-#if (TF_ROCM_VERSION >= 50200)
 template <>
 struct float_bit_mask<Eigen::half> {
   static constexpr uint16_t sign_bit = 0x8000;
@@ -99,7 +99,27 @@ struct float_bit_mask<Eigen::bfloat16> {
   static constexpr uint16_t mantissa = 0x007F;
   using bit_type = uint16_t;
 };
+}; // namespace detail
+
+#else
+namespace traits {
+template<>
+struct rocprim::traits::define<Eigen::half> {
+  using float_bit_mask = rocprim::traits::float_bit_mask::values<uint16_t, 0x8000, 0x7C00, 0x03FF>;
+  using is_arithmetic = rocprim::traits::is_arithmetic::values<true>;
+  using number_format = rocprim::traits::number_format::values<traits::number_format::kind::floating_point_type>;
+};
+
+template<>
+struct rocprim::traits::define<tsl::bfloat16> {
+  using float_bit_mask = rocprim::traits::float_bit_mask::values<uint16_t, 0x8000, 0x7F80, 0x007F>;
+  using is_arithmetic = rocprim::traits::is_arithmetic::values<true>;
+  using number_format = rocprim::traits::number_format::values<traits::number_format::kind::floating_point_type>;
+};
+}; // namespace traits
 #endif
+#if (TF_ROCM_VERSION < 70000)
+namespace detail {
 template <>
 struct radix_key_codec_base<Eigen::half>
     : radix_key_codec_floating<Eigen::half, uint16_t> {};
@@ -107,6 +127,7 @@ template <>
 struct radix_key_codec_base<tensorflow::bfloat16>
     : radix_key_codec_floating<tensorflow::bfloat16, uint16_t> {};
 };  // namespace detail
+#endif
 };  // namespace rocprim
 
 #endif  // TENSORFLOW_USE_ROCM


### PR DESCRIPTION
## Motivation

to fix the build issue reported in https://ontrack-internal.amd.com/browse/SWDEV-553899 via cherry-pick [Update rocPrim usage for ROCm7](https://github.com/ROCm/tensorflow-upstream/commit/fd76165fa1c6d729f77659f2f5101aa7ddc4caa3)

it builds locally on `registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16623_py3.10_tf-manylinux_r2.20-rocm-enhanced_79835f5_base` with MI200. 

```
[45,478 / 45,479] Action tensorflow/tools/pip_package/wheel_house/tf_nightly_rocm-2.20.0.dev20250911-cp310-cp310-linux_x86_64.whl; 100s local
[45,478 / 45,479] Action tensorflow/tools/pip_package/wheel_house/tf_nightly_rocm-2.20.0.dev20250911-cp310-cp310-linux_x86_64.whl; 160s local
[45,479 / 45,479] no actions running
INFO: Found 1 target...
Target //tensorflow/tools/pip_package:wheel up-to-date:
  bazel-bin/tensorflow/tools/pip_package/wheel_house/tf_nightly_rocm-2.20.0.dev20250911-cp310-cp310-linux_x86_64.whl
INFO: Elapsed time: 1388.380s, Critical Path: 655.02s
```