### PR TITLE
Add the TF sync workflow for Claude

### DIFF
--- a/.claude/daily_sync.sh
+++ b/.claude/daily_sync.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+# Daily upstream sync for ROCm/tensorflow-upstream
+#
+# Runs the full /sync skill via Claude Code CLI.
+# Assumes it is running inside a Docker container with:
+#   - Claude Code installed and ANTHROPIC_API_KEY set
+#   - ROCm tools, bazel, python3, etc. available
+#   - The repo mounted/available at REPO_DIR
+#
+# Cron entry (add with `crontab -e`):
+#   0 5 * * * /workspace/.claude/daily_sync.sh >> /var/log/tf_daily_sync.log 2>&1
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(dirname "$SCRIPT_DIR")}"
+DATE_LABEL=$(date -u +%y%m%d)
+LOG_DIR="$REPO_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/sync_${DATE_LABEL}.log"
+
+cleanup() {
+    echo ""
+    echo "=== Sync interrupted — $(date -u '+%Y-%m-%d %H:%M:%S UTC') ==="
+    exit 130
+}
+trap cleanup INT TERM
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "=== TF ROCm Daily Sync — $(date -u '+%Y-%m-%d %H:%M:%S UTC') ==="
+
+cd "$REPO_DIR"
+
+# Ensure on develop-upstream and up to date
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "develop-upstream" ]]; then
+    echo "Switching to develop-upstream (was on '$CURRENT_BRANCH')..."
+    git checkout develop-upstream
+fi
+git pull --ff-only origin develop-upstream
+
+# Skip if today's sync branch already exists
+SYNC_BRANCH="develop-upstream-sync-${DATE_LABEL}"
+if git rev-parse --verify "$SYNC_BRANCH" >/dev/null 2>&1 || \
+   git ls-remote --heads origin "$SYNC_BRANCH" 2>/dev/null | grep -q "$SYNC_BRANCH"; then
+    echo "Sync branch '$SYNC_BRANCH' already exists. Skipping."
+    exit 0
+fi
+
+# Run the full sync.
+# - stream-json is captured to JSONL_LOG via tee (full detail for post-mortem)
+# - jq filter converts it to human-readable lines for the main LOG_FILE
+JSONL_LOG="$LOG_DIR/sync_${DATE_LABEL}.jsonl"
+STDERR_LOG="$LOG_DIR/sync_${DATE_LABEL}.stderr"
+echo "Starting /sync $DATE_LABEL ..."
+echo "Full event log: $JSONL_LOG"
+set +e  # allow pipeline to fail without exiting
+stdbuf -oL claude -p "/sync $DATE_LABEL" \
+    --dangerously-skip-permissions \
+    --model opus \
+    --verbose \
+    --output-format stream-json 2>"$STDERR_LOG" | \
+stdbuf -oL tee "$JSONL_LOG" | \
+jq --unbuffered -rj '
+  if .type == "assistant" then
+    (.message.content[] |
+      if .type == "text" then .text + "\n"
+      elif .type == "tool_use" then "[tool] " + .name + ": " + (.input | tostring | .[0:300]) + "\n"
+      else empty end)
+  elif .type == "result" then
+    "[done] " + .subtype + " cost=$" + (.cost_usd | tostring) + "\n"
+  else empty end
+' 2>/dev/null
+SYNC_EXIT=${PIPESTATUS[0]}
+set -e
+
+echo ""
+if [[ $SYNC_EXIT -ne 0 ]]; then
+    echo "claude exited with code $SYNC_EXIT"
+    [[ -s "$STDERR_LOG" ]] && echo "stderr:" && cat "$STDERR_LOG"
+fi
+echo "=== Sync finished — $(date -u '+%Y-%m-%d %H:%M:%S UTC') ==="
+
+# Report result
+if git rev-parse --verify "$SYNC_BRANCH" >/dev/null 2>&1; then
+    COMMIT_COUNT=$(git rev-list --count "develop-upstream..$SYNC_BRANCH")
+    echo "Branch '$SYNC_BRANCH' created with $COMMIT_COUNT commit(s)."
+    git log --oneline "develop-upstream..$SYNC_BRANCH"
+else
+    echo "WARNING: Sync branch '$SYNC_BRANCH' was not created. Check the log."
+    exit 1
+fi

--- a/.claude/dump_sync_log.py
+++ b/.claude/dump_sync_log.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+dump_sync_log.py — pretty-print a Claude sync session from a .jsonl event log.
+
+Usage:
+    python3 .claude/dump_sync_log.py logs/sync_260312.jsonl
+    python3 .claude/dump_sync_log.py logs/sync_260312.jsonl --mode reasoning
+    python3 .claude/dump_sync_log.py logs/sync_260312.jsonl --tool-results all
+
+Modes:
+    full       Show everything: Claude text, all tool calls + results (default)
+    reasoning  Show only Claude prose + subagent calls/results (skip bash/read/edit noise)
+    summary    Show only Claude prose (no tool calls or results)
+
+--tool-results:
+    agents     Show results only for Agent subagent calls (default)
+    all        Show results for every tool call
+    none       Never show tool results
+"""
+
+import json
+import sys
+import argparse
+import textwrap
+from datetime import timedelta
+
+# ── ANSI colours ──────────────────────────────────────────────────────────────
+RESET  = "\033[0m"
+BOLD   = "\033[1m"
+DIM    = "\033[2m"
+CYAN   = "\033[36m"
+GREEN  = "\033[32m"
+YELLOW = "\033[33m"
+RED    = "\033[31m"
+BLUE   = "\033[34m"
+MAGENTA= "\033[35m"
+
+def c(color, text):
+    return f"{color}{text}{RESET}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+def wrap(text, indent=4, width=100):
+    lines = text.splitlines()
+    out = []
+    for line in lines:
+        if len(line) <= width - indent:
+            out.append(" " * indent + line)
+        else:
+            wrapped = textwrap.wrap(line, width=width - indent,
+                                    break_long_words=False, break_on_hyphens=False)
+            out.extend(" " * indent + l for l in (wrapped or [line]))
+    return "\n".join(out)
+
+def hr(char="─", width=100):
+    return char * width
+
+def fmt_duration(ms):
+    s = ms / 1000
+    if s < 60:
+        return f"{s:.1f}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{int(m)}m{int(s):02d}s"
+    h, m = divmod(m, 60)
+    return f"{int(h)}h{int(m):02d}m{int(s):02d}s"
+
+def fmt_cost(usd):
+    return f"${usd:.4f}" if usd is not None else "$?"
+
+def extract_text(content):
+    """Extract plain text from a tool_result content field (str or list of blocks)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block["text"])
+        return "\n".join(parts)
+    return str(content)
+
+# ── Tool categories ───────────────────────────────────────────────────────────
+NOISE_TOOLS = {"TodoWrite", "TaskUpdate", "TaskCreate", "TaskList", "TaskGet"}
+READ_TOOLS  = {"Read", "Glob", "Grep"}
+EXEC_TOOLS  = {"Bash", "Edit", "Write"}
+
+def tool_color(name):
+    if name == "Agent":       return MAGENTA
+    if name in EXEC_TOOLS:    return YELLOW
+    if name in READ_TOOLS:    return CYAN
+    if name in NOISE_TOOLS:   return DIM
+    return BLUE
+
+# ── Main printer ──────────────────────────────────────────────────────────────
+def dump(jsonl_path, mode="full", tool_results_mode="agents"):
+    with open(jsonl_path) as f:
+        events = [json.loads(l) for l in f if l.strip()]
+
+    # Build id→(name, input) map for labelling tool results
+    tool_map = {}   # tool_use_id → {"name": ..., "input": ...}
+    for e in events:
+        if e.get("type") == "assistant":
+            for block in e.get("message", {}).get("content", []):
+                if block.get("type") == "tool_use":
+                    tool_map[block["id"]] = {
+                        "name":  block["name"],
+                        "input": block.get("input", {}),
+                    }
+
+    # ── Session header ────────────────────────────────────────────────────────
+    init = next((e for e in events if e.get("type") == "system"
+                                   and e.get("subtype") == "init"), None)
+    result = next((e for e in events if e.get("type") == "result"), None)
+
+    model   = init.get("model", "?") if init else "?"
+    sess_id = (init.get("session_id", "") if init else "")[:8]
+
+    print()
+    print(c(BOLD + CYAN, hr("═")))
+    print(c(BOLD + CYAN, f"  SYNC SESSION  {model}  [{sess_id}]"))
+    if result:
+        dur  = fmt_duration(result.get("duration_ms", 0))
+        cost = fmt_cost(result.get("total_cost_usd"))
+        turns = result.get("num_turns", "?")
+        mu = result.get("modelUsage", {})
+        tokens_out = sum(v.get("outputTokens", 0) for v in mu.values())
+        tokens_in  = sum(v.get("inputTokens", 0) + v.get("cacheReadInputTokens", 0)
+                         for v in mu.values())
+        print(c(CYAN, f"  duration={dur}  turns={turns}  "
+                       f"cost={cost}  in={tokens_in:,}tok  out={tokens_out:,}tok"))
+    print(c(BOLD + CYAN, hr("═")))
+    print()
+
+    # ── Walk events ───────────────────────────────────────────────────────────
+    for e in events:
+        etype = e.get("type")
+
+        # ── system: compact boundary / continuation summary ──────────────────
+        if etype == "system" and e.get("subtype") == "compact_boundary":
+            print(c(DIM, hr("·")))
+            print(c(DIM, "  [context compacted — conversation summary injected]"))
+            print(c(DIM, hr("·")))
+            print()
+            continue
+
+        # ── assistant event ──────────────────────────────────────────────────
+        if etype == "assistant":
+            for block in e.get("message", {}).get("content", []):
+
+                # Claude's prose text
+                if block.get("type") == "text":
+                    text = block["text"].strip()
+                    if not text:
+                        continue
+                    print(c(BOLD + GREEN, "▌ CLAUDE"))
+                    print(wrap(text, indent=2))
+                    print()
+
+                # Tool call
+                elif block.get("type") == "tool_use":
+                    name  = block["name"]
+                    inp   = block.get("input", {})
+                    tid   = block["id"]
+                    col   = tool_color(name)
+
+                    # summary: no tool calls at all
+                    if mode == "summary":
+                        continue
+                    # reasoning: only show Agent (subagent) calls, skip everything else
+                    if mode == "reasoning" and name != "Agent":
+                        continue
+                    # full: skip only pure noise tools (todo trackers)
+                    if mode == "full" and name in NOISE_TOOLS:
+                        continue
+
+                    if name == "Agent":
+                        # Subagent — always show full prompt
+                        desc   = inp.get("description", "")
+                        prompt = inp.get("prompt", "")
+                        subtype = inp.get("subagent_type", "")
+                        model_override = inp.get("model", "")
+                        print(c(BOLD + MAGENTA, f"▶ SUBAGENT  {desc}"))
+                        if subtype:
+                            print(c(MAGENTA, f"  type={subtype}"), end="")
+                        if model_override:
+                            print(c(MAGENTA, f"  model={model_override}"), end="")
+                        print()
+                        if prompt:
+                            print(c(DIM, "  ── prompt ──"))
+                            print(wrap(prompt, indent=4))
+                        print()
+                    else:
+                        # Regular tool call
+                        # Build a short human-readable summary of the input
+                        if "command" in inp:
+                            summary = inp["command"]
+                            desc_str = inp.get("description", "")
+                            label = desc_str if desc_str else summary
+                        elif "file_path" in inp:
+                            label = inp["file_path"]
+                            if "offset" in inp or "limit" in inp:
+                                label += f"  [lines {inp.get('offset',1)}–{inp.get('offset',1)+inp.get('limit',0)-1}]"
+                        elif "pattern" in inp:
+                            label = inp.get("pattern", "")
+                            if "path" in inp:
+                                label += f"  in {inp['path']}"
+                        elif "prompt" in inp:
+                            label = inp["prompt"][:120]
+                        else:
+                            label = json.dumps(inp)[:120]
+
+                        print(c(col, f"  [{name}]  {label}"))
+
+                        # Show full input if requested (all mode, or for key tools)
+                        if (mode == "full" and tool_results_mode == "all"
+                                and name not in NOISE_TOOLS):
+                            full = json.dumps(inp, indent=6)
+                            if len(full) > 2000:
+                                full = full[:2000] + "\n      … (truncated)"
+                            print(c(DIM, wrap(full, indent=6)))
+                        print()
+
+        # ── user event: tool results ─────────────────────────────────────────
+        elif etype == "user":
+            for block in e.get("message", {}).get("content", []):
+
+                # Injected system text (continuation summaries)
+                if block.get("type") == "text":
+                    text = block["text"].strip()
+                    if text.startswith("This session is being continued"):
+                        print(c(DIM, "  [continuation summary — session was compacted]"))
+                        print(wrap(text[:600] + ("…" if len(text) > 600 else ""),
+                                   indent=4))
+                        print()
+                    continue
+
+                if block.get("type") != "tool_result":
+                    continue
+
+                tid     = block.get("tool_use_id", "")
+                tool    = tool_map.get(tid, {})
+                tname   = tool.get("name", "?")
+                content = extract_text(block.get("content", ""))
+                is_err  = block.get("is_error", False)
+
+                if mode == "summary":
+                    continue
+                if mode == "reasoning" and tname != "Agent":
+                    continue
+                if tool_results_mode == "none":
+                    continue
+                if tool_results_mode == "agents" and tname != "Agent":
+                    continue
+                if tname in NOISE_TOOLS and tool_results_mode != "all":
+                    continue
+
+                if tname == "Agent":
+                    desc = tool.get("input", {}).get("description", "")
+                    print(c(BOLD + MAGENTA, f"◀ SUBAGENT RESULT  {desc}"))
+                    if is_err:
+                        print(c(RED, "  ERROR"))
+                    print(wrap(content, indent=4))
+                    print()
+                else:
+                    col = RED if is_err else tool_color(tname)
+                    tag = "ERROR" if is_err else "result"
+                    print(c(col, f"  [{tname} {tag}]"))
+                    # Trim very long results
+                    if len(content) > 1500:
+                        content = content[:1500] + "\n  … (truncated)"
+                    print(wrap(content, indent=4))
+                    print()
+
+        # ── final result ─────────────────────────────────────────────────────
+        elif etype == "result":
+            print(c(BOLD + CYAN, hr("═")))
+            sub   = e.get("subtype", "?")
+            err   = e.get("is_error", False)
+            col   = RED if err else GREEN
+            print(c(BOLD + col, f"  DONE  {sub.upper()}"))
+            if e.get("result"):
+                print(wrap(e["result"], indent=4))
+            print()
+            # Cost breakdown per model
+            for mname, mu in e.get("modelUsage", {}).items():
+                print(c(DIM,
+                    f"  {mname}: "
+                    f"in={mu.get('inputTokens',0):,} "
+                    f"cache_read={mu.get('cacheReadInputTokens',0):,} "
+                    f"cache_write={mu.get('cacheCreationInputTokens',0):,} "
+                    f"out={mu.get('outputTokens',0):,} "
+                    f"cost={fmt_cost(mu.get('costUSD'))}"))
+            print(c(BOLD + CYAN, hr("═")))
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pretty-print a Claude sync session JSONL log",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__)
+    parser.add_argument("jsonl", help="Path to the .jsonl event log")
+    parser.add_argument(
+        "--mode", choices=["full", "reasoning", "summary"],
+        default="full",
+        help="full=everything  reasoning=prose+subagents  summary=prose only")
+    parser.add_argument(
+        "--tool-results", dest="tool_results",
+        choices=["agents", "all", "none"],
+        default="agents",
+        help="Which tool results to show (default: agents only)")
+    args = parser.parse_args()
+
+    dump(args.jsonl, mode=args.mode, tool_results_mode=args.tool_results)
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "allowedTools": [
+    "Edit",
+    "Read",
+    "Grep",
+    "Glob",
+    "Write",
+    "Bash(git *)",
+    "Bash(date *)",
+    "Bash(echo *)",
+    "Bash(grep *)",
+    "Bash(ls *)",
+    "Bash(test *)",
+    "Bash(bash -n *)",
+    "Bash(mkdir *)",
+    "Bash(chmod *)",
+    "Bash(./build_rocm_python3*)",
+    "Bash(.claude/skills/sync-test-check/scripts/run_single_xla_test.sh *)",
+    "Bash(.claude/skills/sync-test-check/scripts/run_single_gpu_test.sh *)",
+    "Bash(.claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh *)",
+    "Bash(yes *)",
+    "Bash(python3 *)",
+    "Bash(which *)",
+    "Bash(rocm-smi *)",
+    "Bash(rocminfo *)",
+    "Bash(bazel *)"
+  ]
+}

