### PR TITLE
[r2.18-rocm-enhanced] Fix rocm.bazelrc and clean testing scripts

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_cpu.sh
@@ -28,40 +28,17 @@ export PYTHON_BIN_PATH=`which python3`
 PYTHON_VERSION=`python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')"`
 export TF_PYTHON_VERSION=$PYTHON_VERSION
 
-
-if [ -f /usertools/cpu.bazelrc ]; then
-        # Use the bazelrc files in /usertools if available
-        bazel \
-          --bazelrc=/usertools/cpu.bazelrc \
-          test \
-          --config=sigbuild_local_cache \
-          --config=pycpp \
-          --test_tag_filters=-no_cuda_on_cpu_tap,-no-gpu,-optimize.mlir.test,-requires-gpu-nvidia,-tpu,-v1only,-oss_serial,-no_windows,-no_oss \
-          --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
-          --local_test_jobs=${N_BUILD_JOBS} \
-          --jobs=${N_BUILD_JOBS} --test_env=HIP_VISIBLE_DEVICES= --action_env=TF_NEED_ROCM=0
-else
-         yes "" | $PYTHON_BIN_PATH configure.py
-
-        # Run bazel test command. Double test timeouts to avoid flakes.
-        # xla/mlir_hlo/tests/Dialect/gml_st tests disabled in 09/08/22 sync
-        bazel test \
-              -k \
-              --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-multi_gpu,-tpu,-no_rocm,-benchmark-test,-v1only \
-              --test_lang_filters=cc,py \
-              --jobs=${N_BUILD_JOBS} --test_env=HIP_VISIBLE_DEVICES= --action_env=TF_NEED_ROCM=0 \
-              --local_test_jobs=${N_BUILD_JOBS} \
-              --test_timeout 920,2400,7200,9600 \
-              --config=opt \
-              --build_tests_only \
-              --test_output=errors \
-              --test_size_filters=small,medium \
-              --test_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
-              -- \
-              //tensorflow/... \
-              -//tensorflow/python/integration_testing/... \
-              -//tensorflow/compiler/tf2tensorrt/... \
-              -//tensorflow/core/tpu/... \
-              -//tensorflow/lite/... \
-              -//tensorflow/tools/toolchains/...    
+if [ ! -d /tf ];then
+    # The bazelrc files expect /tf to exist
+    mkdir /tf
 fi
+
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc test \
+    --config=sigbuild_local_cache \
+    --verbose_failures \
+    --config=pycpp \
+    --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
+    --local_test_jobs=${N_BUILD_JOBS} \
+    --jobs=${N_BUILD_JOBS} \
+    --test_env=HIP_VISIBLE_DEVICES= \
+    --action_env=TF_NEED_ROCM=0

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -43,101 +43,17 @@ export TF_PYTHON_VERSION=$PYTHON_VERSION
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR
 
