### PR TITLE
Enable gfx115x and gfx1102.

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -7,7 +7,7 @@ ARG ROCM_DEB_REPO=https://repo.radeon.com/rocm/apt/6.2/
 ARG ROCM_BUILD_NAME=ubuntu
 ARG ROCM_BUILD_NUM=main
 ARG ROCM_PATH=/opt/rocm/
-ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx1030 gfx1100 gfx1101 gfx1102 gfx1200 gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908 gfx90a gfx942 gfx1030 gfx1100 gfx1101 gfx1102 gfx1150 gfx1151 gfx1200 gfx1201"
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TF_NEED_ROCM 1

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.manylinux_2_28
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.manylinux_2_28
@@ -17,7 +17,7 @@ COPY setup.packages.rocm.el8.sh setup.packages.rocm.el8.sh
 COPY builder.packages.rocm.el8.txt builder.packages.rocm.el8.txt
 RUN /setup.packages.rocm.el8.sh /builder.packages.rocm.el8.txt
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.ub20
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.ub20
@@ -9,7 +9,7 @@ COPY runtime.packages.txt /runtime.packages.txt
 COPY sles.runtime.packages.txt /sles.runtime.packages.txt
 RUN /setup.packages.sh /runtime.packages.txt
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.ub22
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.ub22
@@ -11,7 +11,7 @@ COPY runtime.packages.txt /runtime.packages.txt
 COPY sles.runtime.packages.txt /sles.runtime.packages.txt
 RUN /setup.packages.sh /runtime.packages.txt
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.ub24
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.ub24
@@ -11,7 +11,7 @@ COPY runtime.packages.txt /runtime.packages.txt
 COPY sles.runtime.packages.txt /sles.runtime.packages.txt
 RUN /setup.packages.sh /runtime.packages.txt
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub20
@@ -2,7 +2,7 @@
 FROM ubuntu:20.04
 ################################################################################
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub22
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub22
@@ -2,7 +2,7 @@
 FROM ubuntu:22.04
 ################################################################################
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub24
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.ub24
@@ -2,7 +2,7 @@
 FROM ubuntu:24.04
 ################################################################################
 
-ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1150,gfx1151,gfx1200,gfx1201"
 ARG GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
 ENV TF_ROCM_AMDGPU_TARGETS=${GPU_DEVICE_TARGETS}
 

--- a/third_party/xla/xla/stream_executor/device_description.h
+++ b/third_party/xla/xla/stream_executor/device_description.h
@@ -91,6 +91,7 @@ class RocmComputeCapability {
       "gfx1030",  // RX68xx / RX69xx
       "gfx1100",  // RX7900
       "gfx1101",  // RX7700 / RX7800
+      "gfx1102",
       "gfx1103", "gfx1150", "gfx1151", "gfx1200", "gfx1201",
   };
 
@@ -131,7 +132,7 @@ class RocmComputeCapability {
 
   bool gfx11() const { return absl::StartsWith(gfx_version(), "gfx11"); }
 
-  static constexpr absl::string_view kGfx11Discrete[] = {"gfx1100", "gfx1101"};
+  static constexpr absl::string_view kGfx11Discrete[] = {"gfx1100", "gfx1101", "gfx1102"};
   bool gfx11_discrete() const { return IsThisGfxInAnyList(kGfx11Discrete); }
 
   static constexpr absl::string_view kGfx11Apu[] = {"gfx1103", "gfx1150",


### PR DESCRIPTION
## Motivation

Backport of https://github.com/ROCm/tensorflow-upstream/pull/3181 from TF2.20 to TF 2.19.
