### PR TITLE
Update setup.rocm.sh: rhel 8.8 to rhel 8.9

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -123,7 +123,7 @@ elif [[ "$DISTRO" == "el8" ]]; then
     if [ ! -f "/${CUSTOM_INSTALL}" ]; then
         RPM_ROCM_REPO=http://repo.radeon.com/rocm/rhel8/${ROCM_VERS}/main
         echo -e "[ROCm]\nname=ROCm\nbaseurl=$RPM_ROCM_REPO\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >>/etc/yum.repos.d/rocm.repo
-        echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${ROCM_VERS}/rhel/8.8/main/x86_64/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >>/etc/yum.repos.d/amdgpu.repo
+        echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${ROCM_VERS}/rhel/8.9/main/x86_64/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >>/etc/yum.repos.d/amdgpu.repo
     else
         bash "/${CUSTOM_INSTALL}"
     fi


### PR DESCRIPTION
## Motivation

Rocm 7.0 forward, we are no longer publishing 8.8

## Technical Details

Failing release public docker creation using rhel8.8

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
