### PR TITLE
[develop-upstream] Add Deb12 support

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.deb12
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.deb12
@@ -1,0 +1,72 @@
+################################################################################
+FROM debian:bookworm
+################################################################################
+
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ENV GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
+
+# Install build dependencies
+COPY setup.packages.sh setup.packages.sh
+COPY builder.packages.txt builder.packages.txt
+RUN /setup.packages.sh /builder.packages.txt
+
+# Install ROCM
+ARG ROCM_VERSION=6.2.0
+ARG CUSTOM_INSTALL
+ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
+ENV ROCM_PATH=${ROCM_PATH}
+COPY ${CUSTOM_INSTALL} /${CUSTOM_INSTALL}
+COPY setup.rocm.sh /setup.rocm.sh
+COPY devel.packages.rocm.txt /devel.packages.rocm.txt
+RUN /setup.rocm.sh $ROCM_VERSION bookworm
+
+# Install various tools.
+# - bats: bash unit testing framework
+# - bazelisk: always use the correct bazel version
+# - buildifier: clean bazel build deps
+# - buildozer: clean bazel build deps
+# - gcloud SDK: communicate with Google Cloud Platform (GCP) for RBE, CI
+RUN git clone --branch v1.7.0 https://github.com/bats-core/bats-core.git && bats-core/install.sh /usr/local && rm -rf bats-core
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel && chmod +x /usr/local/bin/bazel
+RUN wget https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildifier -O /usr/local/bin/buildifier && chmod +x /usr/local/bin/buildifier
+RUN wget https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildozer -O /usr/local/bin/buildozer && chmod +x /usr/local/bin/buildozer
+RUN curl -sSL https://sdk.cloud.google.com > /tmp/gcloud && bash /tmp/gcloud --install-dir=~/usr/local/bin --disable-prompts
+
+
+# All lines past this point are reset when $CACHEBUSTER is set. We need this
+# for Python specifically because we install some nightly packages which are
+# likely to change daily.
+ARG CACHEBUSTER=0
+RUN echo $CACHEBUSTER
+
+# Setup Python environment. PYTHON_VERSION is e.g. "python3.8"
+ARG PYTHON_VERSION
+COPY setup.build-python_ubuntu.sh /setup.build-python_ubuntu.sh
+COPY devel.requirements.txt /devel.requirements.txt
+RUN /setup.build-python_ubuntu.sh $PYTHON_VERSION /devel.requirements.txt
+
+ARG TF_WHEEL_URL
+RUN if [ -n "${TF_WHEEL_URL}" ]; then pip install "${TF_WHEEL_URL}"; fi
+ARG DWLD_TF_SRC_CMD
+RUN if [ -n "${DWLD_TF_SRC_CMD}" ]; then eval "${DWLD_TF_SRC_CMD}"; fi
+
+# Setup build and environment
+COPY devel.usertools /usertools
+COPY devel.bashrc /root/.bashrc
+
+# Setup ENV variables for tensorflow pip build
+ENV TF_NEED_ROCM=1
+ENV TF_ROCM_GCC=1
+ENV ROCM_TOOLKIT_PATH=${ROCM_PATH}
+
+# Don't use the bazel cache when a new docker image is created.
+RUN echo build --action_env=DOCKER_CACHEBUSTER=$(date +%s%N)$RANDOM >> /etc/bazel.bazelrc
+RUN echo build --host_action_env=DOCKER_HOST_CACHEBUSTER=$(date +%s%N)$RANDOM >> /etc/bazel.bazelrc
+
+ARG TF_TESTING_FL
+ENV TF_TESTING_FL=${TF_TESTING_FL}
+ARG DWLD_TF_SRC_CMD
+RUN if [ -n "${DWLD_TF_SRC_CMD}" ]; then eval "${DWLD_TF_SRC_CMD}"; fi
+ARG CLONE_TEST_REPO
+COPY ${CLONE_TEST_REPO} /${CLONE_TEST_REPO}
+RUN if [ -n "${CLONE_TEST_REPO}" ]; then bash /${CLONE_TEST_REPO}; fi