-if [ -f /usertools/rocm.bazelrc ]; then
-	 # Use the bazelrc files in /usertools if available
-	bazel \
-           --bazelrc=/usertools/rocm.bazelrc \
-           test \
-           --local_test_jobs=${N_TEST_JOBS} \
-           --jobs=${N_BUILD_JOBS} \
-           --config=sigbuild_local_cache \
-           --config=rocm \
-           --config=nonpip_multi_gpu \
-           --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION
-else
-	# Legacy style: run configure then build
-        yes "" | $PYTHON_BIN_PATH configure.py
-
-        # Run bazel test command. Double test timeouts to avoid flakes.
-        bazel test \
-              --config=rocm \
-              -k \
-              --test_tag_filters=-no_gpu,-cuda-only \
-              --jobs=30 \
-              --local_ram_resources=60000 \
-              --local_cpu_resources=15 \
-              --local_test_jobs=${N_TEST_JOBS} \
-              --test_timeout 920,2400,7200,9600 \
-              --build_tests_only \
-              --test_output=errors \
-              --test_sharding_strategy=disabled \
-              --test_size_filters=small,medium,large \
-              --cache_test_results=no \
-              --test_env=TF_PER_DEVICE_MEMORY_LIMIT_MB=2048 \
-              --test_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
-              -- \
-        //tensorflow/core/nccl:nccl_manager_test_2gpu \
-        //tensorflow/python/distribute/integration_test:mwms_peer_failure_test_2gpu \
-        //tensorflow/python/distribute:checkpoint_utils_test_2gpu \
-        //tensorflow/python/distribute:checkpointing_test_2gpu \
-        //tensorflow/python/distribute:collective_all_reduce_strategy_test_xla_2gpu \
-        //tensorflow/python/distribute:custom_training_loop_gradient_test_2gpu \
-        //tensorflow/python/distribute:custom_training_loop_input_test_2gpu \
-        //tensorflow/python/distribute:distribute_utils_test_2gpu \
-        //tensorflow/python/distribute:input_lib_test_2gpu \
-        //tensorflow/python/distribute:input_lib_type_spec_test_2gpu \
-        //tensorflow/python/distribute:metrics_v1_test_2gpu \
-        //tensorflow/python/distribute:mirrored_variable_test_2gpu \
-        //tensorflow/python/distribute:parameter_server_strategy_test_2gpu \
-        //tensorflow/python/distribute:ps_values_test_2gpu \
-        //tensorflow/python/distribute:random_generator_test_2gpu \
-        //tensorflow/python/distribute:test_util_test_2gpu \
-        //tensorflow/python/distribute:tf_function_test_2gpu \
-        //tensorflow/python/distribute:vars_test_2gpu \
-        //tensorflow/python/distribute:warm_starting_util_test_2gpu \
-        //tensorflow/python/training:saver_test_2gpu
+if [ ! -d /tf ];then
+    # The bazelrc files expect /tf to exist
+        mkdir /tf
 fi
 
-
-#  Started failing with 210906 sync
-# FAILED : //tensorflow/core/kernels:collective_nccl_test_2gpu \
-
-# no_rocm : //tensorflow/python/keras/distribute:keras_dnn_correctness_test_2gpu \
-# no_rocm : //tensorflow/python/keras/distribute:keras_embedding_model_correctness_test_2gpu \
-      
-# TIMEOUT : //tensorflow/python/distribute:values_test_2gpu \
-# TIMEOUT : //tensorflow/python/keras/distribute:keras_image_model_correctness_test_2gpu \
-# TIMEOUT : //tensorflow/python/keras/distribute:keras_rnn_model_correctness_test_2gpu \
-# TIMEOUT : //tensorflow/python/keras/distribute:saved_model_mixed_api_test_2gpu \
-# TIMEOUT : //tensorflow/python/keras/distribute:saved_model_save_load_test_2gpu \
-
-# Started timing-out with ROCm 4.1
-# TIMEOUT : //tensorflow/python/keras/distribute:keras_premade_models_test_2gpu \
-
-# Became FLAKY with  ROCm 4.1
-# FLAKY : //tensorflow/python/distribute:strategy_common_test_2gpu \
-# FLAKY : //tensorflow/python/distribute:strategy_common_test_xla_2gpu \
-# FLAKY : //tensorflow/python/distribute:strategy_gather_test_2gpu \
-# FLAKY : //tensorflow/python/distribute:strategy_gather_test_xla_2gpu \
-# FLAKY : //tensorflow/python/keras/distribute:custom_training_loop_metrics_test_2gpu \
-# FLAKY : //tensorflow/python/keras/distribute:custom_training_loop_models_test_2gpu \
-
-# FAILED : //tensorflow/python/distribute/v1:cross_device_ops_test_2gpu \
-# FAILED : //tensorflow/python/distribute:cross_device_ops_test_2gpu \
-# FAILED : //tensorflow/python/distribute:mirrored_strategy_test_2gpu \
-# FAILED : //tensorflow/python/keras/distribute:distribute_strategy_test_2gpu \
-# FAILED : //tensorflow/python/kernel_tests:collective_ops_test_2gpu \
-# FAILED : //tensorflow/python:collective_ops_gpu_test_2gpu \
-# FAILED : //tensorflow/python:nccl_ops_test_2gpu \
-
-# FAILED ON CI Node only : //tensorflow/python/distribute:collective_all_reduce_strategy_test_2gpu \
-# See run : http://ml-ci.amd.com:21096/job/tensorflow/job/github-prs-rocmfork-develop-upstream/job/rocm-latest-ubuntu-gpu-multi/216/console
-
-# FAILED ON CI Node only : //tensorflow/python/keras/distribute:keras_save_load_test_2gpu \
-# Starting with ROCm 4.1, see run : http://ml-ci.amd.com:21096/job/tensorflow/job/github-prs-rocmfork-develop-upstream/job/rocm-latest-ubuntu-gpu-multi/241/console
-
-# FAILED  //tensorflow/python/keras/distribute:minimize_loss_test_2gpu \
-# potential breaking commit : https://github.com/tensorflow/tensorflow/commit/74e39c8fa60079862597c9db506cd15b2443a5a2
-
-# NO MORE MULTI_GPU : //tensorflow/python/keras/distribute:checkpointing_test_2gpu \
-# multi_gpu tag was commented out in this commit : https://github.com/tensorflow/tensorflow/commit/b87d02a3f8d8b55045bf4250dd72e746357a3eba
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
+    --local_test_jobs=${N_TEST_JOBS} \
+    --jobs=${N_BUILD_JOBS} \
+    --verbose_failures \
+    --config=sigbuild_local_cache \
+    --config=rocm \
+    --config=nonpip_multi_gpu \
+    --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
+    --repo_env="ROCM_PATH=$ROCM_PATH" \

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -60,7 +60,7 @@ if [ -z "$TARGET_ARCHS" ]; then
 fi
 
 if [ ! -d /tf ];then
