### PR TITLE
Fix tensorflow being built for only one architecture.

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -151,5 +151,5 @@ echo $ROCM_PATH
 echo $GPU_DEVICE_TARGETS
 
 # Ensure the ROCm target list is set up
-printf '%s\n' ${GPU_DEVICE_TARGETS} | tee -a "$ROCM_PATH/bin/target.lst"
+echo ${GPU_DEVICE_TARGETS} | tr ' ,' '\n' | tee -a "$ROCM_PATH/bin/target.lst"
 touch "${ROCM_PATH}/.info/version"


### PR DESCRIPTION
## Motivation
Tensorflow is prebuilt with only gfx980 architecture

## Technical Details
If GPU_DEVICE_TARGETS is defined in comma separated format it will cause the rocm_agent_enumerator to return only first gfx. rocm_agent_enumerator's parsing looks for the "\n" characters and parses the /opt/rocm/bin/target.lst based on them. 
Added parsing of comma separated and space separated lists so that target.ls has the appropriate format for rocm_agent_enumerator.
