### PR TITLE
Add dynamic_mode=off to force link statically 

### DIFF
--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_multi.sh
@@ -70,5 +70,4 @@ bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.b
         --config=sigbuild_local_cache \
         --action_env=TF_PYTHON_VERSION=$PYTHON_VERSION \
         --repo_env="ROCM_PATH=$ROCM_PATH" \
-	--test_env="ROCPROFILER_QUEUE_INTERPOSITION=0" \
         --dynamic_mode=off

--- a/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
+++ b/tensorflow/tools/ci_build/linux/rocm/run_gpu_single.sh
@@ -81,6 +81,5 @@ bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.b
     --test_output=errors \
     --verbose_failures \
     --test_sharding_strategy=disabled \
-    --test_env="ROCPROFILER_QUEUE_INTERPOSITION=0" \
     --dynamic_mode=off \
     --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute


### PR DESCRIPTION
Verified on rocm/ufb-private:tensorflow-2.20.0-py3.12-prereleases-device-all-rocm7.14.0rc3-09f7183 where the fix for rocprofiler  is already there https://github.com/ROCm/rocm-systems/commit/6168477bc5d2f5f1a0ca533f6deef136c44327d1#diff-89798ddb5241f2bd905c99cfefc7c4785950a3d9973a54faee1dd7fa2dfc5762