### PR TITLE
Extend timeout for gpu_debug_allocator_test for SR-IOV systems

### DIFF
--- a/tensorflow/core/common_runtime/gpu/BUILD
+++ b/tensorflow/core/common_runtime/gpu/BUILD
@@ -434,7 +434,7 @@ tf_cuda_cc_test(
 
 tf_cuda_cc_test(
     name = "gpu_debug_allocator_test",
-    size = "medium",
+    size = "large",
     srcs = ["gpu_debug_allocator_test.cc"],
     args = ["--gtest_death_test_style=threadsafe"],
     features = ["-layering_check"],


### PR DESCRIPTION
## Motivation

Fixes https://ontrack-internal.amd.com/browse/SWDEV-554243

## Technical Details

On SR-IOV system Header and Fotter test in gpu_debug_allocator_test suite takes 600s each and hence we need to make this test size large to accommodate larger timeout

## Test Result

run_gpu_single.sh should pass on SR-IOV system and should not timeout.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