--- a/.claude/skills/sync-build/SKILL.md
+++ b/.claude/skills/sync-build/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: sync-build
+description: Build TensorFlow after sync conflict resolution. Runs build_rocm_python3, diagnoses and fixes any build failures, and repeats until the build succeeds and a wheel is produced.
+---
+
+# Build TensorFlow After Upstream Sync
+
+You are building TensorFlow after the upstream sync conflict resolution for `ROCm/tensorflow-upstream`. The `/sync-start` and `/sync-resolve` skills have already completed — the sync branch has a first commit with unresolved conflicts and a second commit that fixes them. Now you need to verify the merge compiles and produces a working wheel.
+
+**Note:** Run `/sync-ci-mirror` before this skill to check for upstream CI changes that need ROCm mirroring.
+
+Run all steps automatically without asking for confirmation unless a fix is genuinely ambiguous.
+
+## Pre-flight checks
+
+Run these checks first and STOP (report the problem) if any fail:
+
+1. Confirm the current branch matches `develop-upstream-sync-*`. If not, STOP.
+2. Confirm there are no remaining conflict markers:
+   ```bash
+   grep -rn "<<<<<<" --include="*" -l
+   ```
+   If any are found, STOP and tell the user to run `/sync-resolve` first.
+3. Confirm `build_rocm_python3` exists in the repo root and is executable.
+
+## Step 1: Run the build
+
+The TF build takes a very long time (often 1-3 hours). You MUST use background execution with periodic progress monitoring.
+
+### 1.1 Launch the build in the background
+
+Use the Bash tool with `run_in_background: true` to start the build. This removes the timeout limit and lets you monitor progress:
+
+```
+Tool: Bash
+command: ./build_rocm_python3 2>&1
+run_in_background: true
+```
+
+This returns a **task ID**. Save it — you need it to monitor progress.
+
+### 1.2 Monitor build progress
+
+After launching, periodically check progress using the `TaskOutput` tool with `block: false` to get a non-blocking snapshot of the current output:
+
+```
+Tool: TaskOutput
+task_id: <the task ID from 1.1>
+block: false
+timeout: 30000
+```
+
+- Report a brief progress summary to the user each time (e.g., "Bazel is compiling... 1,523 of 24,000 actions")
+- Check every 60-90 seconds using `TaskOutput` with `block: false`
+- Look for key progress indicators in the output:
+  - `Analyzing:` — Bazel is loading/analyzing the build graph
+  - `[X,XXX / YY,YYY]` — Bazel action progress (X of Y actions completed)
+  - `Building ...` — compilation in progress
+  - `PASSED` / `FAILED` — build finished
+  - `ERROR` — build error occurred
+- Continue polling until the task status shows completed (either success or failure)
+
+### 1.3 Check build result
+
+Once the task completes, check the final output for the exit code.
+
+**Success criteria:** The build is successful if and only if:
+- The `build_rocm_python3` script exits with code 0, AND
+- A `.whl` file exists in `bazel-bin/tensorflow/tools/pip_package/wheel_house/`
+
+Verify the wheel exists:
+```bash
+ls bazel-bin/tensorflow/tools/pip_package/wheel_house/*.whl
+```
+
+If the build succeeds on the first try, skip to **Step 3: Commit and report**.
+
+## Step 2: Diagnose and fix build failures (iterate)
+
+If the build fails, follow this loop:
+
+### 2.1 Analyze the build error
+
+Read the build output carefully. Common failure patterns after an upstream sync:
+
+- **Missing/renamed files:** Upstream moved or deleted files that ROCm code references. Fix imports/includes and BUILD deps.
+- **API changes:** Upstream changed function signatures, class names, or namespaces. Update ROCm code to match the new API.
+- **Duplicate symbols:** Both sides added similar code. Remove the duplicate, keeping the upstream version and preserving ROCm-specific behavior.
+- **Missing BUILD dependencies:** New upstream code needs deps that aren't in ROCm BUILD files. Add the missing deps.
+- **Incompatible macro/config changes:** Bazel macros or config settings changed upstream. Adapt ROCm build configs accordingly.
+- **Header include path changes:** Upstream reorganized headers. Update `#include` paths.
+
+### 2.2 Fix the error
+
+Apply the minimal fix needed to resolve the build error. Follow these principles:
+
+- **Minimal changes:** Fix only what is broken. Do not refactor or clean up surrounding code.
+- **Follow upstream patterns:** When adapting to upstream API changes, follow the same patterns used in upstream's own code.
+- **Preserve ROCm code:** Keep `#if TENSORFLOW_USE_ROCM` blocks, ROCm-specific implementations, and ROCm BUILD deps. Adapt them to new APIs rather than removing them.
+- **Mirror CUDA patterns:** If upstream changed CUDA code, make the corresponding change in the ROCm equivalent.
+- **Do NOT modify test exclusion scripts** (`run_xla.sh`, `run_gpu_single.sh`). That happens after CI runs.
+
+### 2.3 Rebuild
+
+After applying fixes, run the build again using the same background pattern from Step 1:
+
+```
+Tool: Bash
+command: ./build_rocm_python3 2>&1
+run_in_background: true
+```
+
+Monitor progress with `TaskOutput` (block: false) as before. Then verify the success criteria again (exit code 0 + wheel file exists).
+
+### 2.4 Repeat
+
+Continue the diagnose → fix → rebuild cycle until the build succeeds. If after 5 iterations the build still fails:
+- Commit whatever fixes have been applied so far
+- Report the remaining build error in detail
+- STOP and ask the user for guidance
+
+## Step 3: Commit and report
+
+Once the build succeeds:
+
+### 3.1 Commit build fixes (if any)
+
+If any code changes were made to fix build errors:
+
+```bash
+git add -u
+git commit -m "Fix build errors from upstream sync"
+```
+
+Use `git add -u` (not `git add -A`) to avoid accidentally staging untracked files.
+
+If no code changes were needed (build passed on first try), skip the commit.
+
+### 3.2 Report
+
+Provide a structured summary:
+
+**Build result:** SUCCESS
+
+**Wheel location:**
+```
+bazel-bin/tensorflow/tools/pip_package/wheel_house/<wheel-filename>.whl
+```
+
+**Build fixes applied** (if any):
+
+For each file modified:
+```
+### `path/to/file`
+**Error:** Brief description of the build error
+**Fix:** What was changed and why
+```
+
+**Summary table** (if fixes were applied):
+
+| File | Error Type | Fix |
+|------|-----------|-----|
+| file1.cc | Missing include | Updated include path to match upstream rename |
+| BUILD | Missing dep | Added new upstream dep |
+
+**If no fixes were needed:**
+"Build passed cleanly after conflict resolution. No additional changes required."
+
+Finish with: "Upstream sync build verified. Ready to push and open a PR."
+
+## Important notes
+- Do NOT push anything. The user will push when ready.
+- Do NOT modify test exclusion scripts.
+- The build can take a very long time. Be patient and let it complete.
+- When fixing build errors, prefer the smallest possible change. Each fix should address exactly one error.
+- If the same file needs multiple fixes across rebuild iterations, that is fine — they will all be captured in a single "Fix build errors" commit.

--- a/.claude/skills/sync-ci-mirror/SKILL.md
+++ b/.claude/skills/sync-ci-mirror/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: sync-ci-mirror
+description: Mirror upstream CI changes to ROCm counterparts. Checks ci/official and tf_sig_build_dockerfiles for upstream changes and applies matching updates to ROCm-specific Dockerfiles, env configs, and package lists.
+---
+
+# Mirror Upstream CI Changes to ROCm Counterparts
+
+You are checking whether the upstream sync introduced CI changes that need to be mirrored into ROCm-specific files. This is part of the regular upstream sync for `ROCm/tensorflow-upstream`.
+
+Upstream CI files have ROCm-specific counterparts that must stay in sync. When upstream modifies a base file, the corresponding ROCm file may need matching updates.
+
+Run all steps automatically without asking for confirmation unless a change is genuinely ambiguous.
+
+## Pre-flight checks
+
+1. Confirm the current branch matches `develop-upstream-sync-*`. If not, STOP.
+2. Confirm the working tree is clean (`git status`). If not, STOP.
+
+## Step 1: Identify what upstream changed
+
+Check if the upstream merge touched any of the CI base files:
+
+```bash
+git diff develop-upstream...HEAD --name-only -- ci/official/ tensorflow/tools/tf_sig_build_dockerfiles/
+```
+
+If no CI files were changed, report "No upstream CI changes require ROCm mirroring." and STOP.
+
+## Step 2: Analyze changes against known upstream → ROCm file pairs
+
+For each changed file, check if it has a ROCm counterpart that needs updating. The known pairs are listed below.
+
+### `ci/official/containers/ml_build/` (new official CI)
+
+| Upstream file | ROCm counterpart |
+|---|---|
+| `Dockerfile` | `Dockerfile.rocm` |
+| `setup.packages.sh` | *(shared — used by both)* |
+| `setup.python.sh` | *(shared — used by both)* |
+| `setup.sources.sh` | *(shared — used by both)* |
+| `builder.packages.txt` | *(shared — used by both)* |
+| `builder.requirements.txt` | *(shared — used by both)* |
+
+The ROCm Dockerfile (`Dockerfile.rocm`) mirrors the upstream `Dockerfile` but replaces CUDA/NVIDIA sections with ROCm installation. When upstream changes the `Dockerfile`, check whether the same change applies to `Dockerfile.rocm` — specifically:
+- Python version additions/removals/reordering
+- Tool version bumps (bats, bazelisk, buildifier, buildozer, patchelf)
+- New shared setup steps or COPY instructions
+- Base image updates
+- Bazel cache configuration changes
+
+The shared scripts (`setup.packages.sh`, `setup.python.sh`, etc.) are used by both Dockerfiles — if upstream changed these, the ROCm build benefits automatically. No ROCm mirroring needed for those.
+
+### `ci/official/envs/`
+
+| Upstream file | ROCm counterpart |
+|---|---|
+| `linux_x86` | `linux_x86_rocm` |
+
+The ROCm env file sources (`source ci/official/envs/linux_x86`) the upstream base and overrides specific variables. If upstream changed `linux_x86`, check whether:
+- New variables were added that `linux_x86_rocm` should override
+- Existing variables that `linux_x86_rocm` overrides were renamed or removed
+- Default values changed that affect ROCm builds
+
+### `tensorflow/tools/tf_sig_build_dockerfiles/` (SIG build)
+
+| Upstream file | ROCm counterparts |
+|---|---|
+| `Dockerfile` | `Dockerfile.rocm` (primary), `Dockerfile.rocm.ub20`, `Dockerfile.rocm.ub22`, `Dockerfile.rocm.ub24`, `Dockerfile.rocm.manylinux_2_28` |
+| `setup.packages.sh` | `setup.packages.rocm.el8.sh`, `setup.packages.rocm.cs7.sh` (distro-specific) |
+| `devel.packages.txt` | `devel.packages.rocm.txt`, `devel.packages.rocm.el8.txt`, `devel.packages.rocm.cs7.txt` |
+| `builder.packages.txt` | `builder.packages.rocm.el8.txt`, `builder.packages.rocm.cs7.txt` |
+| `setup.sources.sh` | *(shared — used by both)* |
+| `devel.requirements.txt` | *(shared — used by both)* |
+
+The SIG build ROCm Dockerfiles are more divergent from upstream (different base images, multi-stage vs single-stage), but shared sections should still be mirrored:
+- Tool versions (bats, bazelisk, buildifier, buildozer, patchelf)
+- Python setup changes
+- Package list updates (new shared dependencies)
+- Build environment configuration
+
+## Step 3: Apply mirroring updates
+
+For each upstream file that was changed in this sync and has a ROCm counterpart:
+
+1. Read the upstream file's diff to understand what changed:
+   ```bash
+   git diff develop-upstream...HEAD -- <upstream-file>
+   ```
+2. Read the ROCm counterpart file
+3. Determine if the change applies to the ROCm version:
+   - **YES, mirror it:** Tool version bumps, Python changes, shared infrastructure updates, new build steps
+   - **NO, skip it:** CUDA/NVIDIA-specific changes, changes already handled differently in the ROCm file
+4. Apply the change to the ROCm file using the Edit tool
+
+## Step 4: Commit
+
+If any ROCm CI files were updated:
+
+```bash
+git add -u
+git commit -m "Mirror upstream CI changes to ROCm counterparts"
+```
+
+Use `git add -u` (not `git add -A`) to avoid accidentally staging untracked files.
+
+If no mirroring was needed (all upstream changes were to shared files or NVIDIA-specific), skip the commit.
+
+## Step 5: Report
+
+Provide a structured summary:
+
+### Upstream CI files changed
+- List all CI files modified by the upstream merge
+
+### ROCm counterparts updated
+
+For each file updated:
+```
+### `path/to/rocm-file`
+**Upstream change:** What changed in the upstream file
+**Mirrored:** What was updated in the ROCm counterpart and why
+```
+
+### Changes skipped
+- List upstream changes that did NOT require ROCm mirroring and why (e.g., "NVIDIA-specific", "shared file — ROCm benefits automatically")
+
+### Summary table
+
+| Upstream file | ROCm counterpart | Action | Reason |
+|---|---|---|---|
+| Dockerfile | Dockerfile.rocm | Updated | Python 3.14 added |
+| setup.python.sh | *(shared)* | Skipped | Shared file, no mirroring needed |
+
+## Important notes
+- Do NOT push anything. The user will push when ready.
+- Do NOT modify non-CI files. This skill is strictly for CI/official and tf_sig_build_dockerfiles mirroring.
+- When in doubt about whether a change applies to ROCm, mirror it — it is safer to keep the ROCm files up to date than to miss an update.

--- a/.claude/skills/sync-cuda-only/SKILL.md
+++ b/.claude/skills/sync-cuda-only/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: sync-cuda-only
+description: Validates newly added cuda-only tags from an upstream sync. Runs each affected test on ROCm and removes the tag if the test passes, preventing tests from being incorrectly hidden from ROCm CI. Use when user says "check cuda-only tags", "validate cuda-only", or as part of the sync pipeline after conflict resolution.
+---
+
+# Validate Newly Added cuda-only Tags
+
+You are checking whether `cuda-only` tags added by upstream in this sync are genuinely justified. Upstream sometimes adds `cuda-only` to tests that actually work on ROCm — this would silently exclude them from ROCm CI. Your job is to catch and reverse that.
+
+This is the mirror of Step 0 in `sync-test-check`, which handles *removed* `cuda-only` tags. This skill handles *added* ones.
+
+Run all steps automatically without asking the user.
+
+## Pre-flight checks
+
+1. Confirm the current branch matches `develop-upstream-sync-*`. If not, STOP.
+2. Confirm the helper script exists and is executable:
+   ```bash
+   test -x .claude/skills/sync-test-check/scripts/run_single_xla_test.sh && echo "OK"
+   ```
+
+## Step 1: Find newly added cuda-only tags
+
+```bash
+git diff develop-upstream HEAD -- "*.BUILD" "*/BUILD" "*/BUILD.bazel" | grep -A 10 '^+.*"cuda-only"'
+```
+
+For each added `cuda-only` line, identify the enclosing Bazel target by reading surrounding context (look for `name = "..."` within the same target block). Determine the full Bazel target path from the file path (e.g. `third_party/xla/xla/service/gpu/tests/BUILD` → `@xla//xla/service/gpu/tests:<target_name>`).
+
+If no newly added `cuda-only` tags are found, report "No newly added cuda-only tags found — nothing to do." and stop.
+
+Otherwise report the full list before proceeding.
+
+## Step 2: Check the exclusion list first
+
+Before inspecting source, check whether the test cases are already in the `run_xla.sh` exclusion list:
+
+```bash
+grep -A 5 "<test_name>" tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+```
+
+**If ALL test cases of a target are already in the exclusion list:** the `cuda-only` tag is almost certainly being misused as a secondary disable mechanism — not as a genuine CUDA-only marker. Mark it as "must run" and proceed to Step 3 regardless of what the source says.
+
+## Step 3: Inspect the test source
+
+Read the test source to classify it. Use these strict criteria:
+
+**Clearly justified — skip running only if ALL of the following are true:**
+- The test directly calls CUDA C APIs (`cudnn*`, `cublas*`, `cufft*`, `cuda*`) in C++ code — NOT just references these names in string literals or FileCheck patterns
+- OR the entire test logic is wrapped in `#if GOOGLE_CUDA`
+- AND there is no `GTEST_SKIP()` / `is_built_with_rocm_` self-skip already present
+
+**Must run — if ANY of the following are true:**
+- The test uses `GTEST_SKIP()` with a ROCm/CUDA check (it already self-skips — `cuda-only` is redundant)
+- The test uses `cuda_compute_capability()` only to select output patterns or expected values (the test body still runs on ROCm)
+- The test submits HLO/computation to XLA and checks the output via `MatchOptimizedHloWithShapes`, `RunAndCompare`, or similar — even if the CHECK patterns contain cuDNN target names as string literals (the strings are patterns, not API calls; the test may fail gracefully with autotuner errors rather than crashing)
+- The test contains no direct CUDA C API calls (cuDNN/cuBLAS function calls in C++ code)
+- The test is already in the exclusion list (Step 2)
+
+**Critical distinction:** `MatchOptimizedHloWithShapes(hlo, "CHECK: __cudnn$convForward")` is checking a string pattern — it is NOT a cuDNN API call. The test runs on ROCm; it may just fail on the assertion. Always run these.
+
+For clearly justified cases, note them and skip to the next target.
+
+## Step 4: Run each candidate test
+
+For each target that may be unjustified, run it on local GPU (no RBE needed — we just need to know if it runs at all):
+
+```
+Tool: Bash
+command: .claude/skills/sync-test-check/scripts/run_single_xla_test.sh "<bazel_target>" "" 2>&1 | tail -50
+run_in_background: true
+```
+
+Wait for each to complete before starting the next — **never run in parallel**.
+
+Use `TaskOutput` (block: true, timeout: 600000).
+
+## Step 5: Handle results
+
+### PASS — tag is unjustified
+
+Remove the `cuda-only` tag from the BUILD file. Commit immediately:
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+Remove incorrect cuda-only tag from <target>
+
+The cuda-only tag was added upstream but the test passes on ROCm.
+<One sentence explaining why the tag is wrong, e.g. "Test self-skips via
+GTEST_SKIP() on non-CUDA builds — cuda-only tag is redundant and hides
+the test from ROCm CI entirely.">
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### FAIL — tag is justified
+
+Leave the tag in place. Note it in the final report.
+
+### BUILD_ERROR
+
+The test fails to build — leave the tag, note it as a build issue for `sync-triage-test` to handle later.
+
+## Step 6: Report
+
+**cuda-only tags added upstream:** N
+**Skipped (clearly justified):** N
+**Tested:** N
+  - Tags removed (passes on ROCm): N — list targets
+  - Tags kept (genuinely cuda-only): N — list targets
+  - Build errors: N — list targets
+
+## Important notes
+
+- Do NOT push anything. The user will push when ready.
+- Tests must run sequentially — the `parallel_gpu_execute` flock is non-blocking and causes false failures under contention.
+- Each removed tag gets its own commit with the justification in the message.
+- If a test passes but you are unsure whether removing the tag is safe, remove it — it can always be re-added. A falsely excluded test is worse than a falsely included one.

