### PR TITLE
[ROCm] version symbols exported by libtensorflow_framework.so.2

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -1591,6 +1591,7 @@ exports_files(
         "tf_version_script.lds",
         "tf_exported_symbols.lds",
         "tf_private_symbols.lds",
+        "tf_framework_version_script.lds",
     ],
 )
 

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1631,6 +1631,11 @@ pywrap_library(
             "//tensorflow:macos": "//tensorflow:tf_exported_symbols.lds",
             "//conditions:default": "//tensorflow:tf_version_script.lds",
         }),
+        "tensorflow/tensorflow_framework": select({
+            "//tensorflow:windows": None,
+            "//tensorflow:macos": None,
+            "//conditions:default": "//tensorflow:tf_framework_version_script.lds",
+        }),
     },
     # buildifier: disable=unsorted-dict-items
     # @unsorted-dict-items

--- a/tensorflow/tf_framework_version_script.lds
+++ b/tensorflow/tf_framework_version_script.lds
@@ -1,5 +1,4 @@
-VERS_1.0 {
-  # Hide libjpeg symbols to avoid symbol conflict with OpenCV
-  local:
-    *mlir*;
+tensorflow {
+  global:
+    *;
 };


### PR DESCRIPTION
We cannot hide llvm symbols from libtensorflow_framework.so.2, so at least version them, so they don't clash with TheRock ones.