--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.deb12
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm.rt.deb12
@@ -1,0 +1,67 @@
+################################################################################
+ARG DISTRO_IMG
+FROM ${DISTRO_IMG:-'debian:bookworm'} as runtime
+################################################################################
+
+ARG GPU_DEVICE_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1200,gfx1201"
+ENV GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS}
+
+# Install build dependencies
+COPY setup.packages.sh /setup.packages.sh
+COPY runtime.packages.txt /runtime.packages.txt
+RUN /setup.packages.sh /runtime.packages.txt
+
+# Install ROCM
+ARG ROCM_VERSION=6.2.0
+ARG CUSTOM_INSTALL
+ARG ROCM_PATH=/opt/rocm-${ROCM_VERSION}
+ENV ROCM_PATH=${ROCM_PATH}
+COPY ${CUSTOM_INSTALL} /${CUSTOM_INSTALL}
+COPY setup.rocm.sh /setup.rocm.sh
+COPY devel.packages.rocm.txt /devel.packages.rocm.txt
+RUN /setup.rocm.sh $ROCM_VERSION bookworm
+
+# All lines past this point are reset when $CACHEBUSTER is set. We need this
+# for Python specifically because we install some nightly packages which are
+# likely to change daily.
+ARG CACHEBUSTER=0
+RUN echo $CACHEBUSTER
+
+# Setup ENV variables for tensorflow pip build
+ENV TF_NEED_ROCM=1
+ENV TF_ROCM_GCC=1
+ENV ROCM_TOOLKIT_PATH=${ROCM_PATH}
+
+# Setup Python environment
+ARG PYTHON_VERSION
+COPY setup.build-python_ubuntu.sh /setup.build-python_ubuntu.sh
+COPY devel.requirements.txt /devel.requirements.txt
+RUN /setup.build-python_ubuntu.sh $PYTHON_VERSION /devel.requirements.txt
+
+# Install TensorFlow nightly wheel
+ARG TF_PKGS_DIR=tmp/my-packages
+RUN mkdir -p /${TF_PKGS_DIR}
+ARG TF_PKG_LOC=http://aus-navi3x-03.amd.com:8080/job/tensorflow/job/nightly-build-whl/lastSuccessfulBuild/artifact/develop-upstream/packages-${PYTHON_VERSION}
+# CI names the nighlty wheel as the latest release version + 1
+ARG TF_VERSION=2.22.0
+ARG TENSORFLOW_PACKAGE
+RUN WHEEL="${TENSORFLOW_PACKAGE}"; \
+    if [ -z "${WHEEL}" ]; then \
+      CP_VERS=$(echo $PYTHON_VERSION | sed 's/\.//g'); \
+      WHEEL="tensorflow-${TF_VERSION}.dev0+selfbuilt-cp${CP_VERS}-cp${CP_VERS}-linux_x86_64.whl"; \
+    fi; \
+    wget ${TF_PKG_LOC}/${WHEEL} -O /${TF_PKGS_DIR}/${WHEEL} && \
+    pip install --no-cache-dir /${TF_PKGS_DIR}/${WHEEL}
+
+RUN echo 'ALL ALL=NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
+
+ARG TF_TESTING_FL
+ENV TF_TESTING_FL=${TF_TESTING_FL}
+ARG DWLD_TF_SRC_CMD
+RUN if [ -n "${DWLD_TF_SRC_CMD}" ]; then eval "${DWLD_TF_SRC_CMD}"; fi
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel && \
+    chmod +x /usr/local/bin/bazel
+RUN git clone https://github.com/tensorflow/models.git
+RUN git clone https://github.com/tensorflow/examples.git
+RUN git clone https://github.com/tensorflow/autograph.git
+RUN git clone https://github.com/tensorflow/benchmarks.git

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -50,8 +50,8 @@ else
         ROCM_VERS=$ROCM_VERSION
 fi
 
-# hardcode to 7.0.2
-AMDGPU_REPO_VERS=7.0.2
+# hardcode to 7.0.3
+AMDGPU_REPO_VERS=7.0.3
 
 if [[ "$DISTRO" == "focal" ]] || [[ "$DISTRO" == "jammy" ]] || [[ "$DISTRO" == "noble" ]]; then
     ROCM_DEB_REPO_HOME=https://repo.radeon.com/rocm/apt/

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -22,6 +22,7 @@
 #   - jammy
 #   - el7
 #   - el8
