### PR TITLE
[QA-rocm71] Adding rocm-dev

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
@@ -51,3 +51,4 @@ kernel-devel-uname-r
 # rocm packagaes
 #libdrm-amdgpu - Not mandatory needed from amdgpu repo. Upstream package is fine too
 rocm-ml-sdk
+rocm-dev

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.el8.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.el8.txt
@@ -50,3 +50,4 @@ kernel-devel-uname-r
 # rocm packagaes
 #libdrm-amdgpu - Not mandatory needed from amdgpu repo. Upstream package is fine too
 rocm-ml-sdk
+rocm-dev

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
@@ -1,5 +1,6 @@
 # All required ROCM packages
 rocm-ml-sdk
+rocm-dev
 
 # Other build-related tools
 apt-transport-https

--- a/tensorflow/tools/tf_sig_build_dockerfiles/sles.devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/sles.devel.packages.rocm.txt
@@ -1,4 +1,5 @@
 rocm-ml-sdk
+rocm-dev
 
 make
 gcc


### PR DESCRIPTION
Adding rocm-dev as rocm-ml-sdk is not pulling roctracer dev/devel packages

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
