### PR TITLE
Use timeout from bazelrc and add ROCM_PATH repo_env

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -28,55 +28,17 @@ export PYTHON_BIN_PATH=`which python3`
 PYTHON_VERSION=`python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')"`
 export TF_PYTHON_VERSION=$PYTHON_VERSION
 
-export TF_NEED_ROCM=0
+# Use the bazelrc files in /usertools if available
+if [ ! -d /tf ];then
+    # The bazelrc files in /usertools expect /tf to exist
+    mkdir /tf
+fi
 
-if [ -f /usertools/cpu.bazelrc ]; then
-        # Use the bazelrc files in /usertools if available
-	if [ ! -d /tf ];then
-           # The bazelrc files in /usertools expect /tf to exist
-           mkdir /tf
-        fi
-        bazel \
-          --bazelrc=/usertools/cpu.bazelrc \
-          test \
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc test \
           --config=sigbuild_local_cache \
           --verbose_failures \
           --config=pycpp \
-          --test_env=HIP_VISIBLE_DEVICES=\"\"  \
-          --repo_env=USE_PYWRAP_RULES=${usePywrapRules} \
           --action_env=TF_NEED_ROCM=0 \
           --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
           --local_test_jobs=${N_BUILD_JOBS} \
-          --test_timeout 920,2400,7200,9600 \
           --jobs=${N_BUILD_JOBS}
-else
-         yes "" | $PYTHON_BIN_PATH configure.py
-
-
-        # Run bazel test command. Double test timeouts to avoid flakes.
-        # xla/mlir_hlo/tests/Dialect/gml_st tests disabled in 09/08/22 sync
-        bazel test \
-              -k \
-              --verbose_failures \
-              --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-multi_gpu,-multi_and_single_gpu,-tpu,-cuda-only,-benchmark-test,-v1only \
-              --test_lang_filters=cc,py \
-	      --jobs=30 \
-              --local_ram_resources=60000 \
-              --local_cpu_resources=15 \
-              --local_test_jobs=${N_BUILD_JOBS} \
-              --test_timeout 920,2400,7200,9600 \
-              --build_tests_only \
-              --test_output=errors \
-              --test_sharding_strategy=disabled \
-              --test_size_filters=small,medium \
-              --test_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
-              --test_env=HIP_VISIBLE_DEVICES=\"\"  \
-              --repo_env=USE_PYWRAP_RULES=${usePywrapRules} \
-              --action_env=TF_NEED_ROCM=0 \
-              -- \
-              //tensorflow/... \
-              -//tensorflow/compiler/tf2tensorrt/... \
-              -//tensorflow/core/tpu/... \
-              -//tensorflow/lite/... \
-              -//tensorflow/tools/toolchains/...
-fi 

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -57,7 +57,8 @@ bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.b
         --config=rocm \
         --config=nonpip_multi_gpu \
         --config=sigbuild_local_cache \
-        --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION
+        --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
+        --repo_env="ROCM_PATH=$ROCM_PATH" \
 
 
 #  Started failing with 210906 sync

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -75,10 +75,10 @@ bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.b
     --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
     --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
     --test_env=MIOPEN_DEBUG_CONV_WINOGRAD=0 \
-    --test_timeout 600,900,2400,7200 \
     --repo_env="TF_ROCM_AMDGPU_TARGETS=$TARGET_ARCHS" \
+    --repo_env="ROCM_PATH=$ROCM_PATH" \
     --build_tests_only \
     --test_output=errors \
     --verbose_failures \
     --test_sharding_strategy=disabled \
-    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute 
+    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute

--- a/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
@@ -63,5 +63,6 @@ bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.b
 	--local_test_jobs=${N_TEST_JOBS} \
 	--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
 	--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+    --repo_env="ROCM_PATH=$ROCM_PATH" \
 	--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
 	-- @local_xla//xla/...


### PR DESCRIPTION
## Motivation

bazelrc has increased timeout for flaky tests, Use that and added ROCM_PATH repo env


- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