-    # The bazelrc files in /usertools expect /tf to exist
+    # The bazelrc files expect /tf to exist
         mkdir /tf
 fi
 

--- a/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
@@ -50,38 +50,19 @@ export TF_PYTHON_VERSION=$PYTHON_VERSION
 export TF_NEED_ROCM=1
 export ROCM_PATH=$ROCM_INSTALL_DIR
 
-if [ -f /usertools/rocm.bazelrc ]; then
-        # Use the bazelrc files in /usertools if available
-	if [ ! -d /tf ];then
-           # The bazelrc files in /usertools expect /tf to exist
-           mkdir /tf
-        fi
- 
-	bazel \
-    		--bazelrc=/usertools/rocm.bazelrc \
-        	test \
-    		--config=sigbuild_local_cache \
-    		--config=rocm \
-    		--config=xla_cpp_filters \
-    		--test_output=errors \
-    		--local_test_jobs=${N_TEST_JOBS} \
-    		--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
-    		--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
-    		--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
-    		-- @local_xla//xla/...
-else
-
-        yes "" | $PYTHON_BIN_PATH configure.py
-	bazel \
-        	test \
-		-k \
-		--test_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-cuda-only --keep_going \
-		--build_tag_filters=-no_oss,-oss_excluded,-oss_serial,gpu,requires-gpu,-no_gpu,-cuda-only \
-    		--config=rocm \
-    		--test_output=errors \
-    		--local_test_jobs=${N_TEST_JOBS} \
-    		--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
-    		--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
-    		--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
-    		-- @local_xla//xla/...
+if [ ! -d /tf ];then
+	# The bazelrc files expect /tf to exist
+	mkdir /tf
 fi
+ 
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc test \
+	--config=sigbuild_local_cache \
+	--config=rocm \
+	--config=xla_cpp_filters \
+	--test_output=errors \
+	--local_test_jobs=${N_TEST_JOBS} \
+	--test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+	--test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+	--repo_env="ROCM_PATH=$ROCM_PATH" \
+	--action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
+	-- @local_xla//xla/...

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -46,6 +46,7 @@ test:nonpip_multi_gpu --config=nonpip_filters_multi_gpu -- \
 //tensorflow/python/distribute/integration_test:mwms_peer_failure_test_2gpu \
 //tensorflow/python/distribute:checkpoint_utils_test_2gpu \
 //tensorflow/python/distribute:checkpointing_test_2gpu \
+//tensorflow/python/distribute:collective_all_reduce_strategy_test_2gpu \
 //tensorflow/python/distribute:collective_all_reduce_strategy_test_xla_2gpu \
 //tensorflow/python/distribute:custom_training_loop_gradient_test_2gpu \
 //tensorflow/python/distribute:custom_training_loop_input_test_2gpu \
