### PR TITLE
[r2.21-rocm-enhanced] Update version properly for ROCm

### DIFF
--- a/tensorflow/tools/ci_build/update_version.py
+++ b/tensorflow/tools/ci_build/update_version.py
@@ -401,7 +401,17 @@ def main():
                             "-dev" + time.strftime("%Y%m%d"),
                             NIGHTLY_VERSION)
   else:
-    new_version = Version.parse_from_string(args.version, SNAPSHOT_VERSION)
+    if args.version:
+      new_version = Version.parse_from_string(args.version, SNAPSHOT_VERSION)
+      if args.rocm_version:
+          new_version.set_identifier_string("." + str(_rocm_version(_get_rocm_install_path()).replace('.', '')) + old_version.identifier_string)
+    else:
+      if args.rocm_version:
+          new_version = Version(old_version.major,
+                            str(old_version.minor),
+                            old_version.patch,
+                            "." + str(_rocm_version(_get_rocm_install_path()).replace('.', '')) + old_version.identifier_string,
+                            SNAPSHOT_VERSION)
 
   update_tf_version_bzl(old_version, new_version)
   update_bazelrc(old_version, new_version)


### PR DESCRIPTION
## Motivation
 
Original PR for r2.20-rocm-enhanced: https://github.com/ROCm/tensorflow-upstream/pull/3190
Cherry-pick for develop-upstream: https://github.com/ROCm/tensorflow-upstream/pull/3192

`update_version.py` was refactored in https://github.com/ROCm/tensorflow-upstream/commit/805775fcb5f9272e4c52dce751b00cf7f70364f2, and then ROCm-specific code was badly resolved in https://github.com/ROCm/tensorflow-upstream/commit/e2592b577f917675dc09828c0d45084b07d1dd3d#diff-83d5c8d1d984dbca2b4f5a4ae3fbcccc96ed997cff733b965d017989b56524adL404-L420.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