--- a/.claude/skills/sync-resolve/SKILL.md
+++ b/.claude/skills/sync-resolve/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: sync-resolve
+description: Resolve merge conflicts after /sync-start. Analyzes the cause of each conflict using git history, resolves using ROCm conventions, and commits the fix.
+---
+
+# Resolve Upstream Sync Conflicts
+
+You are resolving merge conflicts created during the upstream sync of `ROCm/tensorflow-upstream`. The `/sync-start` skill has already created the sync branch and made the first commit with unresolved conflicts. In this context:
+- **Ours** = ROCm (`develop-upstream`) — our changes and ROCm-specific additions
+- **Theirs** = upstream (`tensorflow/tensorflow`) — the new upstream changes being merged in
+
+Reference the full sync process in `sync-process.md` at the repo root.
+
+Run all steps automatically. Only pause to ask the user when a conflict is genuinely ambiguous or a large conflict (>100 lines) needs confirmation of approach.
+
+## Pre-flight checks
+
+1. Confirm the current branch matches `develop-upstream-sync-*`. If not, STOP.
+2. Confirm the working tree is clean. If not, STOP.
+
+## Step 1: Find all conflict markers
+
+```bash
+grep -rn "<<<<<<" --include="*" -l
+```
+
+If none found: report "No conflict markers found." and STOP.
+
+List all conflicted files categorized by area:
+- **XLA/Compiler**: `third_party/xla/`
+- **StreamExecutor/GPU runtime**: `stream_executor/`
+- **Kernels/Ops**: `tensorflow/core/kernels/`
+- **Bazel/Build**: `BUILD`, `.bzl`, `WORKSPACE`
+- **CI scripts**: `tensorflow/tools/ci_build/`
+- **Other**
+
+## Step 2: Resolve conflicts file by file
+
+Process in this order: Bazel/Build → XLA → StreamExecutor → Kernels → CI → Other.
+
+For EACH conflicted file:
+
+### 2.1 Analyze the conflict and its cause (CRITICAL)
+
+Read the conflicted file to understand the conflict markers:
+- `<<<<<<< HEAD` — our version (ROCm/develop-upstream)
+- `=======` — separator
+- `>>>>>>> <commit>` — their version (upstream)
+
+Then **investigate WHY the conflict occurred** using git history on **both branches independently**.
+
+#### Step A: Identify the semantic entity containing the conflict
+
+Do not track raw line numbers — they differ between branches. Instead, identify the enclosing semantic entity (Bazel target name, function name, class name) by reading the file around the conflict markers. Then find the line range of that entity on each branch separately:
+
+```bash
+# Find the entity's line range on our branch
+git show develop-upstream:<file> | grep -n '<entity_name>'
+
+# Find the entity's line range on upstream
+git show upstream/master:<file> | grep -n '<entity_name>'
+```
+
+Read a window around each result to confirm the start and end lines of the full entity on each branch.
+
+#### Step B: Run git log -L on each branch with its own line numbers
+
+```bash
+# Full history of the entity on our branch (use line numbers from develop-upstream)
+git log -L <our_start>,<our_end>:<file> develop-upstream
+
+# Full history of the entity on upstream (use line numbers from upstream/master)
+git log -L <upstream_start>,<upstream_end>:<file> upstream/master
+```
+
+This reveals the complete evolution of the conflicting region on each side — every commit that touched it, in chronological order.
+
+#### Step C: Look at the broader context of each side's history
+
+When reading the `git log -L` output, pay attention to:
+
+- **Intentional upstream deletions**: If upstream removed something (a tag, a parameter, a workaround), find the commit that removed it and read its message. If it says the underlying issue was resolved (e.g., "Enable test after CUDA driver update", "Remove deprecated flag"), that deletion is intentional and correct — do NOT restore it from our side.
+- **ROCm code introduced by a previous sync merge**: Run `git log -L` on `develop-upstream` and check whether the conflicting ROCm-side lines were introduced in a prior sync merge commit (message like "Fix merge conflicts" or "Merge remote-tracking branch 'upstream/master'"). If so, that code may itself be a mistake from a prior sync resolution, not original ROCm work. Treat it with suspicion.
+- **TODOs and workarounds that reference resolved conditions**: If the HEAD side contains a comment like `# TODO: Re-enable once X is fixed` and upstream removed it, check whether upstream removed it *because X was fixed*. If yes, upstream's removal wins.
+
+#### Step D: Document your findings
+
+Before choosing a resolution strategy, record for each conflict:
+- Which commit(s) on `develop-upstream` introduced the conflicting region, and what they did — **include the short commit hash**
+- Which commit(s) on `upstream/master` last touched the same region, and what they did — **include the short commit hash**
+- Whether upstream's change is additive, a deletion of resolved code, or a refactor
+- Whether our side's content is original ROCm work or was re-introduced by a prior sync
+
+Capture the upstream commit hash with:
+```bash
+git log --oneline -1 upstream/master -- <file>
+# or, when git log -L was used, read the hash from its output
+```
+
+This analysis drives the resolution decision **and feeds directly into the commit message** (Step 4).
+
+### 2.2 Choose a resolution strategy
+
+**Strategy A: Independent changes — MERGE BOTH**
+If ours and theirs modified different parts or are complementary (most common for ROCm additions alongside upstream changes):
+- Keep both changes in logical order (upstream first, ROCm additions after)
+
+**Strategy B: Prefer upstream — TAKE THEIRS**
+If upstream's version is a refactoring, API migration, or improvement that our side lacks:
+- Take upstream's version as the base, then re-apply any ROCm-specific additions on top
+
+**Strategy C: Prefer ours — TAKE OURS**
+If our side already has a more complete implementation that supersedes the upstream change:
+- Keep our version. Common when ROCm already generalized a CUDA-only change.
+- **Do NOT use this strategy** if the ROCm-side content was introduced by a prior sync merge conflict resolution (rather than deliberate ROCm work), or if upstream's version deleted a resolved workaround. In those cases use Strategy B.
+
+**Strategy D: Semantic merge — COMBINE INTELLIGENTLY**
+If both sides made meaningful changes to the same code:
+- Understand what each was trying to accomplish
+- Create a merged version that preserves both intents
+- Ensure result is syntactically and semantically correct
+
+### 2.2.1 Function signature conflicts — check for additive resolution
+
+When a conflict involves **function parameters** where each side has a *different* parameter (not the same parameter modified), this is almost always an **additive** situation requiring both parameters. Do NOT treat it as "ours vs theirs".
+
+**Before choosing a resolution:**
+1. **Check usage in the function body.** Search for each conflicting parameter name in the rest of the function. If both are referenced, you MUST keep both.
+2. **Check callers.** Find all call sites of the function. If callers pass the ROCm-side parameter, it cannot be dropped.
+3. **Check git history.** Determine if the upstream parameter is *new* (added in the merge commit) vs the ROCm parameter is *existing* (present before the merge). If one is new and one is existing, you almost certainly need both.
+
+**Example of this mistake:**
+```
+<<<<<<< HEAD
+    const DebugOptions& debug_options,
+    llvm_ir::LLVMCommandLineOptionsLock& llvm_lock) {
+=======
+    const DebugOptions& debug_options, bool keep_tempfiles) {
+>>>>>>> upstream/master
+```
+Wrong: picking one side. Correct: keeping both (`keep_tempfiles` AND `llvm_lock`), since `keep_tempfiles` was new upstream and `llvm_lock` was existing ROCm code used later in the function.
+
+### 2.2.2 Verify no ROCm code is orphaned by the resolution
+
+After resolving any conflict, **grep the rest of the file** for identifiers that existed on the ROCm side of the conflict but were removed in the resolution. If any removed identifier is still referenced elsewhere in the file, the resolution is wrong — you dropped something that's still needed.
+
+```bash
+# For each identifier removed from the ROCm side, check if it's used elsewhere
+grep -n "<removed_identifier>" <file>
+```
+
+### 2.3 ROCm-specific resolution rules
+
+Apply these on top of the strategy chosen above:
+
+#### Bazel / BUILD files
+- Keep both CUDA and ROCm dependencies
+- If upstream renamed `cuda_` → `gpu_`, accept the rename but preserve ROCm equivalents
+- When upstream moved deps, follow the move and keep ROCm-specific deps (`rocm`, `TENSORFLOW_WITH_ROCM`, `if_rocm`)
+- Default: upstream version as base + ROCm additions on top
+
+**`cuda-only` tag handling (important):**
+Only use `tags = ["cuda-only"]` for tests that are genuinely CUDA-only by design (i.e. they test a CUDA-specific feature and cannot run on ROCm). Do NOT use it to disable failing ROCm tests — that practice caused tests to be forgotten for years.
+
+When you encounter `tags = ["cuda-only"]` during conflict resolution or in an upstream file being merged:
+1. **Read the test source file.** Look for:
+   - `GTEST_SKIP()` with a ROCm-related message — the test already self-skips on ROCm; `cuda-only` is redundant and hides it from ROCm CI entirely
+   - `is_built_with_rocm_` guards — same conclusion
+   - `cuda_compute_capability()` used only in `if/else` branches to select expected output patterns — the test still **runs** on ROCm via the `else` branch; `cuda-only` is wrong
+   - `cuda_compute_capability()` used as a hard gate (e.g. `if (!cuda_cap) return;`), or the test exercises cuDNN/NCCL/cuBLAS internals exclusively — genuinely CUDA-only
+2. **If source inspection shows it is not truly CUDA-only**: remove the `cuda-only` tag. The test will be run and verified in the `sync-test-check` phase after the build; if it fails there it will be added to the exclusion list. Upstream may still carry this tag — that is expected; we simply do not propagate it on our branch.
+3. **If source inspection confirms it is truly CUDA-only**: keep the tag.
+
+#### XLA (`third_party/xla/`)
+- Accept upstream API signature changes
+- Preserve ROCm-specific code blocks (`#if TENSORFLOW_USE_ROCM` or `ROCM` guards)
+- For `#if GOOGLE_CUDA` / `#elif TENSORFLOW_USE_ROCM` pairs: keep both, update the ROCm block to match any API changes in the CUDA block
+
+**`XlaSrcRoot()` path fix (critical — recurring pattern):**
+XLA is vendored into TensorFlow via `third_party/xla/`, which means test data files end up under `external/xla/xla/` in bazel runfiles rather than directly under `xla/`. Many XLA test files have an ROCm-side path fix like:
+```cpp
+auto path = tsl::testing::XlaSrcRoot();
+path = path.erase(path.length() - 4);
+// then use: tsl::io::JoinPath(path, "external/xla/xla", ...)
+```
+This pattern exists in multiple test files (e.g. `amdgpu_register_spilling_test.cc`, `xla_gpu_compile_lib_test.cc`, `xla_deviceless_compile_lib_test.cc`). When a conflict involves code that uses `tsl::testing::XlaSrcRoot()`, **always preserve this path adjustment from the ROCm side**. Upstream's direct `XlaSrcRoot()` path works in the upstream XLA repo but breaks in the vendored tensorflow-upstream build.
+
+#### StreamExecutor / GPU runtime
+- Accept upstream interface changes
+- Preserve ROCm implementations alongside CUDA ones
+- Mirror the CUDA version's pattern for the ROCm version
+
+#### Kernels/Ops (`tensorflow/core/kernels/`)
+- If upstream added `#if GOOGLE_CUDA` without ROCm coverage, check if the op should work on ROCm — if so, change to `#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM`
+- Preserve existing `TENSORFLOW_USE_ROCM` guards
+
+#### CI scripts (`tensorflow/tools/ci_build/`)
+- Keep ROCm-specific CI scripts and test configurations
+- Accept upstream changes to shared infrastructure
+
+#### Imports / includes
+- Keep all unique imports from both sides, remove duplicates
+- Sort per project conventions
+
+#### General
+- **Never leave `<<<<<<<`, `=======`, or `>>>>>>>` markers in any file**
+- When upstream deleted code that had ROCm additions: deletion usually wins unless the ROCm code is independent
+- When upstream added new code in the same location as ROCm code: keep both, upstream first
+- **Cross-file consistency:** When the same conflict pattern appears in multiple files (e.g. the same path fix or the same function signature change), resolve one carefully, then apply the same resolution to all others. Do not resolve each file independently — this leads to inconsistent resolutions where some files get the fix and others don't.
+
+### 2.4 Apply the resolution
+
+Use the Edit tool to replace each conflict block (including markers) with the resolved code.
+
+### 2.5 Run tests for resolved test files
+
+If a conflicted file is a test source (e.g. `*_test.cc`), **run that test locally** after resolving the conflict to verify the resolution is correct. A test that crashes or fails immediately after conflict resolution is a strong signal that something was dropped or merged incorrectly. This catches issues like broken paths, missing parameters, or wrong function signatures before they reach CI.
+
+Use the helper scripts from sync-test-check if available, or run via bazel directly:
+```bash
+bazel test --config=rocm <test_target> 2>&1 | tail -20
+```
+
+Do not block on long-running tests — focus on tests that are quick to build and run (< 2 minutes). For slow tests, note them in the report as needing verification.
+
+## Step 3: Verify no markers remain
+
+```bash
+grep -rn "<<<<<<" --include="*" -l
+```
+
+If any remain, go back and resolve them.
+
+Also spot-check for stray `=======` and `>>>>>>>` — these can have false positives (test data, docs), so review each match:
+
+```bash
+grep -rn "=======" --include="*" | grep -v "Binary file" | head -20
+grep -rn ">>>>>>>" --include="*" | grep -v "Binary file" | head -20
+```
+
+## Step 4: Commit the resolution
+
+The commit message must include the full reasoning for every conflict — not just "Fix merge conflicts". Use this format:
+
+```
+Fix merge conflicts from upstream sync
+
+<file1> (upstream <hash>: <one-line description of upstream change>)
+  ROCm: <what our side had>
+  Decision: <strategy + why, e.g. "Took upstream — py_strict migration, python_version deprecated">
+
+<file2> (upstream <hash>: <one-line description of upstream change>)
+  ROCm: <what our side had>
+  Decision: <strategy + why>
+
+... one block per conflicted file ...
+```
+
+Rules:
+- The upstream commit hash must be the actual short hash from `git log` — not a placeholder.
+- If multiple files share the same upstream cause (e.g. the same migration commit touched 4 BUILD files), group them under one header with that shared hash, then list each file's decision.
+- If a ROCm-side change was introduced by a prior sync merge (not deliberate ROCm work), say so explicitly.
+
+Example:
+```
+Fix merge conflicts from upstream sync
+
+tensorflow/dtensor/python/tests/BUILD (upstream 3b3ee72: py_strict → py_test migration)
+tensorflow/python/autograph/utils/BUILD (upstream 3b3ee72)
+tensorflow/python/debug/wrappers/BUILD (upstream 3b3ee72)
+  ROCm: python_version = "PY3", srcs_version = "PY3"
+  Decision: Took upstream — python_version deprecated, replaced with strict_deps = True.
+            debug/wrappers: also preserved ROCm's tags=[] (no-rocm tag intentionally cleared).
+
+tensorflow/lite/python/BUILD (upstream 3b3ee72: py_strict migration + tf_python_pybind_extension removal)
+  ROCm: old load statements including tf_python_pybind_extension
+  Decision: Took upstream load statements; no ROCm-specific additions in that section.
+
+third_party/xla/xla/service/gpu/tests/BUILD (upstream a399d9a: cuda-only tag added to gpu_too_many_blocks_test)
+  ROCm: tags = ["pjrt_migration_candidate"]
+  Decision: Removed cuda-only — source shows test self-skips on ROCm via is_built_with_rocm_; tag would hide it from ROCm CI.
+```
+
+Commit with:
+```bash
+git add -A
+git commit -F - <<'EOF'
+Fix merge conflicts from upstream sync
+
+... message body ...
+EOF
+```
+
+## Step 5: Report
+
+Provide a structured summary:
+
+### Per-file conflict analysis
+
+For each resolved file:
+
+```
+### `path/to/file`
+
+**Cause:** What changed on upstream (commit `abc123` by Author, Date): brief description.
+What changed on HEAD that conflicted: brief description.
+
+**Resolution:** Strategy used — brief explanation of what was done.
+```
+
+### Summary table
+
+| File | Strategy | Reason |
+|------|----------|--------|
+| file1.cc | Merge both | ROCm guard preserved alongside upstream API change |
+| BUILD | Prefer upstream | Dep rename accepted, ROCm deps re-added |
+
+### Concerns / items needing manual verification
+- List any ambiguous resolutions or semantic conflicts that couldn't be automatically verified
+- Note anything that may need a build check
+
+Finish with: "Build TF to verify the merge compiles. Fix any build errors in follow-up commits."
+
+## Important notes
+- Do NOT try to fix build errors. That is a separate step. However, if the build-fix phase requires adding a **new workaround** (e.g., a static mutex, a reimplemented helper) to replace functionality that existed in the pre-merge ROCm code, this is a strong signal that a conflict was resolved incorrectly. Go back and check if the original ROCm code was accidentally dropped during conflict resolution.
+- Do NOT modify test exclusion scripts (`run_xla.sh`, `run_gpu_single.sh`). That happens after CI runs.
+- Do NOT push anything.
+- For very large conflicts (>100 lines), summarize your planned resolution and confirm with the user before editing.
+- If a conflict is genuinely ambiguous after git history analysis, show the user both sides and your recommendation before resolving.