@@ -55,6 +56,7 @@ test:nonpip_multi_gpu --config=nonpip_filters_multi_gpu -- \
 //tensorflow/python/distribute:metrics_v1_test_2gpu \
 //tensorflow/python/distribute:mirrored_variable_test_2gpu \
 //tensorflow/python/distribute:parameter_server_strategy_test_2gpu \
+//tensorflow/python/distribute:values_test_2gpu \
 //tensorflow/python/distribute:ps_values_test_2gpu \
 //tensorflow/python/distribute:random_generator_test_2gpu \
 //tensorflow/python/distribute:test_util_test_2gpu \
@@ -66,6 +68,10 @@ test:nonpip_multi_gpu --config=nonpip_filters_multi_gpu -- \
 //tensorflow/dtensor/python/tests:multi_client_test_nccl_2gpus \
 //tensorflow/dtensor/python/tests:multi_client_test_nccl_local_2gpus \
 //tensorflow/python/distribute/experimental:multi_worker_mirrored_strategy_test_2gpus \
+//tensorflow/python/distribute:strategy_common_test_2gpu \
+//tensorflow/python/distribute:strategy_common_test_xla_2gpu \
+//tensorflow/python/distribute:strategy_gather_test_2gpu \
+//tensorflow/python/distribute:strategy_gather_test_xla_2gpu \
 
 # For building libtensorflow archives
 test:libtensorflow_test -- //tensorflow/tools/lib_package:libtensorflow_test //tensorflow/tools/lib_package:libtensorflow_java_test
@@ -79,12 +85,12 @@ build:build_event_export --build_event_json_file=/tf/pkg/bep.json
 build:rbe --config=rbe_linux_cuda
 
 # For continuous builds
-test:pycpp_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-cuda-only
-test:pycpp_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11,-cuda-only
+test:pycpp_filters --test_tag_filters=gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-requires-gpu:2,-multi_gpu,-no_gpu_presubmit,-tpu,-no_cuda11,-cuda-only,-oneapi-only
+test:pycpp_filters --build_tag_filters=gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-requires-gpu:2,-multi_gpu,-no_gpu_presubmit,-tpu,-no_cuda11,-cuda-only,-oneapi-only
 test:pycpp_filters --test_lang_filters=cc,py --test_size_filters=small,medium
-test:pycpp --config=pycpp_filters -- //tensorflow/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/dtensor/python/tests:multi_client_test_2gpus -//tensorflow/dtensor/python/tests:multi_client_test_nccl_2gpus -//tensorflow/dtensor/python/tests:multi_client_test_nccl_local_2gpus -//tensorflow/python/distribute/experimental:multi_worker_mirrored_strategy_test_2gpus
+test:pycpp --config=pycpp_filters -- //tensorflow/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
 
 # For XLA (rocm)
-test:xla_cpp_filters --test_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only --keep_going
-test:xla_cpp_filters --build_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only
+test:xla_cpp_filters --test_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-requires-gpu-intel,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-multi_gpu,-oneapi-only,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only --keep_going
+test:xla_cpp_filters --build_tag_filters=gpu,requires-gpu-amd,-requires-gpu-nvidia,-requires-gpu-intel,-no_oss,-oss_excluded,-oss_serial,-no_gpu,-multi_gpu,-oneapi-only,-cuda-only,-requires-gpu-sm60,-requires-gpu-sm60-only,-requires-gpu-sm70,-requires-gpu-sm70-only,-requires-gpu-sm80,-requires-gpu-sm80-only,-requires-gpu-sm86,-requires-gpu-sm86-only,-requires-gpu-sm89,-requires-gpu-sm89-only,-requires-gpu-sm90,-requires-gpu-sm90-only
 test:xla_cpp --config=xla_cpp_filters -- //xla/... //build_tools/...


### PR DESCRIPTION
## Motivation

This PR backports changes from https://github.com/ROCm/tensorflow-upstream/pull/3093 and https://github.com/ROCm/tensorflow-upstream/pull/3139

Note: Backporting was partially already covered in https://github.com/ROCm/tensorflow-upstream/commit/013cff8d2876098d429b64e8c86d8738ecdccedd

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
