### PR TITLE
Add both absolute and relative rocm paths to include clang headers

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_xla.sh
@@ -55,7 +55,7 @@ if [ ! -d /tf ];then
 	mkdir /tf
 fi
  
-bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc test \
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
 	--config=sigbuild_local_cache \
 	--config=rocm \
 	--config=xla_cpp_filters \

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -140,10 +140,16 @@ def _rocm_include_path(repository_ctx, rocm_config, bash_bin):
     if resource_dir_result.return_code:
         auto_configure_fail("Failed to run hipcc -print-resource-dir: %s" % err_out(resource_dir_result))
 
-    resource_dir = resource_dir_result.stdout.strip()
+    resource_dir_abs = resource_dir_result.stdout.strip()
+
+    resource_dir_rel = relative_to(repository_ctx, str(rocm_path.realpath), resource_dir_abs, bash_bin)
+
+    resource_dir = str(rocm_path.get_child(resource_dir_rel))
 
     inc_dirs.append(resource_dir + "/include")
     inc_dirs.append(resource_dir + "/share")
+    inc_dirs.append(resource_dir_abs + "/include")
+    inc_dirs.append(resource_dir_abs + "/share")
 
     return inc_dirs
 

--- a/third_party/xla/xla/service/compiler.cc
+++ b/third_party/xla/xla/service/compiler.cc
@@ -32,7 +32,7 @@ namespace xla {
 Compiler::TargetConfig::TargetConfig(se::StreamExecutor* s)
     : device_description(s->GetDeviceDescription()),
       platform_name(s->GetPlatform()->Name()),
-      device_description_str(s->GetDeviceDescription().name()) {
+      device_description_str(s->GetDeviceDescription().rocm_compute_capability().gcn_arch_name()) {
   se::dnn::DnnSupport* dnn = s->AsDnn();
   if (dnn != nullptr) {
     absl::StatusOr<se::dnn::VersionInfo> dnn_version = dnn->GetVersion();

--- a/third_party/xla/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/third_party/xla/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -66,6 +66,7 @@ cc_library(
         "GOOGLE_CUDA=1",
     ]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
+        ":amdgpu_device_lib_data",
         "//xla:status_macros",
         "//xla:types",
         "//xla:util",
@@ -119,7 +120,6 @@ cc_library(
         "@local_config_rocm//rocm:rocm_headers",
         "@llvm-project//llvm:AMDGPUCodeGen",
         "@llvm-project//llvm:AMDGPUAsmParser",
-        ":amdgpu_device_lib_data",
     ]) + if_sycl_is_configured([
         "@spirv_llvm_translator//:spirv_llvm_translator",
     ]),


### PR DESCRIPTION
## Motivation
On MI355 with new 7.1.1 and 7.2 docker images TF 2.18 fails to build with clang include path not found. Adding rocm relative path /opt/rocm is not sufficient as it looks for absolute path as well.

## Technical Details

Add both relative and absolute paths for clang headers to be included



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
