### PR TITLE
remove -lnuma

### DIFF
--- a/third_party/xla/third_party/gpus/rocm/BUILD.tpl
+++ b/third_party/xla/third_party/gpus/rocm/BUILD.tpl
@@ -323,7 +323,6 @@ cc_library(
     includes = [
         "%{rocm_root}/include",
     ],
-    linkopts = ["-lnuma"],
     linkstatic = 1,
     strip_include_prefix = "%{rocm_root}",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Motivation
When trying to build tf 2.21 rocm-enhanced on spack I'm getting the following error: `error: unable to find library -lnuma`. This is because` libnuma.so` is installed to the spack prefix and not in a standard system libraries directory. 