--- a/.claude/skills/sync-run-tests/SKILL.md
+++ b/.claude/skills/sync-run-tests/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sync-run-tests
+description: Runs the full XLA test suite on the EngFlow RBE cluster and reports pass/fail results with triage of new failures. Use when user says "run tests", "run RBE tests", "test on RBE", or asks to validate a sync branch against hardware.
+---
+
+# Run XLA Tests via RBE
+
+You are running the full XLA test suite against the EngFlow RBE cluster. This uses `.claude/skills/sync-run-tests/scripts/run_xla_rbe.sh`, which builds locally and executes tests remotely on `linux_x64_gpu` workers.
+
+Run all steps automatically without asking for confirmation.
+
+## Pre-flight checks
+
+1. Confirm the current branch matches `develop-upstream-sync-*`. If not, STOP and tell the user.
+2. Confirm the TLS certificates required by the RBE cluster exist:
+   ```bash
+   test -f /tf/certificates/ci-cert.crt && test -f /tf/certificates/ci-cert.key && echo "certs OK"
+   ```
+   If missing, STOP and tell the user: "RBE TLS certificates not found at /tf/certificates/ci-cert.{crt,key}".
+3. Confirm the script exists and is executable:
+   ```bash
+   test -x .claude/skills/sync-run-tests/scripts/run_xla_rbe.sh && echo "script OK"
+   ```
+   If not executable, run `chmod +x .claude/skills/sync-run-tests/scripts/run_xla_rbe.sh` and continue.
+4. Confirm `ROCM_PATH` is set or `/opt/rocm` exists (needed for the local build):
+   ```bash
+   echo "ROCM_PATH=${ROCM_PATH:-/opt/rocm}"
+   ```
+
+## Step 1: Launch the test run
+
+The build + test run is long (often 1–3 hours). Use background execution:
+
+```
+Tool: Bash
+command: .claude/skills/sync-run-tests/scripts/run_xla_rbe.sh 2>&1
+run_in_background: true
+```
+
+Save the returned task ID — you need it to monitor progress.
+
+## Step 2: Monitor progress
+
+After launching, periodically check progress using `TaskOutput` with `block: false`:
+
+```
+Tool: TaskOutput
+task_id: <task ID from Step 1>
+block: false
+timeout: 30000
+```
+
+- Check every 60–90 seconds
+- Report a brief summary to the user each time, e.g.:
+  - `"Building: [12,450 / 44,000] actions"`
+  - `"Testing: 87 / 439 tests, 3 failed"`
+- Key indicators to watch for:
+  - `[X / Y]` — Bazel action progress
+  - `X / 439 tests` — test execution progress (439 is the total XLA test count)
+  - `FAIL:` lines — individual test failures
+  - `INFO: Build completed` — run finished
+  - `ERROR:` — hard failure
+
+Continue polling until the task status shows completed.
+
+## Step 3: Collect and report results
+
+Once the run completes, get the full output:
+
+```
+Tool: TaskOutput
+task_id: <task ID from Step 1>
+block: true
+timeout: 600000
+```
+
+Parse the output and report:
+
+### 3.1 Overall result
+
+- Exit code 0 → **PASSED**
+- Non-zero → **FAILED**
+
+### 3.2 Build failures
+
+Extract all lines matching `FAILED TO BUILD` — these are test targets that could not compile. List them separately from test failures:
+
+```
+⛔ BUILD FAILURES:
+- @xla//xla/...:some_test_amdgpu_any — FAILED TO BUILD
+```
+
+For each build failure, search the output for the compiler error (look for lines containing `error:` near the target name). Show the error excerpt. Build failures are high priority — they block the test from running at all and usually indicate a merge issue that needs a code fix.
+
+### 3.3 Failed tests
+
+Extract all lines matching `FAIL:` (but NOT `FAILED TO BUILD`) and list them as a table:
+
+| Test target | Log path |
+|-------------|----------|
+| `@@xla//xla/...` | `/path/to/test.log` |
+
+For each failure, read the test log (the path is printed after `FAIL:`) and extract the first error or assertion failure. Show a brief excerpt.
+
+### 3.4 Summary table
+
+```
+Total tests:   441
+Passed:        X
+Failed:        Y
+Build failures: Z
+(Not run):     W
+```
+
+## Step 4: Handle failures
+
+For each failed test:
+
+1. Read its test log to determine the failure type:
+   - **Known ROCm limitation** (e.g. unsupported op, HIP error): note it, do not add to exclusion list yet — report to user for triage.
+   - **glibc / linker error**: this is an environment issue, not a test failure — report it separately.
+   - **Assertion / correctness failure**: likely a real failure — report for triage.
+
+2. Do NOT automatically add tests to the exclusion list. That is the user's decision.
+
+3. **Cross-reference at the test CASE level, not the target level.** The RBE run does not apply `--test_filter`, so a test binary that has some cases excluded may still fail due to NEW cases not yet in the exclusion list. For each failed test target:
+   a. Read the test log and extract all `[  FAILED  ]` lines to get the specific failing test case names.
+   b. Check each failing case against the `EXCLUDED_TESTS` entries in `run_xla.sh`.
+   c. A test target is only "fully excluded" if **every** failing case from that target matches an entry in `EXCLUDED_TESTS`. If even one failing case is not covered, report it as a new failure.
+
+4. If ALL failing cases across all targets are pre-existing (already in `EXCLUDED_TESTS`), report: "All failures are already in the exclusion list — no new failures."
+
+5. If there are NEW failures (not in the exclusion list), highlight them clearly with the specific case names:
+   ```
+   ⚠ NEW FAILURES (not in exclusion list):
+   - @xla//xla/...:some_test_amdgpu_any — SomeTestClass.SomeTestCase
+   ```
+
+## Important notes
+
+- Do NOT push anything. The user will push when ready.
+- Do NOT modify any source files or exclusion lists during this skill — only observe and report.
+- The EngFlow BES URL is printed at the start of the bazel run. Capture and report it so the user can inspect the run in the web UI.
+- If the run is interrupted (e.g. network error, certificate expiry), report the last known progress and suggest re-running the skill.
+- Queue wait times may be long if the pool is busy. Monitor the output for `(Sched)` annotations indicating queued tests.

--- a/.claude/skills/sync-run-tests/scripts/run_xla_rbe.sh
+++ b/.claude/skills/sync-run-tests/scripts/run_xla_rbe.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ==============================================================================
+#
+# Runs XLA unit tests on ROCm platform for MI250 (gfx90a) via Remote Build
+# Execution (RBE) using the EngFlow cluster (wardite.cluster.engflow.com).
+#
+# Differences from run_xla.sh:
+#   - Loads rocm_xla.bazelrc (provides --config=rocm_rbe with EngFlow settings)
+#   - Adds --config=rocm_rbe  (remote executor, BES streaming, --jobs=200)
+#   - Removes --local_test_jobs  (parallelism is managed by RBE, not locally)
+#   - Removes --test_env=TF_GPU_COUNT/TF_TESTS_PER_GPU  (not applicable to RBE workers)
+#   - Builds locally (--spawn_strategy=local, --jobs=nproc) for speed; only
+#     test execution runs via RBE
+#   - Sets TF_ROCM_RBE_DOCKER_IMAGE (rocm/tensorflow-build:latest-noble-python3.11-rocm7.1.1)
+#     to match the local build environment so remote workers use the same
+#     glibc/libstdc++ as the locally-built binaries
+#
+# Prerequisites:
+#   - TLS client certificate and key at /tf/certificates/ci-cert.{crt,key}
+
+set -e
+set -x
+
+# First positional argument (if any) specifies the ROCM_INSTALL_DIR
+if [[ -n $1 ]]; then
+    ROCM_INSTALL_DIR=$1
+else
+    if [[ -z "${ROCM_PATH}" ]]; then
+        ROCM_INSTALL_DIR=/opt/rocm/
+    else
+        ROCM_INSTALL_DIR=$ROCM_PATH
+    fi
+fi
+
+TF_ROCM_AMDGPU_TARGETS=gfx90a,gfx942
+
+N_BUILD_JOBS=$(nproc)
+
+export PYTHON_BIN_PATH=`which python3`
+PYTHON_VERSION=`python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')"`
+export TF_PYTHON_VERSION=$PYTHON_VERSION
+export TF_NEED_ROCM=1
+export ROCM_PATH=$ROCM_INSTALL_DIR
+export TF_ROCM_RBE_DOCKER_IMAGE=rocm/tensorflow-build@sha256:a2191b80002ad851e5f7274994b0c62859874b38cc587115b116eff69b0948af
+
+if [ ! -d /tf ]; then
+    # The bazelrc files in /usertools expect /tf to exist
+    mkdir /tf
+fi
+
+bazel \
+    --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc \
+    --bazelrc=third_party/xla/build_tools/rocm/rocm_xla.bazelrc \
+    test \
+    --config=sigbuild_local_cache \
+    --config=rocm \
+    --config=xla_cpp_filters \
+    --config=rocm_rbe \
+    --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=rocm/tensorflow-build@sha256:a2191b80002ad851e5f7274994b0c62859874b38cc587115b116eff69b0948af \
+    --repo_env=TF_ROCM_RBE_POOL=linux_x64_gpu \
+    --spawn_strategy=local \
+    --jobs=${N_BUILD_JOBS} \
+    --test_output=errors \
+    --test_env=MIOPEN_FIND_ENFORCE=5 \
+    --test_env=MIOPEN_FIND_MODE=1 \
+    --action_env="ROCM_PATH=$ROCM_PATH" \
+    --action_env=TF_ROCM_AMDGPU_TARGETS="${TF_ROCM_AMDGPU_TARGETS}" \
+    --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
+    -- @xla//xla/...

--- a/.claude/skills/sync-start/SKILL.md
+++ b/.claude/skills/sync-start/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: sync-start
+description: Start a regular upstream sync of ROCm tensorflow-upstream with upstream tensorflow. Creates the sync branch, merges upstream, and records the initial merge commit with unresolved conflicts.
+argument-hint: "[YYMMDD (optional, defaults to today)] [optional: upstream ref, defaults to upstream/master]"
+---
+
+# Upstream Sync Start
+
+You are performing the initial steps of the regular upstream sync for `ROCm/tensorflow-upstream`. This merges changes from upstream `tensorflow/tensorflow` into the `develop-upstream` branch.
+
+Run all steps automatically without asking for confirmation. Report progress and results at the end.
+
+## Arguments
+
+- `$ARGUMENTS[0]` (optional): The YYMMDD date label for this sync (e.g., `260302`). This is the upstream cutoff date, NOT necessarily today's date. **If omitted, defaults to today's date in YYMMDD format** (use the `currentDate` context variable if available, otherwise run `date +%y%m%d` to get it).
+- `$ARGUMENTS[1]` (optional): The upstream ref to merge. Defaults to `upstream/master`. Can be a tag like `r2.21-base` or a specific commit.
+
+**Argument disambiguation:** If only one argument is provided, check whether it looks like a YYMMDD date (6 digits). If it does, treat it as the date label and use `upstream/master` as the ref. If it does not look like a date (e.g. it contains letters or slashes), treat it as the upstream ref and derive the date automatically from today.
+
+## Pre-flight checks
+
+Run these checks first and STOP (report the problem) if any fail:
+
+1. Resolve the date label and upstream ref per the argument rules above.
+2. Run `git status` — working tree must be clean.
+3. Run `git branch --show-current` — must be on `develop-upstream`.
+4. Check if branch `develop-upstream-sync-<date-label>` already exists locally or on the remote — must not exist.
+5. Check if the `upstream` remote exists (`git remote get-url upstream`). If not, add it:
+   ```
+   git remote add upstream https://github.com/tensorflow/tensorflow.git
+   ```
+
+## Steps
+
+### 1. Fetch upstream
+```bash
+git fetch upstream
+```
+
+### 2. Log what will be merged
+Compute and record (for the final summary).
+- Total number of commits
+```bash
+git rev-list --count develop-upstream..upstream/master
+```
+- The date and hash of the newest (first line) and oldest (last line) commit
+```bash
+git log --format="%h %ai %s" develop-upstream..<upstream-ref>
+```
+
+### 3. Create the sync branch
+```bash
+git checkout -b develop-upstream-sync-<date-label>
+```
+
+### 4. Merge upstream
+```bash
+git merge <upstream-ref> --no-edit
+```
+
+### 5. Handle the merge result
+
+**If merge completes with no conflicts:**
+- Show the merge commit stats (files changed, insertions, deletions)
+- Print: "Clean merge! No conflicts to resolve. Proceed to building TF."
+
+**If merge has conflicts:**
+- Count and list all conflicted files using `git diff --name-only --diff-filter=U`
+- Categorize them by area:
+  - **XLA/Compiler**: files under `third_party/xla/`
+  - **StreamExecutor/GPU runtime**: files under `stream_executor/`
+  - **Kernels/Ops**: files under `tensorflow/core/kernels/`
+  - **Bazel/Build**: `BUILD`, `.bzl`, `WORKSPACE` files
+  - **CI scripts**: files under `tensorflow/tools/ci_build/`
+  - **Other**: everything else
+- Stage ALL conflicted files as-is (with conflict markers still present):
+  ```bash
+  git add -u
+  ```
+  Use `git add -u` (not `git add -A`) — this stages only modifications to tracked files and avoids accidentally including untracked files (e.g. `.claude/`, editor temp files) in the merge commit.
+- Finalize the merge commit:
+  ```bash
+  git commit --no-edit
+  ```
+  This records the merge with unresolved conflicts as the first commit, which is intentional — it makes PR review easier.
+- Report:
+  - Total number of conflicted files
+  - Categorized list of conflicted files
+  - "First commit recorded with unresolved conflicts. Run `/sync-resolve` to resolve them."
+
+## Important notes
+- Do NOT attempt to resolve any conflicts. That is the job of `/sync-resolve`.
+- Do NOT push anything. The user will push when ready.
+- When a specific YYMMDD is given, it represents the upstream cutoff point (e.g. for a tag or a past commit), not necessarily today's date. When syncing against the current `upstream/master` with no date given, today's date is the correct label.

