### PR TITLE
Use new line to separate supported gfx architectures in target.lst

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -204,5 +204,5 @@ echo $ROCM_PATH
 echo $GPU_DEVICE_TARGETS
 
 # Ensure the ROCm target list is set up
-printf '%s\n' ${GPU_DEVICE_TARGETS} | tr ',' ' ' | tee -a "$ROCM_PATH/bin/target.lst"
+printf '%s\n' ${GPU_DEVICE_TARGETS} | tr ',' '\n' | tee -a "$ROCM_PATH/bin/target.lst"
 touch "${ROCM_PATH}/.info/version"


### PR DESCRIPTION
## Motivation

New line is needed on debian to support xla and other builds and test infrastructure



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
