### PR TITLE
Guard float64 atomic add for CUDA with GOOGLE_CUDA macro

### DIFF
--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -672,14 +672,14 @@ __device__ inline Eigen::half GpuAtomicAdd(Eigen::half* ptr,
   return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return a + value; });
 }
-#endif
 
-#if (__CUDA_ARCH__ < 600)
+#if (__CUDA_ARCH__ < 600) // TODO beware of merge conflict here
 __device__ inline double GpuAtomicAdd(double* ptr, double value) {
   return detail::GpuAtomicCasHelper(ptr,
                                     [value](double a) { return a + value; });
 }
 #endif
+#endif // !TENSORFLOW_USE_ROCM (line 663)
 
 #if TENSORFLOW_USE_ROCM
 template <typename T>


### PR DESCRIPTION
## Motivation

Put cuda specific code under GOOGLE_CUDA macro
Solves slowness seen as reported int https://amd-hub.atlassian.net/browse/ROCM-3072



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
