### PR TITLE
[QA70] Use timeout from bazelrc and add ROCM_PATH repo_env

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -59,25 +59,26 @@ if [ -z "$TARGET_ARCHS" ]; then
     exit 1
 fi
 
+if [ ! -d /tf ];then
+    # The bazelrc files in /usertools expect /tf to exist
+        mkdir /tf
+fi
+
 # Run bazel test command. Double test timeouts to avoid flakes.
-bazel test \
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
     --config=rocm \
+    --config=sigbuild_local_cache \
+    --config=pycpp \
     -k \
-    --test_tag_filters=gpu,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-cuda-only,-benchmark-test,-rocm_multi_gpu,-tpu,-v1only \
     --jobs=${N_BUILD_JOBS} \
     --local_test_jobs=${N_TEST_JOBS} \
     --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
     --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
     --test_env=MIOPEN_DEBUG_CONV_WINOGRAD=0 \
-    --test_timeout 600,900,2400,7200 \
     --repo_env="TF_ROCM_AMDGPU_TARGETS=$TARGET_ARCHS" \
+    --repo_env="ROCM_PATH=/opt/rocm" \
     --build_tests_only \
     --test_output=errors \
+    --verbose_failures \
     --test_sharding_strategy=disabled \
-    --test_size_filters=small,medium,large \
-    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
-    -- \
-    //tensorflow/... \
-    -//tensorflow/core/tpu/... \
-    -//tensorflow/lite/... \
-    -//tensorflow/compiler/tf2tensorrt/... \
+    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute


### PR DESCRIPTION
## Motivation

Fixes https://ontrack-internal.amd.com/browse/SWDEV-556283

## Technical Details

Increase the timeout as test on ROCm 7 takes > 900s

## Test Result

sort_ops_test should not timeout and pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
