### PR TITLE
Add -no-canonical-prefixes to net_zstd

### DIFF
--- a/third_party/xla/third_party/net_zstd.BUILD
+++ b/third_party/xla/third_party/net_zstd.BUILD
@@ -28,6 +28,7 @@ cc_library(
     hdrs = glob([
         "*.h",
     ]),
+    copts = ["-no-canonical-prefixes"],
 )
 
 alias(


### PR DESCRIPTION
## Motivation

Use -no-canonical-prefixes for clang headers in net_zstd

## Technical Details

Fixes https://github.com/ROCm/tensorflow-upstream/issues/3106


## Test Result
Building TF wheels should be successful

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
