### PR TITLE
fix(rocm): add work-around for removed cub api

### DIFF
--- a/tensorflow/core/kernels/gpu_prim.h
+++ b/tensorflow/core/kernels/gpu_prim.h
@@ -154,6 +154,33 @@ _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int LaneId() {
 #include "rocm/rocm_config.h"
 namespace gpuprim = ::hipcub;
 
+// Newer versions of hipCUB, which follow CCCL 3.x have dropped:
+// * CountingInputIterator
+// * TransformInputIterator
+// * LaneId
+// From the hipcub namesapce. The intermediate solution here is to utilize the 
+// thrust variants of these iterators, until they are available via libhipcxx.
+#if HIPCUB_CCCL_VERSION >= 300000
+#include "rocm/include/thrust/iterator/counting_iterator.h"
+#include "rocm/include/thrust/iterator/transform_iterator.h"
+
+// Inject the removed APIs back into hipcub.
+namespace hipcub {
+    template <typename ValueType, typename OffsetT = ptrdiff_t>
+    using CountingInputIterator =
+        thrust::counting_iterator<ValueType, thrust::use_default,
+                                  thrust::use_default, OffsetT>;
+    template <typename ValueType, typename ConversionOp, typename InputIteratorT,
+              typename OffsetT = ptrdiff_t>
+    using TransformInputIterator =
+        thrust::transform_iterator<ConversionOp, InputIteratorT, ValueType>;
+
+    _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int LaneId() {
+        return ::rocprim::lane_id();
+    }
+}
+#endif // HIPCUB_CCCL_VERSION
+
 // Required for sorting Eigen::half and bfloat16.
 namespace rocprim {
 #if (TF_ROCM_VERSION >= 50200 && TF_ROCM_VERSION < 70000)


### PR DESCRIPTION
## Motivation

hipCUB is targeting to be compatible with CCCL 3.0 (https://github.com/ROCm/rocm-libraries/pull/4079). This requires updating some of the CUB and hipCUB compatibility glue.

To help this transition hipCUB will be exposing `HIPCUB_CCCL_VERSION` in one of the following ROCm releases (>=7.14) (https://github.com/ROCm/rocm-libraries/pull/7632), which will be bumped once hipCUB reaches parity with CCCL 3.0 and beyond.

## Technical Details

The implementation is done following CUB's WAR in the section above the modified code.

We've added a backport for these APIs:
* `hipcub::CountingInputIterator`
* `hipcub::TransformInputIterator`
* `hipcub::LaneId`

A similar change has been implemented on PyTorch: https://github.com/pytorch/pytorch/pull/188072

## Test Plan

To verify this you need to build the current unmerged branches that implement CCCL 3.0  on rocm-libraries.

- https://github.com/ROCm/rocm-libraries/pull/4079
- https://github.com/ROCm/rocm-libraries/pull/3773

I recommend just fetching these two branches and merging them locally onto develop, and install these libraries after installing depedencies s.t. any transitive depedency fetches of rocthrust and hipcub will be overridden.

Then proceed to build tensorflow as normally.

## Test Result

Without this change set, tensorflow will fail to build due to the aforementioned missing symbols.
With this change set, tensorflow will build. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
