### PR TITLE
[r2.20-rocm-enhanced] Use AMDGPU_REPO_VERS to select admgpu driver to be installed

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -49,6 +49,9 @@ else
         ROCM_VERS=$ROCM_VERSION
 fi
 
+# hardcode to 7.0.2
+AMDGPU_REPO_VERS=7.0.2
+
 if [[ "$DISTRO" == "focal" ]] || [[ "$DISTRO" == "jammy" ]] || [[ "$DISTRO" == "noble" ]]; then
     ROCM_DEB_REPO_HOME=https://repo.radeon.com/rocm/apt/
     AMDGPU_DEB_REPO_HOME=https://repo.radeon.com/amdgpu/
@@ -57,7 +60,7 @@ if [[ "$DISTRO" == "focal" ]] || [[ "$DISTRO" == "jammy" ]] || [[ "$DISTRO" == "
 
     # Adjust the ROCM repo location
     ROCM_DEB_REPO=${ROCM_DEB_REPO_HOME}${ROCM_VERS}/
-    AMDGPU_DEB_REPO=${AMDGPU_DEB_REPO_HOME}${ROCM_VERS}/
+    AMDGPU_DEB_REPO=${AMDGPU_DEB_REPO_HOME}${AMDGPU_REPO_VERS}/
 
     DEBIAN_FRONTEND=noninteractive apt-get --allow-unauthenticated update 
     DEBIAN_FRONTEND=noninteractive apt install -y wget software-properties-common
@@ -107,7 +110,7 @@ elif [[ "$DISTRO" == "el7" ]]; then
     if [ ! -f "/${CUSTOM_INSTALL}" ]; then
         RPM_ROCM_REPO=http://repo.radeon.com/rocm/yum/${ROCM_VERS}/main
         echo -e "[ROCm]\nname=ROCm\nbaseurl=$RPM_ROCM_REPO\nenabled=1\ngpgcheck=0" >>/etc/yum.repos.d/rocm.repo
-        echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${ROCM_VERS}/rhel/7/main/x86_64/\nenabled=1\ngpgcheck=0" >>/etc/yum.repos.d/amdgpu.repo
+        echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${AMDGPU_REPO_VERS}/rhel/7/main/x86_64/\nenabled=1\ngpgcheck=0" >>/etc/yum.repos.d/amdgpu.repo
     else
         bash "/${CUSTOM_INSTALL}"
     fi
@@ -123,7 +126,7 @@ elif [[ "$DISTRO" == "el8" ]]; then
     if [ ! -f "/${CUSTOM_INSTALL}" ]; then
         RPM_ROCM_REPO=http://repo.radeon.com/rocm/rhel8/${ROCM_VERS}/main
         echo -e "[ROCm]\nname=ROCm\nbaseurl=$RPM_ROCM_REPO\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >>/etc/yum.repos.d/rocm.repo
-        echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${ROCM_VERS}/rhel/8.8/main/x86_64/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >>/etc/yum.repos.d/amdgpu.repo
+        echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/${AMDGPU_REPO_VERS}/rhel/8.10/main/x86_64/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" >>/etc/yum.repos.d/amdgpu.repo
     else
         bash "/${CUSTOM_INSTALL}"
     fi


### PR DESCRIPTION
## Motivation

This is a cherry-pick of https://github.com/ROCm/tensorflow-upstream/commit/33c05f2ed25ce7a816251fcdc5e8598c4b9e5bbd
It is necessary because docker image build job is failing with:
```
[2026-03-06T12:33:39.891Z] 2.009 Err:8 https://repo.radeon.com/amdgpu/7.2//ubuntu jammy Release
[2026-03-06T12:33:39.892Z] 2.009   404  Not Found [IP: 23.222.17.237 443]
[2026-03-06T12:33:39.892Z] 
[2026-03-06T12:33:39.892Z] 3.610 E: The repository 'https://repo.radeon.com/amdgpu/7.2//ubuntu jammy Release' does not have a Release file.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
