### PR TITLE
[r2.20-rocm-enhanced] Update version properly for ROCm

### DIFF
--- a/tensorflow/tools/ci_build/update_version.py
+++ b/tensorflow/tools/ci_build/update_version.py
@@ -401,7 +401,17 @@ def main():
                             "-dev" + time.strftime("%Y%m%d"),
                             NIGHTLY_VERSION)
   else:
-    new_version = Version.parse_from_string(args.version, SNAPSHOT_VERSION)
+    if args.version:
+      new_version = Version.parse_from_string(args.version, SNAPSHOT_VERSION)
+      if args.rocm_version:
+          new_version.set_identifier_string("." + str(_rocm_version(_get_rocm_install_path()).replace('.', '')) + old_version.identifier_string)
+    else:
+      if args.rocm_version:
+          new_version = Version(old_version.major,
+                            str(old_version.minor),
+                            old_version.patch,
+                            "." + str(_rocm_version(_get_rocm_install_path()).replace('.', '')) + old_version.identifier_string,
+                            SNAPSHOT_VERSION)
 
   update_tf_version_bzl(old_version, new_version)
   update_bazelrc(old_version, new_version)


### PR DESCRIPTION
## Motivation

Currently release wheels buil job is failing for r2.20 with:
```
[2026-03-10T00:35:12.271Z] + docker exec tf-3.9 python3 tensorflow/tools/ci_build/update_version.py --rocm_version
[2026-03-10T00:35:12.271Z] Traceback (most recent call last):
[2026-03-10T00:35:12.271Z]   File "/tf/tensorflow/tensorflow/tools/ci_build/update_version.py", line 420, in <module>
[2026-03-10T00:35:12.271Z]     main()
[2026-03-10T00:35:12.271Z]   File "/tf/tensorflow/tensorflow/tools/ci_build/update_version.py", line 404, in main
[2026-03-10T00:35:12.271Z]     new_version = Version.parse_from_string(args.version, SNAPSHOT_VERSION)
[2026-03-10T00:35:12.271Z]   File "/tf/tensorflow/tensorflow/tools/ci_build/update_version.py", line 131, in parse_from_string
[2026-03-10T00:35:12.271Z]     raise RuntimeError("Invalid version string: %s" % string)
[2026-03-10T00:35:12.271Z] RuntimeError: Invalid version string: 
```

`update_version.py` was refactored in https://github.com/ROCm/tensorflow-upstream/commit/805775fcb5f9272e4c52dce751b00cf7f70364f2, and then ROCm-specific code was badly resolved in https://github.com/ROCm/tensorflow-upstream/commit/e2592b577f917675dc09828c0d45084b07d1dd3d#diff-83d5c8d1d984dbca2b4f5a4ae3fbcccc96ed997cff733b965d017989b56524adL404-L420. 

With this change scripts works as expected:
```
tf-docker /tensorflow > python3 tensorflow/tools/ci_build/update_version.py --rocm_version
/tensorflow/tensorflow/tools/ci_build/update_version.py:68: FutureWarning: Possible nested set at position 9
  source.write(re.sub(search, replace, content))
Major: 2 -> 2
Minor: 20 -> 20
Patch: 0 -> 0
Identifier String:  -> .710
```

r2.21 -> https://github.com/ROCm/tensorflow-upstream/pull/3191
develop-upstream -> https://github.com/ROCm/tensorflow-upstream/pull/3192

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