--- a/.claude/skills/sync-test-check/SKILL.md
+++ b/.claude/skills/sync-test-check/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: sync-test-check
+description: Check excluded ROCm tests to see if they still fail. Runs each excluded test individually and removes passing tests from the exclusion lists in run_xla.sh and run_gpu_single.sh.
+---
+
+# Check Excluded ROCm Tests
+
+You are verifying whether previously-excluded ROCm tests are still failing. Over time, upstream fixes or ROCm improvements may cause excluded tests to start passing. This skill runs each excluded test individually and removes any that now pass from the exclusion lists.
+
+The exclusion lists live in two files:
+- `tensorflow/tools/ci_build/linux/rocm/run_xla.sh` — XLA tests
+- `tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh` — GPU/pycpp tests
+
+This skill has helper scripts to run individual tests:
+- `.claude/skills/sync-test-check/scripts/run_single_xla_test.sh <bazel_target> <test_filter>`
+- `.claude/skills/sync-test-check/scripts/run_single_gpu_test.sh <bazel_target> <test_filter>`
+
+Run all steps automatically. Each test may take several minutes to build and run.
+
+**IMPORTANT: Tests must be run strictly one at a time (sequentially, never in parallel).** The GPU test infrastructure uses `parallel_gpu_execute`, a file-based `flock(1)` locking system that assigns each test exclusive access to a single GPU via `/var/lock/gpulock*`. The lock is **non-blocking** — if all GPU slots are occupied, the test immediately fails with "Cannot find a free GPU" rather than waiting. Running multiple `bazel test` commands simultaneously will cause false failures due to lock contention. Even the codebase notes that `parallel_gpu_execute` is "fragile". Always wait for one test to fully complete before starting the next.
+
+## Pre-flight checks
+
+1. Confirm the current branch matches `develop-upstream-sync-*`. If not, STOP.
+2. Confirm the working tree is clean (`git status`). If not, STOP.
+3. Confirm the helper scripts exist and are executable:
+   ```bash
+   test -x .claude/skills/sync-test-check/scripts/run_single_xla_test.sh && echo "xla runner OK"
+   test -x .claude/skills/sync-test-check/scripts/run_single_gpu_test.sh && echo "gpu runner OK"
+   ```
+
+## Step 0: Find tests where `cuda-only` tag was removed in this sync
+
+During conflict resolution, `cuda-only` tags may have been removed from Bazel test targets (because the tag was being misused to disable failing tests rather than to mark tests as truly CUDA-only). These tests are now enabled for ROCm but may fail — they must be tested and, if failing, added to the exclusion list.
+
+### 0.1 Find removed `cuda-only` occurrences
+
+```bash
+git diff develop-upstream HEAD -- "*.BUILD" "*/BUILD" "*/BUILD.bazel" | grep -B 10 '^-.*"cuda-only"'
+```
+
+For each removed `cuda-only` line, identify the enclosing Bazel target name by reading the surrounding context (look for `name = "..."` within the same target block). Then determine the full Bazel target path from the file path (e.g., `third_party/xla/xla/stream_executor/gpu/BUILD` → `//xla/stream_executor/gpu:<target_name>` for XLA targets, or `tensorflow/...` → `//tensorflow/...:<target_name>`).
+
+If no `cuda-only` removals are found, skip to Step 1.
+
+### 0.2 Run each newly-enabled test
+
+For each target identified, run it using the appropriate helper script. Use the GPU test runner for targets under `tensorflow/`, and the XLA test runner for targets under `third_party/xla/`:
+
+```
+Tool: Bash
+command: .claude/skills/sync-test-check/scripts/run_single_gpu_test.sh "<bazel_target>" "" 2>&1 | tail -50
+run_in_background: true
+```
+
+Wait for each test to complete before starting the next (same sequential rule as Step 2).
+
+### 0.3 Handle results
+
+- **PASS**: The test works on ROCm — no action needed. Report it as enabled and passing.
+- **FAIL / BUILD_ERROR**: The test fails on ROCm — add it to the `EXCLUDED_TESTS` array in `tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh` with a comment identifying the target, then commit immediately:
+  ```bash
+  git add -u
+  git commit -m "Exclude failing test newly enabled by cuda-only tag removal: <target>"
+  ```
+
+## Step 1: Parse the exclusion lists
+
+Read both test scripts and extract every excluded test entry along with its associated bazel target.
+
+### 1.1 Parse `run_xla.sh`
+
+Read `tensorflow/tools/ci_build/linux/rocm/run_xla.sh` and extract the `EXCLUDED_TESTS` array. Each entry has:
+- A **comment line** above it (or group of entries) with the bazel target, e.g. `# @xla//xla/backends/gpu/codegen/triton:triton_gemm_fusion_test_amdgpu_any`
+- One or more **test filter names**, e.g. `CompareTest.SplitK`
+
+Also check for **whole-file exclusions** at the end of the bazel command (lines starting with `-@xla//` or `-//`). These are entire bazel targets excluded from the test suite.
+
+Build a list of `(bazel_target, test_filter, source_file="xla")` tuples.
+
+### 1.2 Parse `run_gpu_single.sh`
+
+Read `tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh` and extract the `EXCLUDED_TESTS` array using the same comment→filter pattern.
+
+Build a list of `(bazel_target, test_filter, source_file="gpu")` tuples.
+
+### 1.3 Report the full list
+
+Print the complete list of excluded tests with their targets, grouped by source file. Show the total count.
+
+## Step 2: Run, update, and commit — incrementally
+
+**CRITICAL: Update the exclusion list and commit after EACH passing test, not at the end.** The exclusion list is long and context may be exhausted before all tests are checked. By committing after each pass, progress is never lost — if the session ends mid-way, all previously-verified results are already saved in git history.
+
+### 2.1 Process each test — ONE AT A TIME
+
+For each `(bazel_target, test_filter, source_file)` tuple from Step 1, repeat this loop:
+
+#### A. Run the test
+
+**For XLA tests** (`source_file="xla"`):
+```
+Tool: Bash
+command: .claude/skills/sync-test-check/scripts/run_single_xla_test.sh "<bazel_target>" "<test_filter>" 2>&1 | tail -50
+run_in_background: true
+```
+
+**For GPU tests** (`source_file="gpu"`):
+```
+Tool: Bash
+command: .claude/skills/sync-test-check/scripts/run_single_gpu_test.sh "<bazel_target>" "<test_filter>" 2>&1 | tail -50
+run_in_background: true
+```
+
+**For whole-file exclusions** (entire bazel targets excluded at the command line, not in `EXCLUDED_TESTS` array):
+```
+Tool: Bash
+command: .claude/skills/sync-test-check/scripts/run_single_xla_test.sh "<bazel_target>" "" 2>&1 | tail -50
+run_in_background: true
+```
+
+Wait for the test to complete before doing anything else. Use `TaskOutput` (block: true, timeout: 600000) — individual tests should not take more than 10 minutes.
+
+#### B. Classify the result
+
+- **PASS**: Exit code 0 — the test no longer fails
+- **FAIL**: Non-zero exit code — the test still fails, keep it excluded
+- **BUILD_ERROR**: Failed to build — keep it excluded
+- **TIMEOUT**: Did not complete within 10 minutes — keep it excluded
+
+#### C. If PASS: immediately remove from exclusion list and commit
+
+1. **Edit** the source file (`run_xla.sh` or `run_gpu_single.sh`):
+   - Remove the passing test filter line from the `EXCLUDED_TESTS` array
+   - If this was the last filter under a comment (bazel target), remove the comment line too
+   - If a whole-file exclusion now passes, remove the `-@xla//...` line from the bazel command
+   - Preserve blank lines and formatting conventions of the file
+   - Do NOT remove comment-only lines that are section headers (like `# vvv TODO (rocm) weekly-sync-XXXXXXXX excluded tests`)
+
+2. **Verify** the script is still valid bash:
+   ```bash
+   bash -n tensorflow/tools/ci_build/linux/rocm/<modified-script>.sh
+   ```
+
+3. **Commit** immediately:
+   ```bash
+   git add -u
+   git commit -m "Remove passing excluded test: <test_filter>"
+   ```
+   Use `git add -u` (not `git add -A`) to avoid staging untracked files.
+
+This way, each passing test is persisted in a separate commit. If the session ends unexpectedly, all verified results are safe.
+
+#### D. If FAIL/BUILD_ERROR/TIMEOUT: report and move on
+
+Report the result to the user (test name, status, brief reason) and proceed to the next test. No edits needed.
+
+### 2.2 Group tests by target for efficiency
+
+When multiple excluded test filters belong to the same bazel target, you can test them together in a single run by combining filters with `:`:
+```
+Tool: Bash
+command: .claude/skills/sync-test-check/scripts/run_single_xla_test.sh "<bazel_target>" "<filter1>:<filter2>:<filter3>" 2>&1 | tail -100
+run_in_background: true
+```
+
+If the combined run passes, all tests in the group pass — remove them all and commit:
+```bash
+git add -u
+git commit -m "Remove passing excluded tests from <target_short_name>"
+```
+
+If the combined run fails, re-run each filter individually to identify which ones still fail and which now pass. Remove and commit each passing one individually.
+
+### 2.3 Track progress
+
+After each test (pass or fail), report a running tally to the user:
+```
+Progress: X/Y tests checked. P passed (removed), F still failing.
+```
+
+## Step 3: Final report
+
+After all tests have been checked (or if the session must end early):
+
+**Tests checked:** X total (Y from run_xla.sh, Z from run_gpu_single.sh)
+
+**Results:**
+
+| Status | Count |
+|--------|-------|
+| PASS (removed & committed) | N |
+| FAIL (kept) | N |
+| BUILD_ERROR (kept) | N |
+| TIMEOUT (kept) | N |
+
+**Tests removed (now passing):**
+
+| Test filter | Bazel target | Source | Commit |
+|------------|-------------|--------|--------|
+| CompareTest.SplitK | @xla//...:triton_gemm_fusion_test_amdgpu_any | run_xla.sh | abc1234 |
+
+**Tests still failing (kept):**
+
+| Test filter | Bazel target | Failure reason |
+|------------|-------------|----------------|
+| TopKTests/TopKKernelTest.* | @xla//...:topk_test_amdgpu_any | Assertion failed: expected X got Y |
+
+**If not all tests were checked** (session ended early), report:
+- How many tests remain unchecked
+- "Run `/sync-test-check` again to continue — already-removed tests will not be re-tested since they are no longer in the exclusion list."
+
+## Important notes
+- Do NOT push anything. The user will push when ready.
+- Do NOT modify any test source code. This skill only modifies the exclusion lists.
+- Tests that use wildcards (e.g. `TopKTests/TopKKernelTest.*`) should be run as-is — the wildcard is part of the gtest filter syntax.
+- If a test is marked with a comment like `# failing on mi250`, note that the result may depend on the GPU hardware being used. Report the hardware detected.
+- NEVER run tests in parallel. The `parallel_gpu_execute` flock mechanism is non-blocking and will cause false "Cannot find a free GPU" failures if multiple tests compete for GPU locks.
+- For very large exclusion lists, report progress periodically so the user knows work is happening.
+
+### Parameterized test patterns
+
+When a passing test is removed from the exclusion list, check whether the remaining exclusion entries for the same target are **complete**. A common error is having a pattern like `SortRewriterTest.*` that only covers non-parameterized `TEST_F` tests, while `TEST_P` tests with names like `SortRewriterTest/SortRewriterTest.SortNumpyOrder/bf16_desc` are not covered by any pattern.
+
+If after removing a passing entry the target still shows as `FAIL` in the RBE run (i.e. the test binary exits non-zero despite the exclusion), the remaining patterns may not be covering all failing cases. In that situation, re-read the test log and check whether uncovered parameterized test names are slipping through — then add the missing `InstantiationName/SuiteName.*` patterns.

