### PR TITLE
[r2.18] remove libdrm-amdgpu from ROCm

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.cs7.txt
@@ -49,20 +49,6 @@ wget
 kernel-devel-uname-r
 
 # rocm packagaes
-libdrm-amdgpu
-rocm-dev
+#libdrm-amdgpu - Not mandatory needed from amdgpu repo. Upstream package is fine too
 rocm-ml-sdk
-miopen-hip 
-miopen-hip-devel 
-rocblas 
-rocblas-devel 
-rocsolver-devel 
-rocrand-devel 
-rocfft-devel 
-hipfft-devel 
-hipblas-devel 
-rocprim-devel 
-hipcub-devel 
-rccl-devel 
-hipsparse-devel 
-hipsolver-devel
+rocm-dev

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.el8.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.el8.txt
@@ -48,20 +48,6 @@ wget
 kernel-devel-uname-r
 
 # rocm packagaes
-libdrm-amdgpu
-rocm-dev
+#libdrm-amdgpu - Not mandatory needed from amdgpu repo. Upstream package is fine too
 rocm-ml-sdk
-miopen-hip 
-miopen-hip-devel 
-rocblas 
-rocblas-devel 
-rocsolver-devel 
-rocrand-devel 
-rocfft-devel 
-hipfft-devel 
-hipblas-devel 
-rocprim-devel 
-hipcub-devel 
-rccl-devel 
-hipsparse-devel 
-hipsolver-devel
+rocm-dev

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
@@ -1,22 +1,6 @@
 # All required ROCM packages
-libdrm-amdgpu-dev
-rocm-libs
-rocm-dev
 rocm-ml-sdk
-miopen-hip 
-miopen-hip-dev
-rocblas
-rocblas-dev
-rocsolver-dev
-rocrand-dev
-rocfft-dev
-hipfft-dev
-hipblas-dev
-rocprim-dev
-hipcub-dev
-rccl-dev
-hipsparse-dev
-hipsolver-dev
+rocm-dev
 
 # Other build-related tools
 apt-transport-https

--- a/tensorflow/tools/tf_sig_build_dockerfiles/sles.devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/sles.devel.packages.rocm.txt
@@ -1,4 +1,5 @@
-rocm-libs
+#ROCm 
+rocm-ml-sdk
 rocm-dev
 
 make


### PR DESCRIPTION
To fix, https://ontrack-internal.amd.com/browse/SWDEV-558007 libdrm-amdgpu is not mandatory needed from amdgpu-repo. If any rocm package needs, it can pull from upstream without any impact.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