+#   - bookworm
 set -x
 
 # Get arguments (or defaults)
@@ -31,11 +32,11 @@ if [[ -n $1 ]]; then
     ROCM_VERSION=$1
 fi
 if [[ -n $2 ]]; then
-    if [[ "$2" == "focal" ]] || [[ "$2" == "jammy" ]] || [[ "$2" == "noble" ]] || [[ "$2" == "el7" ]] || [[ "$2" == "el8" ]]; then
+    if [[ "$2" == "focal" ]] || [[ "$2" == "jammy" ]] || [[ "$2" == "noble" ]] || [[ "$2" == "el7" ]] || [[ "$2" == "el8" ]] || [[ "$2" == "bookworm" ]]; then
         DISTRO=$2
     else
         echo "Distro not supported"
-        echo "Supported distros are:\n focal\n jammy\n noble\n el7\n el8"
+        echo "Supported distros are:\n focal\n jammy\n noble\n el7\n el8\n bookworm"
 	exit 1
     fi
 fi
@@ -137,6 +138,56 @@ elif [[ "$DISTRO" == "el8" ]]; then
 
     # install hipblasLT if available
     dnf --enablerepo=extras,epel,elrepo,build_system install -y hipblaslt-devel || true
+
+elif [[ "$DISTRO" == "bookworm" ]]; then
+    ROCM_DEB_REPO_HOME=https://repo.radeon.com/rocm/apt/
+    AMDGPU_DEB_REPO_HOME=https://repo.radeon.com/amdgpu/
+    ROCM_BUILD_NAME=${DISTRO}
+    ROCM_BUILD_NUM=main
+
+    # Adjust the ROCM repo location
+    ROCM_DEB_REPO=${ROCM_DEB_REPO_HOME}${ROCM_VERS}/
+    AMDGPU_DEB_REPO=${AMDGPU_DEB_REPO_HOME}${AMDGPU_REPO_VERS}/
+
+    DEBIAN_FRONTEND=noninteractive apt-get --allow-unauthenticated update 
+    DEBIAN_FRONTEND=noninteractive apt install -y wget software-properties-common
+    DEBIAN_FRONTEND=noninteractive apt-get clean all
+
+    if [ ! -f "/${CUSTOM_INSTALL}" ]; then
+        # Make the directory if it doesn't exist yet.
+        # This location is recommended by the distribution maintainers.
+        mkdir --parents --mode=0755 /etc/apt/keyrings
+
+        # Download the key, convert the signing-key to a full
+        # keyring required by apt and store in the keyring directory
+        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+            gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null
+
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] $AMDGPU_DEB_REPO/ubuntu jammy $ROCM_BUILD_NUM" | tee --append /etc/apt/sources.list.d/amdgpu.list
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] $ROCM_DEB_REPO jammy $ROCM_BUILD_NUM" | tee /etc/apt/sources.list.d/rocm.list
+        echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+             | tee /etc/apt/preferences.d/rocm-pin-600
+    else
+        bash "/${CUSTOM_INSTALL}"
+    fi
+    apt-get update --allow-insecure-repositories
+
+    wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+    echo "deb [arch=amd64 trusted=yes] http://apt.llvm.org/$DISTRO/ llvm-toolchain-$DISTRO-18 main" | tee /etc/apt/sources.list.d/llvm.list
+    apt-get update --allow-insecure-repositories
+
+    # install rocm
+    /setup.packages.sh /devel.packages.rocm.txt
+
+    MIOPENKERNELS=$( \
+                        apt-cache search --names-only miopen-hip-gfx | \
+                        awk '{print $1}' | \
+                        grep -F -v . || \
+                        true )
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated ${MIOPENKERNELS}
+
+    #install hipblasLT if available
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated hipblaslt-dev || true
 fi
 
 function ver { printf "%03d%03d%03d" $(echo "$1" | tr '.' ' '); }


### PR DESCRIPTION
## Motivation

This PR adds Dockerfiles for Deb12 support.

## Technical Details

`setup.rocm.sh` was modified to support Deb12 in accordance with:
- ROCm packages -> https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/install-methods/package-manager/package-manager-debian.html#register-packages
- driver -> https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/install/detailed-install/package-manager/package-manager-debian.html#register-kernel-mode-driver

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