--- a/.claude/skills/sync-test-check/scripts/run_single_gpu_test.sh
+++ b/.claude/skills/sync-test-check/scripts/run_single_gpu_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Run a single GPU (pycpp) test by bazel target and test filter.
+#
+# Usage:
+#   ./run_single_gpu_test.sh <bazel_target> <test_filter>
+#
+# Examples:
+#   ./run_single_gpu_test.sh //tensorflow/core/kernels:matmul_op_test_gpu "Test/FusedMatMulWithBiasOpTest/1.MatMul*"
+#   ./run_single_gpu_test.sh //tensorflow/core/profiler/backends/gpu:device_tracer_test "DeviceTracerTest.TraceToXSpace"
+#
+# Exit code: 0 if the test passes, non-zero if it fails.
+
+set -e
+set -x
+
+BAZEL_TARGET="$1"
+TEST_FILTER="$2"
+
+if [[ -z "$BAZEL_TARGET" || -z "$TEST_FILTER" ]]; then
+    echo "Usage: $0 <bazel_target> <test_filter>"
+    echo "  bazel_target: e.g. //tensorflow/core/kernels:matmul_op_test_gpu"
+    echo "  test_filter:  e.g. DeviceTracerTest.TraceToXSpace"
+    exit 1
+fi
+
+# GPU detection
+N_BUILD_JOBS=$(grep -c ^processor /proc/cpuinfo)
+rocm-smi -i > /dev/null 2>&1
+STATUS=$?
+if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
+    TF_GPU_COUNT=$(rocm-smi -i | grep 'Device ID' | grep 'GPU' | wc -l)
+fi
+TF_TESTS_PER_GPU=1
+N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
+
+# ROCM path
+if [[ -z "${ROCM_PATH}" ]]; then
+    ROCM_INSTALL_DIR=/opt/rocm/
+else
+    ROCM_INSTALL_DIR=$ROCM_PATH
+fi
+export ROCM_PATH=$ROCM_INSTALL_DIR
+
+export PYTHON_BIN_PATH=$(which python3)
+PYTHON_VERSION=$(python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+export TF_PYTHON_VERSION=$PYTHON_VERSION
+export TF_NEED_ROCM=1
+
+# Detect GPU architecture
+TARGET_ARCHS=$(rocminfo | grep "Name: *gfx" | awk '/Name:/ {print $2}' | sort -u)
+if [ -z "$TARGET_ARCHS" ]; then
+    echo "No gpu found"
+    exit 1
+fi
+
+if [ ! -d /tf ]; then
+    mkdir -p /tf
+fi
+
+yes "" | $PYTHON_BIN_PATH configure.py
+
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
+    --config=rocm \
+    --config=sigbuild_local_cache \
+    --config=pycpp \
+    -k \
+    --jobs=${N_BUILD_JOBS} \
+    --local_test_jobs=${N_TEST_JOBS} \
+    --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+    --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+    --test_env=MIOPEN_DEBUG_CONV_WINOGRAD=0 \
+    --repo_env="TF_ROCM_AMDGPU_TARGETS=$TARGET_ARCHS" \
+    --repo_env="ROCM_PATH=$ROCM_PATH" \
+    --build_tests_only \
+    --test_output=all \
+    --verbose_failures \
+    --test_sharding_strategy=disabled \
+    --test_filter="$TEST_FILTER" \
+    --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute \
+    -- "$BAZEL_TARGET"

--- a/.claude/skills/sync-test-check/scripts/run_single_xla_test.sh
+++ b/.claude/skills/sync-test-check/scripts/run_single_xla_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Run a single XLA test by bazel target and test filter.
+#
+# Usage:
+#   ./run_single_xla_test.sh <bazel_target> <test_filter>
+#
+# Examples:
+#   ./run_single_xla_test.sh @xla//xla/backends/gpu/codegen/triton:triton_gemm_fusion_test_amdgpu_any "CompareTest.SplitK"
+#   ./run_single_xla_test.sh @xla//xla/service/gpu/tests:command_buffer_test_amdgpu_any "CommandBufferTests/CommandBufferTest.WhileLoop/*"
+#
+# Exit code: 0 if the test passes, non-zero if it fails.
+
+set -e
+set -x
+
+BAZEL_TARGET="$1"
+TEST_FILTER="$2"
+
+if [[ -z "$BAZEL_TARGET" || -z "$TEST_FILTER" ]]; then
+    echo "Usage: $0 <bazel_target> <test_filter>"
+    echo "  bazel_target: e.g. @xla//xla/backends/gpu/codegen/triton:triton_gemm_fusion_test_amdgpu_any"
+    echo "  test_filter:  e.g. CompareTest.SplitK"
+    exit 1
+fi
+
+# GPU detection
+rocm-smi -i > /dev/null 2>&1
+STATUS=$?
+if [ $STATUS -ne 0 ]; then TF_GPU_COUNT=1; else
+    TF_GPU_COUNT=$(rocm-smi -i | grep 'Device ID' | grep 'GPU' | wc -l)
+fi
+TF_TESTS_PER_GPU=1
+N_TEST_JOBS=$(expr ${TF_GPU_COUNT} \* ${TF_TESTS_PER_GPU})
+
+# ROCM path
+if [[ -z "${ROCM_PATH}" ]]; then
+    ROCM_INSTALL_DIR=/opt/rocm/
+else
+    ROCM_INSTALL_DIR=$ROCM_PATH
+fi
+export ROCM_PATH=$ROCM_INSTALL_DIR
+
+export PYTHON_BIN_PATH=$(which python3)
+PYTHON_VERSION=$(python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+export TF_PYTHON_VERSION=$PYTHON_VERSION
+export TF_NEED_ROCM=1
+
+if [ ! -d /tf ]; then
+    mkdir -p /tf
+fi
+
+bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc test \
+    --config=sigbuild_local_cache \
+    --config=rocm \
+    --config=xla_cpp_filters \
+    --test_output=all \
+    --local_test_jobs=${N_TEST_JOBS} \
+    --test_env=TF_TESTS_PER_GPU=$TF_TESTS_PER_GPU \
+    --test_env=TF_GPU_COUNT=$TF_GPU_COUNT \
+    --test_env=MIOPEN_FIND_ENFORCE=5 \
+    --test_env=MIOPEN_FIND_MODE=1 \
+    --action_env="ROCM_PATH=$ROCM_PATH" \
+    --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
+    --test_filter="$TEST_FILTER" \
+    -- "$BAZEL_TARGET"

--- a/.claude/skills/sync-triage-test/SKILL.md
+++ b/.claude/skills/sync-triage-test/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: sync-triage-test
+description: Investigates a failing XLA RBE test on MI250 (gfx90a), determines the root cause, and either fixes the code or adds the test to the exclusion list in run_xla.sh. Use when user says "investigate failing test", "triage test", "fix failing test", "why is <test> failing", or provides a specific failing test target from an RBE run.
+---
+
+# Triage a Failing XLA RBE Test
+
+You are investigating a specific failing test from the MI250 RBE test run. Your goal is to determine the root cause and take one of two actions:
+
+1. **Fix the code** — if the failure is due to a ROCm-specific bug, a missing HIP implementation, or a broken upstream change that can clearly and safely be corrected.
+2. **Add to exclusion list** — in all other cases, including when a fix is possible but non-trivial, ambiguous, or risky.
+
+**When in doubt, exclude. Never ask the user to decide.**
+
+The user will provide a failing test target and optionally a test filter (test case name). If not provided, ask for both before proceeding.
+
+Run all steps automatically without asking the user for guidance.
+
+## Pre-flight checks
+
+1. Confirm the helper script exists and is executable:
+   ```bash
+   test -x .claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh && echo "OK"
+   ```
+   If not executable, run `chmod +x .claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh`.
+
+2. Confirm TLS certificates exist:
+   ```bash
+   test -f /tf/certificates/ci-cert.crt && test -f /tf/certificates/ci-cert.key && echo "certs OK"
+   ```
+   If missing, STOP and tell the user.
+
+## Step 0: Check for partially-excluded targets
+
+Before reproducing, check if the test target already has some (but not all) cases in the exclusion list. This is critical because the RBE run does not apply `--test_filter` — a test binary with 3 excluded cases and 1 new failing case will still show as `FAIL:` in the RBE output.
+
+1. Read `tensorflow/tools/ci_build/linux/rocm/run_xla.sh` and find all `EXCLUDED_TESTS` entries.
+2. If the test log from the RBE run is available (path printed after `FAIL:`), read it and extract all `[  FAILED  ]` lines to get the specific failing case names.
+3. Cross-reference: for each failing case, check if it matches an entry in `EXCLUDED_TESTS`.
+4. If **all** failing cases are already excluded → report "All failing cases already excluded — no action needed" and stop.
+5. If some cases are new → proceed with only the **new** (non-excluded) cases. Set the test filter to target only these cases.
+
+This prevents the mistake of skipping a test target as "already excluded" when it actually contains new failures.
+
+### Parameterized test name matching (critical)
+
+gtest has two test types with **different full-name formats**:
+
+- **`TEST_F` (non-parameterized):** `SuiteName.TestName`
+  - Example: `SortRewriterTest.SortKeysLessThan`
+  - Matched by pattern: `SortRewriterTest.*`
+
+- **`TEST_P` (parameterized):** `InstantiationName/SuiteName.TestName/ParamName`
+  - Example: `SortRewriterTest/SortRewriterTest.SortNumpyOrder/bf16_desc`
+  - Example: `NumericTestsForBlas/NumericTestsForBlas.Infinity/dot_bf16_bf16_f32_x9`
+  - Example: `SortRewriterArgsort/SortRewriterArgsortTest.SortNumpyOrderArgsort/f16_desc_s32_cub`
+
+**The pattern `SuiteName.*` does NOT match `InstantiationName/SuiteName.TestName/ParamName`** because `SuiteName.*` requires a dot immediately after `SuiteName`, but parameterized names have a slash.
+
+When cross-referencing failures against exclusion patterns, check: does the existing pattern actually match the failing test's full name? A target with `SortRewriterTest.*` in exclusions is **not** covered for `SortRewriterTest/SortRewriterTest.SortNumpyOrder/bf16_desc`.
+
+## Step 1: Reproduce the failure
+
+**For build failures (FAILED TO BUILD):** Do NOT re-run the test — it will just fail to build again. Instead, extract the compiler error from the RBE run output (search for `error:` lines near the target name). Then go directly to Step 2 → classify as Category E → Step 3 → investigate the source and fix the build error. After applying the fix, re-run via RBE to verify the build and test pass.
+
+**For test failures (FAIL):** Run the failing test via RBE to get a fresh, detailed failure log:
+
+```
+Tool: Bash
+command: .claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh "<bazel_target>" "<test_filter>" 2>&1
+run_in_background: true
+```
+
+Wait for completion with `TaskOutput` (block: true, timeout: 600000).
+
+If the test **passes** on re-run, report: "Test passed on re-run — likely an intermittent failure (pool contention, flaky test, or transient hardware error). No action taken." Then stop.
+
+## Step 2: Classify the failure
+
+Read the full test output and classify into one of these categories:
+
+### A. Infrastructure / environment error
+Symptoms: linker errors, missing `.so`, `GLIBC_*` not found, `HIP_ERROR_OutOfMemory` at startup, `cannot open shared object`.
+→ This is not a test failure. Report the infrastructure issue to the user. Do NOT add to exclusion list. Stop.
+
+### B. Unsupported op / CUDA-only feature
+Symptoms: `Unimplemented`, `not supported on ROCm`, `CUDA-only`, hipBLASLt/cuDNN-specific error, `CUBLAS_STATUS_*`, or **platform name mismatch** (`Could not find registered platform with name: "CUDA". Available platform names are: ROCM`).
+→ Add to exclusion list.
+
+**Platform mismatch heuristic:** When the error mentions "CUDA" vs "ROCM" platform names, do NOT attempt to fix the test by replacing hardcoded `"CUDA"` with `se::GpuPlatformName()`. Instead, read the **implementation source** (not the test) and check whether the underlying feature supports ROCm. Look for patterns like:
+- `if (platform_name == "CUDA")` with no ROCm branch
+- `return.*Unimplemented.*platform` for non-CUDA platforms
+- FFI handlers registered only for `"CUDA"` (e.g. `ffi::FindHandler(..., "CUDA")`)
+- `#if GOOGLE_CUDA` blocks with no `#elif TENSORFLOW_USE_ROCM` counterpart
+
+If the implementation is CUDA-only, the test failure is a consequence of the missing ROCm support — fixing the test to be "platform-aware" would just shift the error. Classify as Category B and exclude.
+
+### C. Numerical / correctness failure
+Symptoms: `ASSERT_NEAR failed`, `Expected: X, got: Y`, wrong output values.
+→ Investigate source (Step 3). If a clear, minimal fix exists, fix it. Otherwise, exclude.
+
+### D. Crash / HIP runtime error
+Symptoms: `HIP error`, `hipErrorInvalidValue`, segfault, `Aborted`.
+→ Investigate source (Step 3). If a clear, minimal fix exists, fix it. Otherwise, exclude.
+
+### E. Build / compilation failure
+Symptoms: `FAILED TO BUILD`, `ERROR: Build did NOT complete`, compiler error (`error: use of undeclared identifier`, `error: no member named`), missing symbol, missing header.
+→ Fix the build error directly (not an exclusion). Build failures are often caused by:
+- **Missed renames during merge**: upstream renamed a class/function (e.g. `AutotunerUtil` → `AutotunerCache`) but the merge re-introduced old references from a conflicting upstream commit. Check `git log` on the file and the upstream commits to find the rename.
+- **Missing `#include`**: a new upstream commit uses a symbol without including the right header.
+- **ROCm-specific `#ifdef` conflicts**: merge brought in CUDA code inside a ROCm guard or vice versa.
+
+For build failures, always use `git log` and `git show` to reference the specific commits that caused the conflict in your commit message.
+
+### F. Test logic failure / assertion
+Symptoms: `FAIL` with a clear assertion in the test body.
+→ Investigate source (Step 3). If a clear, minimal fix exists, fix it. Otherwise, exclude.
+
+## Step 3: Investigate the source
+
+For categories C, D, F — read the relevant source files before deciding:
+
+1. Find the test source from the bazel target (e.g. `@xla//xla/backends/gpu/runtime:foo_test` → `third_party/xla/xla/backends/gpu/runtime/foo_test.cc`).
+2. **Always read the implementation under test before deciding on a fix.** A test may look like it just needs a string change, but if the underlying implementation doesn't support ROCm, the test failure is a symptom — not the disease. For example, if a test hardcodes `"CUDA"` but the implementation's `::Create()` method returns `UnimplementedError` for non-CUDA platforms, making the test platform-aware would just produce a different error.
+3. Look for `#if TENSORFLOW_USE_ROCM` / `#if GOOGLE_CUDA` guards — a missing ROCm path explains many failures.
+4. Check recent upstream changes:
+   ```bash
+   git log --oneline -20 -- <file_path>
+   ```
+5. If a CUDA implementation exists without a ROCm equivalent, look for similar ROCm implementations nearby.
+
+**Fix only if:** the fix is minimal, safe, and clearly correct. If there is any ambiguity — exclude instead.
+
+## Step 4: Act and commit
+
+Perform exactly **one commit per test**, regardless of whether the action is a fix or an exclusion. The commit message must contain the full analysis.
+
+### If fixing the code
+
+Apply the minimal fix:
+- Preserve `#if TENSORFLOW_USE_ROCM` blocks and ROCm-specific logic.
+- Mirror CUDA patterns in the ROCm path.
+- No refactoring, no cleanup, no new comments outside the fix.
+
+Re-run the test to verify the fix:
+```
+Tool: Bash
+command: .claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh "<bazel_target>" "<test_filter>" 2>&1
+run_in_background: true
+```
+
+If it still fails after the fix, discard the fix (`git checkout -- .`) and fall back to excluding instead.
+
+Commit with the full analysis in the message:
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+Fix <TestClass.TestCase> for ROCm
+
+Test: <bazel_target>
+Filter: <test_filter>
+Category: <category description, e.g. "Build / compilation failure", "Unsupported op / CUDA-only feature">
+
+Root cause:
+<One or two sentences describing why the test was failing.>
+
+Fix:
+<What was changed and why — file(s), what the old code did, what the new code does.>
+
+Verified: test passes on MI250 (gfx90a) via RBE after fix.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### If adding to the exclusion list
+
+Add the failing test filter to the `EXCLUDED_TESTS` array in `tensorflow/tools/ci_build/linux/rocm/run_xla.sh`.
+
+**Every `[  FAILED  ]` line in the test output must be covered by an exclusion pattern.** Before committing, re-read all `[  FAILED  ]` lines from the test log and verify each one matches at least one pattern in `EXCLUDED_TESTS`. It is not sufficient to add a pattern that covers the first failure — if the test binary reports 20 failures, all 20 must be matched. Use wildcards (`*`) to cover groups, but confirm the wildcard actually matches the full test name format (see below).
+
+### Choosing the right exclusion pattern
+
+The gtest filter pattern must match the **full test name** as it appears in `[  FAILED  ]` lines. Always copy the exact name from the test output and derive the pattern from it.
+
+**Non-parameterized tests (`TEST_F`)** — full name is `SuiteName.TestName`:
+```bash
+    FailingTestSuite.FailingTestCase
+    FailingTestSuite.*          # excludes all TEST_F cases in the suite
+```
+
+**Parameterized tests (`TEST_P`)** — full name is `InstantiationName/SuiteName.TestName/ParamName`:
+```bash
+    # To exclude a specific parameter:
+    NumericTestsForBlas/NumericTestsForBlas.Infinity/dot_bf16_bf16_f32_x9
+
+    # To exclude all test methods for a specific parameter:
+    NumericTestsForBlas/NumericTestsForBlas.*/dot_bf16_bf16_f32_x9
+
+    # To exclude all parameters for a specific instantiation:
+    SortRewriterTest/SortRewriterTest.*
+    SortRewriterArgsort/SortRewriterArgsortTest.*
+```
+
+**A suite may have both `TEST_F` and `TEST_P` tests.** If both kinds are failing, add patterns for both:
+```bash
+    SortRewriterTest.*                     # covers TEST_F cases
+    SortRewriterTest/SortRewriterTest.*    # covers TEST_P cases (parameterized)
+```
+
+**Never use `SuiteName.*` alone to exclude a `TEST_P` test** — it will not match.
+
+Format (match existing style exactly):
+```bash
+    # @xla//xla/backends/...:some_test_amdgpu_any
+    FailingTestClass.FailingTestCase
+```
+
+Placement: append under the most recent `# vvv TODO (rocm) weekly-sync-XXXXXX excluded tests` section header. If there is no header for the current sync, add one first (derive the date from the branch name `develop-upstream-sync-XXXXXX` or from `git log --oneline -1`):
+```bash
+    # vvv TODO (rocm) weekly-sync-XXXXXX excluded tests
+
+    # @xla//xla/...:some_test_amdgpu_any
+    FailingTestClass.FailingTestCase
+```
+
+Verify the script is still valid bash:
+```bash
+bash -n tensorflow/tools/ci_build/linux/rocm/run_xla.sh
+```
+
+**If the original failure was a crash (segfault, `Aborted`, `HIP error`, `hipErrorInvalidValue`, or any signal-based termination), you MUST re-run the full test binary via RBE after adding the exclusion patterns.** A crash aborts the entire test process mid-run, hiding all test cases that would have run after the crash. Once those cases are excluded, a new crash in a previously-hidden case may surface. This is a cascading pattern: excluding x9 reveals x6 crashes, excluding x6 reveals x3 crashes, and so on.
+
+Run the full test binary without a test filter to let the updated global exclusion list take effect:
+
+```
+Tool: Bash
+command: .claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh "<bazel_target>" "" 2>&1
+run_in_background: true
+```
+
+Wait for completion with `TaskOutput` (block: true, timeout: 600000).
+
+- If the re-run **passes**: proceed to commit.
+- If the re-run **reveals a new crash**: add those new cases to `EXCLUDED_TESTS` and re-run again. Repeat until the binary passes.
+- If the re-run **fails with the same test**: the exclusion pattern is wrong — check the exact `[  FAILED  ]` name against the pattern (see parameterized test naming rules above).
+
+For non-crash failures (assertion failures, wrong output values, `FAIL` without a signal), this re-run is not required — those failures do not abort the process and all failing test names are visible in the original log.
+
+Commit with the full analysis in the message:
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+Exclude failing test: <TestClass.TestCase>
+
+Test: <bazel_target>
+Filter: <test_filter>
+Category: <category description, e.g. "Unsupported op / CUDA-only feature", "Numerical / correctness failure">
+
+Root cause:
+<One or two sentences describing why the test is failing.>
+
+Reason for exclusion (not fix):
+<Why a fix was not applied — e.g. "CUDA-only feature (hipBLASLt not supported)",
+"Numerical precision divergence in fp16 reduction, non-trivial to fix",
+"Missing ROCm equivalent for cuDNN fused op", etc.>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Step 5: Report to user
+
+After committing, report a concise summary:
+
+**Test:** `<bazel_target>` / `<test_filter>`
+**Category:** `<category description>`
+**Root cause:** one sentence
+**Action:** `FIXED` | `EXCLUDED` | `INFRASTRUCTURE` | `FLAKY`
+**Commit:** `<hash> <subject>`
+
+## Important notes
+
+- Run tests one at a time. Never launch parallel RBE test runs.
+- Do NOT push anything. The user will push when ready.
+- Never ask the user for guidance on fix vs. exclude — default to exclude when uncertain.
+- Each test gets exactly one commit containing the full analysis in the commit message.
+- If multiple test cases from the same target are failing, run them together with `CaseA:CaseB` for efficiency. If the combined run fails, re-run individually to isolate. Each case that requires a separate action gets its own commit.
+- **Never add `cuda-only` tags to BUILD files.** The correct action for CUDA-only tests is always to add the failing test cases to the exclusion list in `run_xla.sh`. The `cuda-only` tag validation is handled separately by the `sync-cuda-only` skill.

--- a/.claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh
+++ b/.claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Run a single XLA test via RBE on MI250 (gfx90a) workers.
+#
+# Usage:
+#   ./run_single_xla_rbe_test.sh <bazel_target> [test_filter]
+#
+# Examples:
+#   ./run_single_xla_rbe_test.sh @@xla//xla/backends/profiler/gpu:rocm_tracer_test "RocmTracerTest.Counters"
+#   ./run_single_xla_rbe_test.sh @@xla//xla/backends/profiler/gpu:rocm_tracer_test ""
+#
+# Exit code: 0 if the test passes, non-zero if it fails.
+
+set -e
+set -x
+
+BAZEL_TARGET="$1"
+TEST_FILTER="$2"
+
+if [[ -z "$BAZEL_TARGET" ]]; then
+    echo "Usage: $0 <bazel_target> [test_filter]"
+    exit 1
+fi
+
+if [[ -z "${ROCM_PATH}" ]]; then
+    ROCM_INSTALL_DIR=/opt/rocm/
+else
+    ROCM_INSTALL_DIR=$ROCM_PATH
+fi
+export ROCM_PATH=$ROCM_INSTALL_DIR
+export TF_ROCM_RBE_DOCKER_IMAGE=rocm/tensorflow-build@sha256:a2191b80002ad851e5f7274994b0c62859874b38cc587115b116eff69b0948af
+
+export PYTHON_BIN_PATH=$(which python3)
+PYTHON_VERSION=$(python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+export TF_PYTHON_VERSION=$PYTHON_VERSION
+export TF_NEED_ROCM=1
+
+if [ ! -d /tf ]; then
+    mkdir -p /tf
+fi
+
+FILTER_ARG=""
+if [[ -n "$TEST_FILTER" ]]; then
+    FILTER_ARG="--test_filter=${TEST_FILTER}"
+fi
+
+bazel \
+    --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc \
+    --bazelrc=third_party/xla/build_tools/rocm/rocm_xla.bazelrc \
+    test \
+    --config=sigbuild_local_cache \
+    --config=rocm \
+    --config=xla_cpp_filters \
+    --config=rocm_rbe \
+    --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=rocm/tensorflow-build@sha256:a2191b80002ad851e5f7274994b0c62859874b38cc587115b116eff69b0948af \
+    --repo_env=TF_ROCM_RBE_POOL=linux_x64_gpu \
+    --spawn_strategy=local \
+    --jobs=$(nproc) \
+    --test_output=all \
+    --test_env=MIOPEN_FIND_ENFORCE=5 \
+    --test_env=MIOPEN_FIND_MODE=1 \
+    --action_env="ROCM_PATH=$ROCM_PATH" \
+    --action_env=TF_ROCM_AMDGPU_TARGETS=gfx90a,gfx942 \
+    --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
+    $FILTER_ARG \
+    -- "$BAZEL_TARGET"

--- a/.claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test_mi250.sh
+++ b/.claude/skills/sync-triage-test/scripts/run_single_xla_rbe_test_mi250.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Run a single XLA test via RBE on MI250 (gfx90a) workers.
+#
+# Usage:
+#   ./run_single_xla_rbe_test.sh <bazel_target> [test_filter]
+#
+# Examples:
+#   ./run_single_xla_rbe_test.sh @@xla//xla/backends/profiler/gpu:rocm_tracer_test "RocmTracerTest.Counters"
+#   ./run_single_xla_rbe_test.sh @@xla//xla/backends/profiler/gpu:rocm_tracer_test ""
+#
+# Exit code: 0 if the test passes, non-zero if it fails.
+
+set -e
+set -x
+
+BAZEL_TARGET="$1"
+TEST_FILTER="$2"
+
+if [[ -z "$BAZEL_TARGET" ]]; then
+    echo "Usage: $0 <bazel_target> [test_filter]"
+    exit 1
+fi
+
+if [[ -z "${ROCM_PATH}" ]]; then
+    ROCM_INSTALL_DIR=/opt/rocm/
+else
+    ROCM_INSTALL_DIR=$ROCM_PATH
+fi
+export ROCM_PATH=$ROCM_INSTALL_DIR
+export TF_ROCM_RBE_DOCKER_IMAGE=rocm/tensorflow-build@sha256:a2191b80002ad851e5f7274994b0c62859874b38cc587115b116eff69b0948af
+
+export PYTHON_BIN_PATH=$(which python3)
+PYTHON_VERSION=$(python3 -c "import sys;print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+export TF_PYTHON_VERSION=$PYTHON_VERSION
+export TF_NEED_ROCM=1
+
+if [ ! -d /tf ]; then
+    mkdir -p /tf
+fi
+
+FILTER_ARG=""
+if [[ -n "$TEST_FILTER" ]]; then
+    FILTER_ARG="--test_filter=${TEST_FILTER}"
+fi
+
+bazel \
+    --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc \
+    --bazelrc=third_party/xla/build_tools/rocm/rocm_xla.bazelrc \
+    test \
+    --config=sigbuild_local_cache \
+    --config=rocm \
+    --config=xla_cpp_filters \
+    --config=rocm_rbe \
+    --repo_env=TF_ROCM_RBE_DOCKER_IMAGE=rocm/tensorflow-build@sha256:a2191b80002ad851e5f7274994b0c62859874b38cc587115b116eff69b0948af \
+    --repo_env=TF_ROCM_RBE_POOL=linux_x64_gpu_gfx90a \
+    --spawn_strategy=local \
+    --jobs=$(nproc) \
+    --test_output=all \
+    --test_env=MIOPEN_FIND_ENFORCE=5 \
+    --test_env=MIOPEN_FIND_MODE=1 \
+    --action_env="ROCM_PATH=$ROCM_PATH" \
+    --action_env=TF_ROCM_AMDGPU_TARGETS=gfx90a,gfx942 \
+    --action_env=XLA_FLAGS=--xla_gpu_force_compilation_parallelism=16 \
+    $FILTER_ARG \
+    -- "$BAZEL_TARGET"

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: sync
+description: "Full end-to-end upstream sync: merge, resolve conflicts, mirror CI, build, and check excluded tests. Orchestrates sync-start → sync-resolve → sync-ci-mirror → sync-build → sync-test-check automatically."
+argument-hint: "[YYMMDD (optional, defaults to today)] [optional: upstream ref, defaults to upstream/master]"
+---
+
+# Full Upstream Sync — Orchestrator
+
+This skill runs the complete upstream sync pipeline for `ROCm/tensorflow-upstream` end-to-end, without manual intervention. It executes each phase in order by following the instructions in each sub-skill's SKILL.md file.
+
+Arguments are passed through to `/sync-start` (see its SKILL.md for details).
+
+## Pipeline
+
+Execute each phase below **in order**. After each phase completes, proceed immediately to the next one — do not stop to ask the user. Only stop if a phase explicitly says to STOP (e.g., a pre-flight check failure).
+
+### Phase 1: Merge upstream
+
+Follow all instructions in `.claude/skills/sync-start/SKILL.md`.
+
+Pass `$ARGUMENTS` through — they specify the YYMMDD date label and optional upstream ref.
+
+When this phase completes (merge commit recorded), proceed immediately to Phase 2.
+
+### Phase 2: Resolve merge conflicts
+
+Follow all instructions in `.claude/skills/sync-resolve/SKILL.md`.
+
+If Phase 1 reported "Clean merge! No conflicts to resolve", skip this phase entirely.
+
+When this phase completes (conflicts resolved and committed), proceed immediately to Phase 3.
+
+### Phase 3: Mirror upstream CI changes to ROCm counterparts
+
+Follow all instructions in `.claude/skills/sync-ci-mirror/SKILL.md`.
+
+When this phase completes (CI mirroring committed or skipped), proceed immediately to Phase 4.
+
+### Phase 4: Build TensorFlow
+
+Follow all instructions in `.claude/skills/sync-build/SKILL.md`.
+
+When this phase completes (build succeeds, fixes committed if any), proceed immediately to Phase 5.
+
+### Phase 5: Check excluded tests
+
+Follow all instructions in `.claude/skills/sync-test-check/SKILL.md`.
+
+When this phase completes, proceed immediately to Phase 6.
+
+### Phase 6: Validate newly added cuda-only tags
+
+Follow all instructions in `.claude/skills/sync-cuda-only/SKILL.md`.
+
+When this phase completes, proceed immediately to Phase 7.
+
+### Phase 7: Run full XLA test suite on MI250 via RBE
+
+Follow all instructions in `.claude/skills/sync-run-tests/SKILL.md`.
+
+This runs the complete test suite on the EngFlow `linux_x64_gpu_gfx90a` pool and collects all failures.
+
+When this phase completes, record the list of new failing tests (those not already in the exclusion list) and proceed immediately to Phase 8.
+
+### Phase 8: Triage all new failures
+
+For each new failing test identified in Phase 7, follow all instructions in `.claude/skills/sync-triage-test/SKILL.md`.
+
+Process tests **one at a time** (never in parallel). For each test the skill will either fix the code or add it to the exclusion list, committing the result with the full analysis in the commit message.
+
+When all failures have been triaged, proceed immediately to Phase 9.
+
+### Phase 9: Generate test change summary
+
+Produce a markdown summary of all test exclusion changes made during this sync.
+
+**How to extract the data:**
+
+1. Find the merge base between the current branch and `develop-upstream`:
+   ```bash
+   MERGE_BASE=$(git merge-base HEAD develop-upstream)
+   ```
+
+2. Get the diff of the exclusion list files since the merge base:
+   ```bash
+   git diff $MERGE_BASE HEAD -- tensorflow/tools/ci_build/linux/rocm/run_xla.sh tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+   ```
+
+3. Parse the diff to find:
+   - **Enabled tests** — lines removed from the exclusion list (diff lines starting with `-` that contain test case patterns or `# @xla//` target comments).
+   - **New disabled tests** — lines added to the exclusion list (diff lines starting with `+` that contain test case patterns or `# @xla//` target comments).
+   - Ignore diff headers, context lines, section headers (`# vvv TODO`), and blank lines.
+
+4. Group test cases under their target name (from `# @xla//...` comment lines). Separate targets with a blank line.
+
+5. Output the summary in this format:
+
+````markdown
+## Technical details
+
+### Enabled tests
+
+```bash
+# @xla//xla/path/to:test_target_amdgpu_any
+    TestClass.TestCase1
+    TestClass.TestCase2
+```
+
+### New Disabled Tests
+
+```bash
+# @xla//xla/path/to:test_target_amdgpu_any
+    TestClass.FailingCase1
+    TestClass.FailingCase2
+
+# @xla//xla/path/to:another_test_amdgpu_any
+    AnotherClass.FailingCase
+```
+````
+
+- If no tests were enabled, write "No tests were enabled in this sync."
+- If no tests were disabled, write "No new tests were disabled in this sync."
+
+This is the final phase. When complete, print the final summary.
+
+## Final summary
+
+After all phases complete, provide a consolidated summary:
+
+```
+## Upstream Sync Complete
+
+**Branch:** develop-upstream-sync-<YYMMDD>
+**Upstream ref:** <ref merged>
+**Commits on branch:**
+1. Merge commit (with unresolved conflicts)
+2. Fix merge conflicts
+3. Mirror upstream CI changes to ROCm counterparts (if applicable)
+4. Fix build errors from upstream sync (if applicable)
+5. Remove passing excluded tests (if applicable)
+6. Remove incorrect cuda-only tags (if applicable)
+7. [Per-test triage commits from Phase 8] (if applicable)
+
+**Conflicts resolved:** N files
+**CI files mirrored:** N files (or "none")
+**Build fixes:** N files (or "clean build")
+**Excluded tests removed:** N (or "none")
+**cuda-only tags removed:** N (or "none")
+**RBE test results:** X passed, Y failed
+**Failures triaged:** N fixed, M excluded
+
+Ready to push and open a PR.
+```
+
+## Important notes
+- Do NOT push anything. The user will push when ready.
+- Do NOT stop between phases to ask the user unless a pre-flight check fails or a phase explicitly requires user input (e.g., ambiguous conflict resolution).
+- Each phase's SKILL.md contains the full instructions — read and follow them completely.
+- If any phase fails irrecoverably, commit whatever progress has been made and report what failed and what remains.

--- a/.claude/skills/sync/scripts/tag-post.sh
+++ b/.claude/skills/sync/scripts/tag-post.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Usage: tag-post.sh YYMMDD
+# Step 3 of 3 in the post-approval workflow (run AFTER merging the PR).
+# Checks out develop-upstream, pulls the merged result, and tags the new HEAD
+# as merge-YYMMDD to mark the completed sync point.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 YYMMDD" >&2
+    exit 1
+fi
+
+YYMMDD="$1"
+
+git checkout develop-upstream
+git fetch origin
+git pull origin develop-upstream
+git tag "merge-${YYMMDD}"
+git push origin "merge-${YYMMDD}"

--- a/.claude/skills/sync/scripts/tag-prev.sh
+++ b/.claude/skills/sync/scripts/tag-prev.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Usage: tag-prev.sh YYMMDD
+# Step 1 of 3 in the post-approval workflow (run BEFORE merging the PR).
+# Checks out develop-upstream, pulls, and tags the current HEAD as
+# merge-YYMMDD-prev so there is a clear baseline of what existed before the merge.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 YYMMDD" >&2
+    exit 1
+fi
+
+YYMMDD="$1"
+
+git checkout develop-upstream
+git fetch origin
+git pull origin develop-upstream
+git tag "merge-${YYMMDD}-prev"
+git push origin "merge-${YYMMDD}-prev"

--- a/.claude/stats.py
+++ b/.claude/stats.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dump stats from Claude Code JSONL session logs.
+
+Usage:
+  python3 stats.py                     # all *.jsonl in same directory
+  python3 stats.py sync_260316.jsonl   # specific file(s)
+  python3 stats.py --dir /path/to/dir  # different directory
+"""
+
+import json
+import sys
+import os
+import argparse
+from pathlib import Path
+from datetime import timedelta
+from collections import defaultdict
+
+
+# ── formatting helpers ────────────────────────────────────────────────────────
+
+def fmt_dur(ms: int) -> str:
+    if ms < 0:
+        return f"-{fmt_dur(-ms)}"
+    h, rem = divmod(ms // 1000, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m {s}s"
+    if m:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+def fmt_tok(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n/1_000_000:.2f}M"
+    if n >= 1_000:
+        return f"{n/1_000:.1f}K"
+    return str(n)
+
+def fmt_cost(usd: float) -> str:
+    return f"${usd:.2f}"
+
+
+# ── pricing (Anthropic public pricing, approximate) ───────────────────────────
+
+PRICING = {
+    # Model string as it appears in the JSONL 'model' field
+    "claude-opus-4-6": {
+        "input":          15.00 / 1e6,
+        "output":         75.00 / 1e6,
+        "cache_read":      1.50 / 1e6,
+        "cache_create_5m": 3.75 / 1e6,
+        "cache_create_1h":18.75 / 1e6,
+    },
+    "claude-haiku-4-5-20251001": {
+        "input":           0.80 / 1e6,
+        "output":          4.00 / 1e6,
+        "cache_read":      0.08 / 1e6,
+        "cache_create_5m": 1.00 / 1e6,
+        "cache_create_1h": 5.00 / 1e6,
+    },
+}
+
+
+def msg_raw_cost(model: str, usage: dict) -> float:
+    """Estimate cost of a single API call from its usage block."""
+    p = PRICING.get(model)
+    if not p:
+        return 0.0
+    cc = usage.get("cache_creation", {})
+    return (
+        usage.get("input_tokens", 0)              * p["input"] +
+        usage.get("output_tokens", 0)             * p["output"] +
+        usage.get("cache_read_input_tokens", 0)   * p["cache_read"] +
+        cc.get("ephemeral_5m_input_tokens", 0)    * p["cache_create_5m"] +
+        cc.get("ephemeral_1h_input_tokens", 0)    * p["cache_create_1h"]
+    )
+
+
+# ── phase detection ───────────────────────────────────────────────────────────
+
+# Ordered list of (label, text-trigger) for phase detection.
+# We scan assistant 'text' content blocks for the first matching trigger.
+PHASE_TRIGGERS = [
+    ("Phase 1: Merge Upstream",        "## Phase 1"),
+    ("Phase 2: Resolve Conflicts",     "## Phase 2"),
+    ("Phase 3: Mirror CI",             "## Phase 3"),
+    ("Phase 4: Build TensorFlow",      "## Phase 4"),
+    ("Phase 5: Check Excluded Tests",  "## Phase 5"),
+    ("Phase 6: Run RBE Tests",         "## Phase 6"),
+    ("Phase 7: Triage",                "## Phase 7"),
+    ("Phase 8: CUDA-only Tags",        "## Phase 8"),
+    ("Phase 9",                        "## Phase 9"),
+]
+
+
+def detect_phase(text: str) -> str | None:
+    for label, trigger in PHASE_TRIGGERS:
+        if trigger in text:
+            return label
+    return None
+
+
+# ── core parser ───────────────────────────────────────────────────────────────
+
+class Session:
+    """One contiguous init→result block."""
+    def __init__(self, init_rec: dict):
+        self.model = init_rec.get("model", "")
+        self.session_id = init_rec.get("session_id", "")
+        self.records: list[dict] = []
+        self.result: dict = {}
+
+    # Accumulated token usage across all assistant messages in this session
+    @property
+    def usage(self):
+        u = defaultdict(int)
+        for r in self.records:
+            if r.get("type") != "assistant":
+                continue
+            m = r.get("message", {})
+            mu = m.get("usage", {})
+            u["input"]    += mu.get("input_tokens", 0)
+            u["output"]   += mu.get("output_tokens", 0)
+            u["cache_r"]  += mu.get("cache_read_input_tokens", 0)
+            cc = mu.get("cache_creation", {})
+            u["cache_c"]  += cc.get("ephemeral_5m_input_tokens", 0) + cc.get("ephemeral_1h_input_tokens", 0)
+        return dict(u)
+
+    @property
+    def raw_cost(self) -> float:
+        total = 0.0
+        for r in self.records:
+            if r.get("type") != "assistant":
+                continue
+            m = r.get("message", {})
+            total += msg_raw_cost(m.get("model", ""), m.get("usage", {}))
+        return total
+
+    @property
+    def tool_calls(self) -> dict[str, int]:
+        counts: dict[str, int] = defaultdict(int)
+        for r in self.records:
+            if r.get("type") != "assistant":
+                continue
+            for c in r.get("message", {}).get("content", []):
+                if isinstance(c, dict) and c.get("type") == "tool_use":
+                    counts[c.get("name", "?")] += 1
+        return dict(counts)
+
+    @property
+    def skill_calls(self) -> list[dict]:
+        out = []
+        for r in self.records:
+            if r.get("type") != "assistant":
+                continue
+            for c in r.get("message", {}).get("content", []):
+                if isinstance(c, dict) and c.get("type") == "tool_use" and c["name"] == "Skill":
+                    out.append(c.get("input", {}))
+        return out
+
+    @property
+    def agent_calls(self) -> list[dict]:
+        out = []
+        for r in self.records:
+            if r.get("type") != "assistant":
+                continue
+            for c in r.get("message", {}).get("content", []):
+                if isinstance(c, dict) and c.get("type") == "tool_use" and c["name"] == "Agent":
+                    out.append({"input": c.get("input", {}), "id": c.get("id", "")})
+        return out
+
+    @property
+    def duration_ms(self) -> int:
+        return self.result.get("duration_ms", 0)
+
+    @property
+    def turns(self) -> int:
+        return self.result.get("num_turns", 0)
+
+    @property
+    def is_main(self) -> bool:
+        return self.turns > 5
+
+
+def parse_sessions(records: list[dict]) -> list[Session]:
+    """Split records into Session objects at each system/init boundary."""
+    sessions = []
+    current: Session | None = None
+    for r in records:
+        if r.get("type") == "system" and r.get("subtype") == "init":
+            if current is not None:
+                sessions.append(current)
+            current = Session(r)
+        elif current is not None:
+            current.records.append(r)
+            if r.get("type") == "result":
+                current.result = r
+    if current is not None:
+        sessions.append(current)
+    return sessions
+
+
+def enrich_agent_calls(sessions: list[Session]) -> None:
+    """Attach task_notification data to agent_calls."""
+    # Build map: tool_use_id → task_notification record
+    notif_map = {}
+    for s in sessions:
+        for r in s.records:
+            if r.get("type") == "system" and r.get("subtype") == "task_notification":
+                notif_map[r.get("tool_use_id", "")] = r
+
+    for s in sessions:
+        for ac in s.agent_calls:
+            notif = notif_map.get(ac["id"], {})
+            if notif:
+                usage = notif.get("usage", {})
+                ac["status"]       = notif.get("status", "")
+                ac["total_tokens"] = usage.get("total_tokens", 0)
+                ac["tool_uses"]    = usage.get("tool_uses", 0)
+                ac["duration_ms"]  = usage.get("duration_ms", 0)
+                ac["summary"]      = notif.get("summary", "")
+
+
+# ── phase breakdown ───────────────────────────────────────────────────────────
+
+class PhaseStats:
+    def __init__(self, name: str):
+        self.name = name
+        self.n_msgs = 0
+        self.in_tok = self.out_tok = self.cache_r = self.cache_c = 0
+        self.n_tools = 0
+        self.raw_cost = 0.0
+
+    def add_msg(self, model: str, usage: dict, n_tools: int = 0):
+        self.n_msgs += 1
+        self.in_tok   += usage.get("input_tokens", 0)
+        self.out_tok  += usage.get("output_tokens", 0)
+        self.cache_r  += usage.get("cache_read_input_tokens", 0)
+        cc = usage.get("cache_creation", {})
+        self.cache_c  += cc.get("ephemeral_5m_input_tokens", 0) + cc.get("ephemeral_1h_input_tokens", 0)
+        self.n_tools  += n_tools
+        self.raw_cost += msg_raw_cost(model, usage)
+
+
+def compute_phases(session: Session) -> list[PhaseStats]:
+    """Segment a main session into phases based on text markers."""
+    phases: list[PhaseStats] = [PhaseStats("Pre-flight / Reading Skills")]
+    current = phases[0]
+
+    for r in session.records:
+        if r.get("type") != "assistant":
+            continue
+        msg = r.get("message", {})
+        model = msg.get("model", "")
+        usage = msg.get("usage", {})
+        content = msg.get("content", [])
+
+        # Count tool calls in this message
+        n_tools = sum(1 for c in content
+                      if isinstance(c, dict) and c.get("type") == "tool_use")
+
+        # Check for phase transition in text blocks
+        for c in content:
+            if isinstance(c, dict) and c.get("type") == "text":
+                label = detect_phase(c.get("text", ""))
+                if label and label != current.name:
+                    new_phase = PhaseStats(label)
+                    phases.append(new_phase)
+                    current = new_phase
+                    break
+
+        if usage:
+            current.add_msg(model, usage, n_tools)
+
+    return phases
+
+
+# ── display ───────────────────────────────────────────────────────────────────
+
+def print_phase_breakdown(phases: list[PhaseStats], actual_total: float):
+    """Print cost breakdown by phase, scaled to match the authoritative total."""
+    raw_total = sum(p.raw_cost for p in phases)
+    scale = actual_total / raw_total if raw_total > 0 else 1.0
+
+    col = "{:<33}  {:>4}  {:>6}  {:>6}  {:>9}  {:>9}  {:>5}  {:>8}"
+    print(col.format("Phase", "Msgs", "Input", "Output", "CacheR", "CacheC", "Tools", "Cost"))
+    print("─" * 93)
+    for p in phases:
+        cost = p.raw_cost * scale
+        print(col.format(
+            p.name[:33],
+            p.n_msgs,
+            fmt_tok(p.in_tok),
+            fmt_tok(p.out_tok),
+            fmt_tok(p.cache_r),
+            fmt_tok(p.cache_c),
+            p.n_tools,
+            fmt_cost(cost),
+        ))
+    print("─" * 93)
+    print(col.format("TOTAL", "", "", "", "", "", "", fmt_cost(actual_total)))
+    if abs(scale - 1.0) > 0.01:
+        print(f"  (pricing scale factor: {scale:.3f} — applied to match authoritative result total)")
+
+
+def print_file_stats(path: str, verbose: bool = False) -> dict:
+    with open(path) as f:
+        records = []
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+
+    sessions = parse_sessions(records)
+    enrich_agent_calls(sessions)
+
+    # The authoritative cost/duration is in the last result record's cumulative totals.
+    # Each result.total_cost_usd is a RUNNING CUMULATIVE — use the last one as the grand total.
+    all_results = [r for r in records if r.get("type") == "result"]
+    if not all_results:
+        print(f"\nNo result records found in {os.path.basename(path)}")
+        return {}
+
+    last_result = all_results[-1]
+    actual_total_cost = last_result.get("total_cost_usd", 0.0)
+    # duration and turns: sum the INCREMENTAL values (each result.duration_ms is for that sub-session)
+    total_duration_ms = sum(r.get("duration_ms", 0) for r in all_results)
+    total_turns = sum(r.get("num_turns", 0) for r in all_results)
+
+    # Per-model totals from the last result's modelUsage (also cumulative)
+    model_usage = last_result.get("modelUsage", {})
+
+    # Main session vs follow-up sessions
+    main_sessions = [s for s in sessions if s.is_main]
+    followup_sessions = [s for s in sessions if not s.is_main]
+
+    print(f"\n{'═'*65}")
+    print(f"  File: {os.path.basename(path)}")
+    print(f"{'═'*65}")
+    print(f"  Sessions:    {len(sessions)}  "
+          f"({len(main_sessions)} main, {len(followup_sessions)} follow-up)")
+
+    # Duration
+    print(f"\n  Duration")
+    print(f"    Wall time:   {fmt_dur(total_duration_ms)}")
+    print(f"    Turns:       {total_turns}")
+
+    # Cost
+    print(f"\n  Cost (authoritative)")
+    print(f"    Total:       {fmt_cost(actual_total_cost)}")
+    for model, mu in sorted(model_usage.items()):
+        cost = mu.get("costUSD", 0.0)
+        pct = cost / actual_total_cost * 100 if actual_total_cost else 0
+        print(f"    {model:<28} {fmt_cost(cost):>8}  ({pct:.0f}%)")
+
+    # Tokens (from last result's modelUsage — cumulative session totals)
+    total_in  = sum(mu.get("inputTokens", 0) for mu in model_usage.values())
+    total_out = sum(mu.get("outputTokens", 0) for mu in model_usage.values())
+    total_cr  = sum(mu.get("cacheReadInputTokens", 0) for mu in model_usage.values())
+    total_cc  = sum(mu.get("cacheCreationInputTokens", 0) for mu in model_usage.values())
+    print(f"\n  Tokens")
+    print(f"    Input:              {fmt_tok(total_in):>9}")
+    print(f"    Output:             {fmt_tok(total_out):>9}")
+    print(f"    Cache read:         {fmt_tok(total_cr):>9}")
+    print(f"    Cache creation:     {fmt_tok(total_cc):>9}")
+
+    # Tool calls across all sessions
+    all_tools: dict[str, int] = defaultdict(int)
+    all_skills: list[dict] = []
+    all_agents: list[dict] = []
+    for s in sessions:
+        for name, count in s.tool_calls.items():
+            all_tools[name] += count
+        all_skills.extend(s.skill_calls)
+        all_agents.extend(s.agent_calls)
+
+    total_tool_calls = sum(all_tools.values())
+    print(f"\n  Tool calls   ({total_tool_calls} total)")
+    for name, count in sorted(all_tools.items(), key=lambda x: -x[1]):
+        bar = "█" * min(count, 35)
+        print(f"    {name:<22} {count:>4}  {bar}")
+
+    if all_skills:
+        print(f"\n  Skill calls  ({len(all_skills)} total)")
+        skill_counts: dict[str, int] = defaultdict(int)
+        for sc in all_skills:
+            skill_counts[sc.get("skill", "?")] += 1
+        for skill, count in sorted(skill_counts.items(), key=lambda x: -x[1]):
+            print(f"    {skill:<22} {count:>4}")
+    else:
+        print(f"\n  Skill calls  0")
+
+    if all_agents:
+        print(f"\n  Agent calls  ({len(all_agents)} total)")
+        for ac in all_agents:
+            inp = ac.get("input", {})
+            atype = inp.get("subagent_type", "")
+            desc = inp.get("description", "")[:48]
+            status = ac.get("status", "")
+            dur_a = ac.get("duration_ms", 0)
+            toks = ac.get("total_tokens", 0)
+            uses = ac.get("tool_uses", 0)
+            status_tag = f"[{status}] " if status else ""
+            print(f"    [{atype}] {status_tag}{desc}")
+            if dur_a:
+                print(f"      duration={fmt_dur(dur_a)}  tokens={fmt_tok(toks)}  tool_uses={uses}")
+    else:
+        print(f"\n  Agent calls  0")
+
+    # Phase breakdown (main sessions only)
+    if main_sessions:
+        # Cost attributable to follow-up sessions
+        followup_raw = sum(s.raw_cost for s in followup_sessions)
+        main_raw = sum(s.raw_cost for s in main_sessions)
+        grand_raw = main_raw + followup_raw
+
+        # Scale factor so everything sums to actual_total_cost
+        scale = actual_total_cost / grand_raw if grand_raw > 0 else 1.0
+        followup_cost = followup_raw * scale
+
+        for i, ms in enumerate(main_sessions):
+            label = f"  Phase breakdown — main session {i+1}" if len(main_sessions) > 1 else "  Phase breakdown — main session"
+            if len(followup_sessions) > 0:
+                ms_actual = ms.raw_cost * scale
+            else:
+                ms_actual = actual_total_cost
+            print(f"\n{label}  ({fmt_cost(ms_actual)}, {ms.turns} turns, {fmt_dur(ms.duration_ms)})")
+            phases = compute_phases(ms)
+            print_phase_breakdown(phases, ms_actual)
+
+        if followup_sessions and followup_cost > 0.01:
+            print(f"\n  Follow-up sessions ({len(followup_sessions)} sub-sessions, ~{fmt_cost(followup_cost)})")
+            print(f"    These are short sessions triggered by background task notifications")
+            print(f"    (each ~{fmt_cost(followup_cost/len(followup_sessions))}, "
+                  f"{sum(s.turns for s in followup_sessions)} turns total)")
+
+    return {
+        "file": os.path.basename(path),
+        "total_cost": actual_total_cost,
+        "total_duration_ms": total_duration_ms,
+        "total_turns": total_turns,
+        "total_tool_calls": total_tool_calls,
+        "n_agents": len(all_agents),
+        "n_skills": len(all_skills),
+        "model_usage": model_usage,
+    }
+
+
+def print_aggregate(all_file_stats: list[dict]):
+    if len(all_file_stats) < 2:
+        return
+
+    total_cost = sum(s["total_cost"] for s in all_file_stats)
+    total_dur = sum(s["total_duration_ms"] for s in all_file_stats)
+    total_turns = sum(s["total_turns"] for s in all_file_stats)
+    total_tools = sum(s["total_tool_calls"] for s in all_file_stats)
+    total_agents = sum(s["n_agents"] for s in all_file_stats)
+    total_skills = sum(s["n_skills"] for s in all_file_stats)
+
+    print(f"\n{'═'*65}")
+    print(f"  AGGREGATE  ({len(all_file_stats)} files)")
+    print(f"{'═'*65}")
+    print(f"\n  {'File':<28}  {'Cost':>8}  {'Wall time':>10}  {'Turns':>6}")
+    print("  " + "─" * 58)
+    for s in all_file_stats:
+        print(f"  {s['file']:<28}  {fmt_cost(s['total_cost']):>8}  "
+              f"{fmt_dur(s['total_duration_ms']):>10}  {s['total_turns']:>6}")
+    print("  " + "─" * 58)
+    print(f"  {'TOTAL':<28}  {fmt_cost(total_cost):>8}  "
+          f"{fmt_dur(total_dur):>10}  {total_turns:>6}")
+
+    print(f"\n  Tool calls:  {total_tools}")
+    print(f"  Agent calls: {total_agents}")
+    print(f"  Skill calls: {total_skills}")
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("files", nargs="*",
+                        help="JSONL files to analyze (default: all *.jsonl here)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--dir", default=None,
+                        help="Directory to search for JSONL files")
+    args = parser.parse_args()
+
+    files = args.files
+    if not files:
+        search_dir = args.dir or os.path.dirname(os.path.abspath(__file__))
+        files = sorted(Path(search_dir).glob("*.jsonl"))
+        if not files:
+            print(f"No .jsonl files found in {search_dir}")
+            sys.exit(1)
+
+    all_stats = []
+    for f in files:
+        path = str(f)
+        if not os.path.exists(path):
+            print(f"File not found: {path}", file=sys.stderr)
+            continue
+        s = print_file_stats(path, verbose=args.verbose)
+        if s:
+            all_stats.append(s)
+
+    if len(all_stats) > 1:
+        print_aggregate(all_stats)
+
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

To make the TF sync workflow as automatic as possible.

## Technical Details

Adds the .claude directory with the Claude Code configuration used to run and maintain the regular ROCm upstream sync pipeline:

- skills/: nine custom slash-command skills covering the full sync pipeline (sync, sync-start, sync-resolve, sync-ci-mirror, sync-build, sync-test-check, sync-cuda-only, sync-triage-test, sync-run-tests)
- settings.json: allowed-tools allowlist scoped to git, bazel, build scripts, and test runners
- stats.py: script to parse JSONL session logs and report cost, token, duration, tool-call, and per-phase breakdowns
- daily_sync.sh, dump_sync_log.py: utilities for scheduling and inspecting sync sessions

## Test Result

- #3197 
- #3194
- #3185 
- #3180

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
